### PR TITLE
Update xSetWeight.rst

### DIFF
--- a/docs/source/mwscript/functions/reference/xSetWeight.rst
+++ b/docs/source/mwscript/functions/reference/xSetWeight.rst
@@ -10,7 +10,7 @@ xSetWeight
 
 - ``long`` **result**: 1 if the reference's base object was modified, otherwise 0.
 
-`xSetWeight`_ modifies the weight of the reference's base object. Supports alchemy apparatus, lockpicks, probes, and repair tools.
+`xSetWeight`_ modifies the weight of the reference's base object.
 
 .. tip:: Use `xGetWeight`_ to read this value.
 


### PR DESCRIPTION
Removed the previous noted limitation to  support only alchemy apparatus, lockpicks, probes, and repair tools.