### PR TITLE
Added mwscript.getPCSneaking, getPCRunning, and getPCJumping.

### DIFF
--- a/MWSE/ScriptUtil.cpp
+++ b/MWSE/ScriptUtil.cpp
@@ -424,6 +424,18 @@ namespace mwse
 			return value;
 		}
 
+		bool GetPCJumping(TES3::Script* script) {
+			return RunOriginalOpCode(script, NULL, OpCode::GetPCJumping) == 1;
+		}
+
+		bool GetPCRunning(TES3::Script* script) {
+			return RunOriginalOpCode(script, NULL, OpCode::GetPCRunning) == 1;
+		}
+
+		bool GetPCSneaking(TES3::Script* script) {
+			return RunOriginalOpCode(script, NULL, OpCode::GetPCSneaking) == 1;
+		}
+
 		bool GetSpellEffects(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* spellTemplate) {
 			// Cache previous script variables.
 			TES3::BaseObject* cachedSecondObject = getScriptSecondObject();

--- a/MWSE/ScriptUtil.h
+++ b/MWSE/ScriptUtil.h
@@ -138,6 +138,12 @@ namespace mwse
 		
 		long GetItemCount(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* itemTemplate);
 
+		bool GetPCJumping(TES3::Script* script);
+
+		bool GetPCRunning(TES3::Script* script);
+
+		bool GetPCSneaking(TES3::Script* script);
+
 		bool GetSpellEffects(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* spellTemplate);
 
 		void PlaceAtPC(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* placedTemplate, long count, float distance, float direction);

--- a/MWSE/ScriptUtilLua.cpp
+++ b/MWSE/ScriptUtilLua.cpp
@@ -251,6 +251,18 @@ namespace mwse {
 
 				return mwscript::GetItemCount(script, reference, item);
 			};
+			state["mwscript"]["getPCJumping"] = [](sol::optional<sol::table> params) {
+				TES3::Script* script = getOptionalParamExecutionScript(params);
+				return mwscript::GetPCJumping(script);
+			};
+			state["mwscript"]["getPCRunning"] = [](sol::optional<sol::table> params) {
+				TES3::Script* script = getOptionalParamExecutionScript(params);
+				return mwscript::GetPCRunning(script);
+			};
+			state["mwscript"]["getPCSneaking"] = [](sol::optional<sol::table> params) {
+				TES3::Script* script = getOptionalParamExecutionScript(params);
+				return mwscript::GetPCSneaking(script);
+			};
 			state["mwscript"]["getSpellEffects"] = [](sol::optional<sol::table> params) {
 				TES3::Script* script = getOptionalParamExecutionScript(params);
 				TES3::Reference* reference = getOptionalParamExecutionReference(params);


### PR DESCRIPTION
All tested and working, but I didn't have anything to refer to as far as 0 arg functions, so maybe I'm messing up state somewhere by not having any reference passed.