### PR TITLE
Branch for weapon sheathing feature requests

### DIFF
--- a/MWSE/LuaEvents.cpp
+++ b/MWSE/LuaEvents.cpp
@@ -1550,38 +1550,36 @@ namespace mwse {
 			}
 
 			//
-			// Mobile actor attached to reference event.
+			// Mobile actor added to mob manager event.
 			//
 
-			MobileActorAttachedEvent::MobileActorAttachedEvent(TES3::Reference * reference, TES3::MobileActor * mobileActor) :
-				ObjectFilteredEvent("mobileAttached", reference),
-				m_Reference(reference),
-				m_MobileActor(mobileActor)
-			{
-
-			}
-
-			sol::table MobileActorAttachedEvent::createEventTable() {
-				sol::table eventData = LuaManager::getInstance().getState().create_table();
-
-				eventData["reference"] = lua::makeLuaObject(m_Reference);
-				eventData["mobile"] = lua::makeLuaObject(m_MobileActor);
-
-				return eventData;
-			}
-
-			//
-			// Mobile actor detached to reference event.
-			//
-
-			MobileActorDetachedEvent::MobileActorDetachedEvent(TES3::Reference * reference) :
-				ObjectFilteredEvent("mobileDetached", reference),
+			MobileActorActivatedEvent::MobileActorActivatedEvent(TES3::Reference * reference) :
+				ObjectFilteredEvent("mobileActivated", reference),
 				m_Reference(reference)
 			{
 
 			}
 
-			sol::table MobileActorDetachedEvent::createEventTable() {
+			sol::table MobileActorActivatedEvent::createEventTable() {
+				sol::table eventData = LuaManager::getInstance().getState().create_table();
+
+				eventData["reference"] = lua::makeLuaObject(m_Reference);
+
+				return eventData;
+			}
+
+			//
+			// Mobile actor removed from mob manager event.
+			//
+
+			MobileActorDeactivatedEvent::MobileActorDeactivatedEvent(TES3::Reference * reference) :
+				ObjectFilteredEvent("mobileDeactivated", reference),
+				m_Reference(reference)
+			{
+
+			}
+
+			sol::table MobileActorDeactivatedEvent::createEventTable() {
 				sol::table eventData = LuaManager::getInstance().getState().create_table();
 
 				eventData["reference"] = lua::makeLuaObject(m_Reference);

--- a/MWSE/LuaEvents.cpp
+++ b/MWSE/LuaEvents.cpp
@@ -1461,6 +1461,43 @@ namespace mwse {
 				return eventData;
 			}
 
+			//
+			// Weapon (un)readied events.
+			//
+
+			WeaponReadiedEvent::WeaponReadiedEvent(TES3::Reference* reference) :
+				ObjectFilteredEvent("weaponReadied", reference),
+				m_Reference(reference)
+			{
+
+			}
+
+			sol::table WeaponReadiedEvent::createEventTable() {
+				sol::state& state = LuaManager::getInstance().getState();
+				sol::table eventData = state.create_table();
+
+				eventData["reference"] = makeLuaObject(m_Reference);
+				eventData["weaponStack"] = tes3::getAttachedMobileActor(m_Reference)->readiedWeapon;
+
+				return eventData;
+			}
+
+			WeaponUnreadiedEvent::WeaponUnreadiedEvent(TES3::Reference* reference) :
+				ObjectFilteredEvent("weaponUnreadied", reference),
+				m_Reference(reference)
+			{
+
+			}
+
+			sol::table WeaponUnreadiedEvent::createEventTable() {
+				sol::state& state = LuaManager::getInstance().getState();
+				sol::table eventData = state.create_table();
+
+				eventData["reference"] = makeLuaObject(m_Reference);
+
+				return eventData;
+			}
+
 		}
 	}
 }

--- a/MWSE/LuaEvents.cpp
+++ b/MWSE/LuaEvents.cpp
@@ -1549,6 +1549,46 @@ namespace mwse {
 				return eventData;
 			}
 
+			//
+			// Mobile actor attached to reference event.
+			//
+
+			MobileActorAttachedEvent::MobileActorAttachedEvent(TES3::Reference * reference, TES3::MobileActor * mobileActor) :
+				ObjectFilteredEvent("mobileAttached", reference),
+				m_Reference(reference),
+				m_MobileActor(mobileActor)
+			{
+
+			}
+
+			sol::table MobileActorAttachedEvent::createEventTable() {
+				sol::table eventData = LuaManager::getInstance().getState().create_table();
+
+				eventData["reference"] = lua::makeLuaObject(m_Reference);
+				eventData["mobile"] = lua::makeLuaObject(m_MobileActor);
+
+				return eventData;
+			}
+
+			//
+			// Mobile actor detached to reference event.
+			//
+
+			MobileActorDetachedEvent::MobileActorDetachedEvent(TES3::Reference * reference) :
+				ObjectFilteredEvent("mobileDetached", reference),
+				m_Reference(reference)
+			{
+
+			}
+
+			sol::table MobileActorDetachedEvent::createEventTable() {
+				sol::table eventData = LuaManager::getInstance().getState().create_table();
+
+				eventData["reference"] = lua::makeLuaObject(m_Reference);
+
+				return eventData;
+			}
+
 		}
 	}
 }

--- a/MWSE/LuaEvents.h
+++ b/MWSE/LuaEvents.h
@@ -687,6 +687,26 @@ namespace mwse {
 				int m_Situation;
 			};
 
+			// ---------------------------------------------------------------------------- //
+
+			class WeaponReadiedEvent : public ObjectFilteredEvent {
+			public:
+				WeaponReadiedEvent(TES3::Reference* reference);
+				sol::table createEventTable();
+
+			protected:
+				TES3::Reference* m_Reference;
+			};
+
+			class WeaponUnreadiedEvent : public ObjectFilteredEvent {
+			public:
+				WeaponUnreadiedEvent(TES3::Reference* reference);
+				sol::table createEventTable();
+
+			protected:
+				TES3::Reference* m_Reference;
+			};
+
 		}
 	}
 }

--- a/MWSE/LuaEvents.h
+++ b/MWSE/LuaEvents.h
@@ -729,6 +729,27 @@ namespace mwse {
 				TES3::Object* m_Result;
 			};
 
+			// ---------------------------------------------------------------------------- //
+
+			class MobileActorAttachedEvent : public ObjectFilteredEvent {
+			public:
+				MobileActorAttachedEvent(TES3::Reference * reference, TES3::MobileActor * mobileActor);
+				sol::table createEventTable();
+
+			protected:
+				TES3::Reference* m_Reference;
+				TES3::MobileActor* m_MobileActor;
+			};
+
+			class MobileActorDetachedEvent : public ObjectFilteredEvent {
+			public:
+				MobileActorDetachedEvent(TES3::Reference * reference);
+				sol::table createEventTable();
+
+			protected:
+				TES3::Reference* m_Reference;
+			};
+
 		}
 	}
 }

--- a/MWSE/LuaEvents.h
+++ b/MWSE/LuaEvents.h
@@ -731,19 +731,18 @@ namespace mwse {
 
 			// ---------------------------------------------------------------------------- //
 
-			class MobileActorAttachedEvent : public ObjectFilteredEvent {
+			class MobileActorActivatedEvent : public ObjectFilteredEvent {
 			public:
-				MobileActorAttachedEvent(TES3::Reference * reference, TES3::MobileActor * mobileActor);
+				MobileActorActivatedEvent(TES3::Reference * reference);
 				sol::table createEventTable();
 
 			protected:
 				TES3::Reference* m_Reference;
-				TES3::MobileActor* m_MobileActor;
 			};
 
-			class MobileActorDetachedEvent : public ObjectFilteredEvent {
+			class MobileActorDeactivatedEvent : public ObjectFilteredEvent {
 			public:
-				MobileActorDetachedEvent(TES3::Reference * reference);
+				MobileActorDeactivatedEvent(TES3::Reference * reference);
 				sol::table createEventTable();
 
 			protected:

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -1419,18 +1419,6 @@ namespace mwse {
 			}
 		}
 
-		void __fastcall OnWeaponAnimationState(TES3::MobileActor* actor, DWORD _UNUSED_, TES3::EquipmentStack * stack) {
-			TES3_MobileActor_weaponAnimState(actor, stack);
-			if (actor->reference) {
-				if (stack) {
-					LuaManager::getInstance().triggerEvent(new event::WeaponReadiedEvent(actor->reference));
-				}
-				else {
-					LuaManager::getInstance().triggerEvent(new event::WeaponUnreadiedEvent(actor->reference));
-				}
-			}
-		}
-
 		void LuaManager::executeMainModScripts(const char* path, const char* filename) {
 			for (auto & p : std::experimental::filesystem::recursive_directory_iterator(path)) {
 				if (p.path().filename() == filename) {
@@ -1912,12 +1900,12 @@ namespace mwse {
 			genCallEnforced(0x527FEA, 0x52D5B0, reinterpret_cast<DWORD>(OnReadyNoWeapon));
 
 			// Event: Weapon unready.
-			genCallEnforced(0x4E891A, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			genCallEnforced(0x4E8AB6, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			//genCallEnforced(0x4E891A, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			//genCallEnforced(0x4E8AB6, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
 			genCallEnforced(0x528040, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			genCallEnforced(0x52830B, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			genCallEnforced(0x5B54E4, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			genCallEnforced(0x5B72CB, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			//genCallEnforced(0x52830B, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			//genCallEnforced(0x5B54E4, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			//genCallEnforced(0x5B72CB, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
 
 			// Event: Leveled item picked.
 			auto leveledItemPick = &TES3::LeveledItem::resolve;

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -1933,20 +1933,41 @@ namespace mwse {
 			genCallEnforced(0x4CFB43, 0x4CF870, *reinterpret_cast<DWORD*>(&leveledCreaturePick));
 			genCallEnforced(0x635236, 0x4CF870, *reinterpret_cast<DWORD*>(&leveledCreaturePick));
 
-			// Event: Mobile actor attached/detached. 
-			auto setReferenceMobileActor = &TES3::Reference::setMobileActor;
-			genCallEnforced(0x4C6C88, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x4E02C9, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x4E0338, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x5636F6, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x56615A, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x5661A0, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x566338, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x566348, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x572378, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x5725D9, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x572630, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
-			genCallEnforced(0x574114, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			// Event: Mobile added to controller.
+			auto mobControllerAddMob = &TES3::MobController::addMob;
+			genCallEnforced(0x4665D5, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x484F3D, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x4C6954, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x4DC965, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x4EBCBF, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x5090BF, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x50990C, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x509A6E, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x50EFE3, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x529C3B, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x54DE92, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x57356C, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x5752C6, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x57595B, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+			genCallEnforced(0x635390, 0x5636A0, *reinterpret_cast<DWORD*>(&mobControllerAddMob));
+
+			// Event: Mobile added to controller.
+			auto mobControllerRemoveMob = &TES3::MobController::removeMob;
+			genCallEnforced(0x4668D8, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x484E24, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x4E47C1, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x4E8911, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x4EBD8C, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x50919F, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x523A1F, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x523AE5, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x52E980, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x52EA6D, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x52EDE5, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x574FDB, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x57509A, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x57548A, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
+			genCallEnforced(0x575647, 0x5637F0, *reinterpret_cast<DWORD*>(&mobControllerRemoveMob));
 
 			// UI framework hooks
 			TES3::UI::hook();

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -1398,10 +1398,6 @@ namespace mwse {
 		// Event: Weapon Ready
 		//
 
-		const auto TES3_Reference_attachWeaponModel = reinterpret_cast<void(__thiscall*)(const TES3::Reference*)>(0x4E8F50);
-		const auto TES3_Reference_detatchWeaponModel = reinterpret_cast<void(__thiscall*)(const TES3::Reference*, bool)>(0x4E9080);
-
-		const auto TES3_MobileActor_weaponAnimState = reinterpret_cast<void(__thiscall*)(const TES3::MobileActor*, TES3::EquipmentStack *)>(0x52CB70);
 		const auto TES3_MobileActor_offhandAnimState = reinterpret_cast<void(__thiscall*)(const TES3::MobileActor*)>(0x52D5B0);
 
 		void __fastcall OnReadyNoWeapon(TES3::MobileActor * actor) {
@@ -1410,6 +1406,8 @@ namespace mwse {
 				LuaManager::getInstance().triggerEvent(new event::WeaponReadiedEvent(actor->reference));
 			}
 		}
+
+		const auto TES3_Reference_detatchWeaponModel = reinterpret_cast<void(__thiscall*)(const TES3::Reference*, bool)>(0x4E9080);
 
 		void __fastcall OnDetachWeaponMesh(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
 			TES3_Reference_detatchWeaponModel(reference, isActor);

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -1404,11 +1404,6 @@ namespace mwse {
 		const auto TES3_MobileActor_weaponAnimState = reinterpret_cast<void(__thiscall*)(const TES3::MobileActor*, TES3::EquipmentStack *)>(0x52CB70);
 		const auto TES3_MobileActor_offhandAnimState = reinterpret_cast<void(__thiscall*)(const TES3::MobileActor*)>(0x52D5B0);
 
-		void __fastcall OnAttachWeaponMesh(TES3::Reference* reference) {
-			TES3_Reference_attachWeaponModel(reference);
-			LuaManager::getInstance().triggerEvent(new event::WeaponReadiedEvent(reference));
-		}
-
 		void __fastcall OnReadyNoWeapon(TES3::MobileActor * actor) {
 			TES3_MobileActor_offhandAnimState(actor);
 			if (actor->reference) {
@@ -1419,64 +1414,9 @@ namespace mwse {
 		void __fastcall OnDetachWeaponMesh(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
 			TES3_Reference_detatchWeaponModel(reference, isActor);
 			TES3::AttachmentWithNode<void> * attachment = tes3::getAttachment<TES3::AttachmentWithNode<void>>(reference, static_cast<TES3::AttachmentType::AttachmentType>(1));
-			if (isActor && attachment && attachment->data) {
+			if (isActor && attachment && attachment->data && tes3::getAttachedMobileActor(reference)) {
 				LuaManager::getInstance().triggerEvent(new event::WeaponUnreadiedEvent(reference));
 			}
-		}
-
-		void __fastcall OnDetachWeaponMeshA(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshA" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
-		}
-
-		void __fastcall OnDetachWeaponMeshB(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshB" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
-		}
-
-		void __fastcall OnDetachWeaponMeshC(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshC" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
-		}
-
-		void __fastcall OnDetachWeaponMeshD(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshD" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
-		}
-
-		void __fastcall OnDetachWeaponMeshE(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshE" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
-		}
-
-		void __fastcall OnDetachWeaponMeshF(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshF" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
-		}
-
-		void __fastcall OnDetachWeaponMeshG(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshG" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
-		}
-
-		void __fastcall OnDetachWeaponMeshH(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshH" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
-		}
-
-		void __fastcall OnDetachWeaponMeshI(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshI" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
-		}
-
-		void __fastcall OnDetachWeaponMeshJ(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshJ" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
-		}
-
-		void __fastcall OnDetachWeaponMeshK(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			mwse::log::getLog() << "OnDetachWeaponMeshK" << std::endl;
-			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
 		}
 
 		void __fastcall OnWeaponAnimationState(TES3::MobileActor* actor, DWORD _UNUSED_, TES3::EquipmentStack * stack) {
@@ -1968,44 +1908,16 @@ namespace mwse {
 			genCallEnforced(0x40F8CA, 0x410EA0, reinterpret_cast<DWORD>(OnSelectMusicTrack));
 			genCallEnforced(0x40F901, 0x410EA0, reinterpret_cast<DWORD>(OnSelectMusicTrack));
 
-			// Event: Weapon ready
-#if false
-			genCallEnforced(0x495D92, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x495E5B, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x496030, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x49604F, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x496811, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x4E8C3C, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x4E8EE4, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x52C899, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x52C8B8, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x53FEEE, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x54A1FA, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x54A268, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x55A759, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x5CF404, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x5D012A, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-			genCallEnforced(0x5D0C7A, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
-#else
-			genCallEnforced(0x4E8F27, 0x4E8F50, reinterpret_cast<DWORD>(OnAttachWeaponMesh));
-			// genCallEnforced(0x4E8FC7, 0x4E8F50, reinterpret_cast<DWORD>(OnAttachWeaponMesh));
-			genCallEnforced(0x527F7E, 0x4E8F50, reinterpret_cast<DWORD>(OnAttachWeaponMesh));
-			genCallEnforced(0x527FC4, 0x4E8F50, reinterpret_cast<DWORD>(OnAttachWeaponMesh));
-
+			// Event: Weapon ready.
 			genCallEnforced(0x527FEA, 0x52D5B0, reinterpret_cast<DWORD>(OnReadyNoWeapon));
 
-			//genCallEnforced(0x49693C, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMeshA));
-			//genCallEnforced(0x4E469A, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMeshB));
+			// Event: Weapon unready.
 			genCallEnforced(0x4E891A, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
 			genCallEnforced(0x4E8AB6, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			//genCallEnforced(0x4E9107, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMeshE));
-			//genCallEnforced(0x524B60, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMeshF));
 			genCallEnforced(0x528040, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
 			genCallEnforced(0x52830B, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			//genCallEnforced(0x52CBBC, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMeshI));
 			genCallEnforced(0x5B54E4, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
 			genCallEnforced(0x5B72CB, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-#endif
 
 			// Event: Leveled item picked.
 			auto leveledItemPick = &TES3::LeveledItem::resolve;

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -108,6 +108,7 @@
 #include "NINodeLua.h"
 #include "NIPickLua.h"
 #include "NISwitchNodeLua.h"
+#include "NITimeControllerLua.h"
 
 #include "windows.h"
 #include "psapi.h"
@@ -323,6 +324,7 @@ namespace mwse {
 			bindNINode();
 			bindNIPick();
 			bindNISwitchNode();
+			bindNITimeController();
 		}
 
 		//

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -1933,6 +1933,21 @@ namespace mwse {
 			genCallEnforced(0x4CFB43, 0x4CF870, *reinterpret_cast<DWORD*>(&leveledCreaturePick));
 			genCallEnforced(0x635236, 0x4CF870, *reinterpret_cast<DWORD*>(&leveledCreaturePick));
 
+			// Event: Mobile actor attached/detached. 
+			auto setReferenceMobileActor = &TES3::Reference::setMobileActor;
+			genCallEnforced(0x4C6C88, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x4E02C9, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x4E0338, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x5636F6, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x56615A, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x5661A0, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x566338, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x566348, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x572378, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x5725D9, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x572630, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+			genCallEnforced(0x574114, 0x4E5770, *reinterpret_cast<DWORD*>(&setReferenceMobileActor));
+
 			// UI framework hooks
 			TES3::UI::hook();
 

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -1394,6 +1394,103 @@ namespace mwse {
 			return reinterpret_cast<bool(__thiscall *)(TES3::WorldController*, int)>(0x410EA0)(controller, situation);
 		}
 
+		//
+		// Event: Weapon Ready
+		//
+
+		const auto TES3_Reference_attachWeaponModel = reinterpret_cast<void(__thiscall*)(const TES3::Reference*)>(0x4E8F50);
+		const auto TES3_Reference_detatchWeaponModel = reinterpret_cast<void(__thiscall*)(const TES3::Reference*, bool)>(0x4E9080);
+
+		const auto TES3_MobileActor_weaponAnimState = reinterpret_cast<void(__thiscall*)(const TES3::MobileActor*, TES3::EquipmentStack *)>(0x52CB70);
+		const auto TES3_MobileActor_offhandAnimState = reinterpret_cast<void(__thiscall*)(const TES3::MobileActor*)>(0x52D5B0);
+
+		void __fastcall OnAttachWeaponMesh(TES3::Reference* reference) {
+			TES3_Reference_attachWeaponModel(reference);
+			LuaManager::getInstance().triggerEvent(new event::WeaponReadiedEvent(reference));
+		}
+
+		void __fastcall OnReadyNoWeapon(TES3::MobileActor * actor) {
+			TES3_MobileActor_offhandAnimState(actor);
+			if (actor->reference) {
+				LuaManager::getInstance().triggerEvent(new event::WeaponReadiedEvent(actor->reference));
+			}
+		}
+
+		void __fastcall OnDetachWeaponMesh(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			TES3_Reference_detatchWeaponModel(reference, isActor);
+			TES3::AttachmentWithNode<void> * attachment = tes3::getAttachment<TES3::AttachmentWithNode<void>>(reference, static_cast<TES3::AttachmentType::AttachmentType>(1));
+			if (isActor && attachment && attachment->data) {
+				LuaManager::getInstance().triggerEvent(new event::WeaponUnreadiedEvent(reference));
+			}
+		}
+
+		void __fastcall OnDetachWeaponMeshA(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshA" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnDetachWeaponMeshB(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshB" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnDetachWeaponMeshC(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshC" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnDetachWeaponMeshD(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshD" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnDetachWeaponMeshE(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshE" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnDetachWeaponMeshF(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshF" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnDetachWeaponMeshG(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshG" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnDetachWeaponMeshH(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshH" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnDetachWeaponMeshI(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshI" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnDetachWeaponMeshJ(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshJ" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnDetachWeaponMeshK(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
+			mwse::log::getLog() << "OnDetachWeaponMeshK" << std::endl;
+			OnDetachWeaponMesh(reference, _UNUSED_, isActor);
+		}
+
+		void __fastcall OnWeaponAnimationState(TES3::MobileActor* actor, DWORD _UNUSED_, TES3::EquipmentStack * stack) {
+			TES3_MobileActor_weaponAnimState(actor, stack);
+			if (actor->reference) {
+				if (stack) {
+					LuaManager::getInstance().triggerEvent(new event::WeaponReadiedEvent(actor->reference));
+				}
+				else {
+					LuaManager::getInstance().triggerEvent(new event::WeaponUnreadiedEvent(actor->reference));
+				}
+			}
+		}
+
 		void LuaManager::executeMainModScripts(const char* path, const char* filename) {
 			for (auto & p : std::experimental::filesystem::recursive_directory_iterator(path)) {
 				if (p.path().filename() == filename) {
@@ -1870,6 +1967,45 @@ namespace mwse {
 			// Event: Select music track
 			genCallEnforced(0x40F8CA, 0x410EA0, reinterpret_cast<DWORD>(OnSelectMusicTrack));
 			genCallEnforced(0x40F901, 0x410EA0, reinterpret_cast<DWORD>(OnSelectMusicTrack));
+
+			// Event: Weapon ready
+#if false
+			genCallEnforced(0x495D92, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x495E5B, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x496030, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x49604F, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x496811, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x4E8C3C, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x4E8EE4, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x52C899, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x52C8B8, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x53FEEE, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x54A1FA, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x54A268, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x55A759, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x5CF404, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x5D012A, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+			genCallEnforced(0x5D0C7A, 0x52CB70, reinterpret_cast<DWORD>(OnWeaponAnimationState));
+#else
+			genCallEnforced(0x4E8F27, 0x4E8F50, reinterpret_cast<DWORD>(OnAttachWeaponMesh));
+			// genCallEnforced(0x4E8FC7, 0x4E8F50, reinterpret_cast<DWORD>(OnAttachWeaponMesh));
+			genCallEnforced(0x527F7E, 0x4E8F50, reinterpret_cast<DWORD>(OnAttachWeaponMesh));
+			genCallEnforced(0x527FC4, 0x4E8F50, reinterpret_cast<DWORD>(OnAttachWeaponMesh));
+
+			genCallEnforced(0x527FEA, 0x52D5B0, reinterpret_cast<DWORD>(OnReadyNoWeapon));
+
+			//genCallEnforced(0x49693C, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMeshA));
+			//genCallEnforced(0x4E469A, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMeshB));
+			genCallEnforced(0x4E891A, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			genCallEnforced(0x4E8AB6, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			//genCallEnforced(0x4E9107, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMeshE));
+			//genCallEnforced(0x524B60, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMeshF));
+			genCallEnforced(0x528040, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			genCallEnforced(0x52830B, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			//genCallEnforced(0x52CBBC, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMeshI));
+			genCallEnforced(0x5B54E4, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			genCallEnforced(0x5B72CB, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+#endif
 
 			// UI framework hooks
 			TES3::UI::hook();

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -1409,13 +1409,15 @@ namespace mwse {
 			}
 		}
 
-		const auto TES3_Reference_detatchWeaponModel = reinterpret_cast<void(__thiscall*)(const TES3::Reference*, bool)>(0x4E9080);
+		const auto TES3_MobileActor_unreadyWeapon = reinterpret_cast<void(__thiscall*)(const TES3::MobileActor*)>(0x528000);
 
-		void __fastcall OnDetachWeaponMesh(TES3::Reference * reference, DWORD _UNUSED_, bool isActor) {
-			TES3_Reference_detatchWeaponModel(reference, isActor);
-			TES3::AttachmentWithNode<void> * attachment = tes3::getAttachment<TES3::AttachmentWithNode<void>>(reference, static_cast<TES3::AttachmentType::AttachmentType>(1));
-			if (isActor && attachment && attachment->data && tes3::getAttachedMobileActor(reference)) {
-				LuaManager::getInstance().triggerEvent(new event::WeaponUnreadiedEvent(reference));
+		void __fastcall OnUnreadyWeapon(TES3::MobileActor * mobile) {
+			bool wasDrawn = (mobile->actorFlags & TES3::MobileActorFlag::WeaponDrawn);
+
+			TES3_MobileActor_unreadyWeapon(mobile);
+
+			if (mobile && mobile->reference && wasDrawn) {
+				LuaManager::getInstance().triggerEvent(new event::WeaponUnreadiedEvent(mobile->reference));
 			}
 		}
 
@@ -1900,12 +1902,15 @@ namespace mwse {
 			genCallEnforced(0x527FEA, 0x52D5B0, reinterpret_cast<DWORD>(OnReadyNoWeapon));
 
 			// Event: Weapon unready.
-			//genCallEnforced(0x4E891A, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			//genCallEnforced(0x4E8AB6, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			genCallEnforced(0x528040, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			//genCallEnforced(0x52830B, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			//genCallEnforced(0x5B54E4, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
-			//genCallEnforced(0x5B72CB, 0x4E9080, reinterpret_cast<DWORD>(OnDetachWeaponMesh));
+			genCallEnforced(0x495D73, 0x528000, reinterpret_cast<DWORD>(OnUnreadyWeapon));
+			genCallEnforced(0x495E3A, 0x528000, reinterpret_cast<DWORD>(OnUnreadyWeapon));
+			genCallEnforced(0x49601C, 0x528000, reinterpret_cast<DWORD>(OnUnreadyWeapon));
+			genCallEnforced(0x53FEDB, 0x528000, reinterpret_cast<DWORD>(OnUnreadyWeapon));
+			genCallEnforced(0x558479, 0x528000, reinterpret_cast<DWORD>(OnUnreadyWeapon));
+			genCallEnforced(0x569D02, 0x528000, reinterpret_cast<DWORD>(OnUnreadyWeapon));
+			genCallEnforced(0x56AA65, 0x528000, reinterpret_cast<DWORD>(OnUnreadyWeapon));
+			genCallEnforced(0x56B0B5, 0x528000, reinterpret_cast<DWORD>(OnUnreadyWeapon));
+			genCallEnforced(0x5D0C66, 0x528000, reinterpret_cast<DWORD>(OnUnreadyWeapon));
 
 			// Event: Leveled item picked.
 			auto leveledItemPick = &TES3::LeveledItem::resolve;

--- a/MWSE/MWSE.vcxproj
+++ b/MWSE/MWSE.vcxproj
@@ -15,6 +15,8 @@
     <ClInclude Include="CodePatchUtil.h" />
     <ClInclude Include="NIPointer.h" />
     <ClInclude Include="NIStream.h" />
+    <ClInclude Include="NITimeController.h" />
+    <ClInclude Include="NITimeControllerLua.h" />
     <ClInclude Include="TES3CrimeEvent.h" />
     <ClInclude Include="TES3CrimeTree.h" />
     <ClInclude Include="D3DColorValue.h" />
@@ -262,6 +264,7 @@
     <ClCompile Include="NIPickLua.cpp" />
     <ClCompile Include="NIStream.cpp" />
     <ClCompile Include="NISwitchNodeLua.cpp" />
+    <ClCompile Include="NITimeControllerLua.cpp" />
     <ClCompile Include="NIUtil.cpp" />
     <ClCompile Include="PatchUtil.cpp" />
     <ClCompile Include="RngUtil.cpp" />

--- a/MWSE/MWSE.vcxproj.filters
+++ b/MWSE/MWSE.vcxproj.filters
@@ -864,6 +864,12 @@
     <ClInclude Include="NIStream.h">
       <Filter>Header Files\DataAdapters\NI</Filter>
     </ClInclude>
+    <ClInclude Include="NITimeController.h">
+      <Filter>Header Files\DataAdapters\NI</Filter>
+    </ClInclude>
+    <ClInclude Include="NITimeControllerLua.h">
+      <Filter>Header Files\Lua\Bindings\NI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -1954,6 +1960,9 @@
     </ClCompile>
     <ClCompile Include="TES3GameFile.cpp">
       <Filter>Source Files\DataAdapters\TES3</Filter>
+    </ClCompile>
+    <ClCompile Include="NITimeControllerLua.cpp">
+      <Filter>Source Files\Lua\Bindings\NI</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/MWSE/NIDefines.h
+++ b/MWSE/NIDefines.h
@@ -12,6 +12,7 @@ namespace NI {
 	struct PickRecord;
 	struct RTTI;
 	struct SwitchNode;
+	struct TimeController;
 	struct Transform;
 	struct TriShape;
 

--- a/MWSE/NIObjectLua.cpp
+++ b/MWSE/NIObjectLua.cpp
@@ -65,10 +65,16 @@ namespace mwse {
 				usertypeDefinition.set(sol::base_classes, sol::bases<NI::Object>());
 
 				// Basic property binding.
+				usertypeDefinition.set("controller", sol::readonly_property(&NI::ObjectNET::controllers));
 				usertypeDefinition.set("name", sol::property(
 					[](NI::ObjectNET& self) { return self.name; },
 					[](NI::ObjectNET& self, const char * name) { self.setName(name); }
 				));
+
+				// Basic function binding.
+				usertypeDefinition.set("prependController", &NI::ObjectNET::prependController);
+				usertypeDefinition.set("removeController", &NI::ObjectNET::removeController);
+				usertypeDefinition.set("removeAllControllers", &NI::ObjectNET::removeAllControllers);
 
 				// Finish up our usertype.
 				state.set_usertype("niObjectNET", usertypeDefinition);

--- a/MWSE/NIObjectNET.cpp
+++ b/MWSE/NIObjectNET.cpp
@@ -1,7 +1,23 @@
 #include "NIObjectNET.h"
 
 namespace NI {
+	const auto NI_ObjectNET_prependController = reinterpret_cast<void(__thiscall*)(const ObjectNET*, TimeController*)>(0x6EA3E0);
+	const auto NI_ObjectNET_removeController = reinterpret_cast<void(__thiscall*)(const ObjectNET*, TimeController*)>(0x6EA450);
+	const auto NI_ObjectNET_removeAllControllers = reinterpret_cast<void(__thiscall*)(const ObjectNET*)>(0x6EA5A0);
+
 	const auto NI_ObjectNET_setName = reinterpret_cast<void(__thiscall*)(const ObjectNET*, const char *)>(0x6EA1A0);
+
+	void ObjectNET::prependController(TimeController * controller) {
+		NI_ObjectNET_prependController(this, controller);
+	}
+
+	void ObjectNET::removeController(TimeController * controller) {
+		NI_ObjectNET_removeController(this, controller);
+	}
+
+	void ObjectNET::removeAllControllers() {
+		NI_ObjectNET_removeAllControllers(this);
+	}
 
 	void ObjectNET::setName(const char* name) {
 		NI_ObjectNET_setName(this, name);

--- a/MWSE/NIObjectNET.h
+++ b/MWSE/NIObjectNET.h
@@ -1,16 +1,22 @@
 #pragma once
 
 #include "NIObject.h"
+#include "NIPointer.h"
+#include "NITimeController.h"
 
 namespace NI {
 	struct ObjectNET : Object {
 		char * name; // 0x8
 		void * extraData; // 0xC
-		void * controllers; // 0x10
+		Pointer<TimeController> controllers; // 0x10
 
 		//
 		// Other related this-call functions.
 		//
+
+		void prependController(TimeController * controller);
+		void removeController(TimeController * controller);
+		void removeAllControllers();
 
 		void setName(const char* name);
 

--- a/MWSE/NITimeController.h
+++ b/MWSE/NITimeController.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "NIDefines.h"
+
+#include "NIObject.h"
+#include "NIPointer.h"
+
+namespace NI {
+struct TimeController : Object {
+	unsigned short deprecatedFlags; // 0x8
+	float frequency; // 0xC
+	float phase; // 0x10
+	float lowKeyFrame; // 0x14
+	float highKeyFrame; // 0x18
+	float startTime; // 0x1C
+	float lastTime; // 0x20
+	int unknown_0x24;
+	ObjectNET * target; // 0x28
+	Pointer<TimeController> nextController; // 0x2C
+	bool unknown_0x30; // Force update? Compute scaled time?
+};
+	static_assert(sizeof(TimeController) == 0x34, "NI::TimeController failed size validation");
+}

--- a/MWSE/NITimeControllerLua.cpp
+++ b/MWSE/NITimeControllerLua.cpp
@@ -1,0 +1,37 @@
+#include "NITimeControllerLua.h"
+
+#include "sol.hpp"
+
+#include "LuaManager.h"
+#include "LuaUtil.h"
+
+#include "NITimeController.h"
+
+namespace mwse {
+	namespace lua {
+		void bindNITimeController() {
+			// Get our lua state.
+			sol::state& state = LuaManager::getInstance().getState();
+
+			// Start our usertype. We must finish this with state.set_usertype.
+			auto usertypeDefinition = state.create_simple_usertype<NI::TimeController>();
+			usertypeDefinition.set("new", sol::no_constructor);
+
+			// Define inheritance structures. These must be defined in order from top to bottom. The complete chain must be defined.
+			usertypeDefinition.set(sol::base_classes, sol::bases<NI::Object>());
+
+			// Basic property binding.
+			usertypeDefinition.set("frequency", &NI::TimeController::frequency);
+			usertypeDefinition.set("phase", &NI::TimeController::phase);
+			usertypeDefinition.set("lowKeyFrame", &NI::TimeController::lowKeyFrame);
+			usertypeDefinition.set("highKeyFrame", &NI::TimeController::highKeyFrame);
+			usertypeDefinition.set("startTime", &NI::TimeController::startTime);
+			usertypeDefinition.set("lastTime", &NI::TimeController::lastTime);
+			usertypeDefinition.set("target", sol::readonly_property(&NI::TimeController::target));
+			usertypeDefinition.set("nextController", &NI::TimeController::nextController);
+
+			// Finish up our usertype.
+			state.set_usertype("niTimeController", usertypeDefinition);
+		}
+	}
+}

--- a/MWSE/NITimeControllerLua.h
+++ b/MWSE/NITimeControllerLua.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace mwse {
+	namespace lua {
+		void bindNITimeController();
+	}
+}

--- a/MWSE/TES3Actor.cpp
+++ b/MWSE/TES3Actor.cpp
@@ -31,8 +31,10 @@ namespace TES3 {
 	Object* Actor::equipItem(Object* item, ItemData* itemData, EquipmentStack** out_equipmentStack, MobileActor* mobileActor) {
 		Object* result = TES3_Actor_equipItem(this, item, itemData, out_equipmentStack, mobileActor);
 
-		// Trigger or queue our event.
-		mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::EquippedEvent(this, mobileActor, item, itemData));
+		// Trigger or queue our event, if this actor has a mobile actor.
+		if (mobileActor) {
+			mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::EquippedEvent(this, mobileActor, item, itemData));
+		}
 
 		return result;
 	}
@@ -40,8 +42,10 @@ namespace TES3 {
 	EquipmentStack* Actor::unequipItem(Object* item, bool deleteStack, MobileActor* mobileActor, bool updateGUI, ItemData* itemData) {
 		EquipmentStack* result = TES3_Actor_unequipItem(this, item, deleteStack, mobileActor, updateGUI, itemData);
 
-		// Trigger or queue our event.
-		mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::UnequippedEvent(this, mobileActor, item, itemData));
+		// Trigger or queue our event if there's an attached mobile actor.
+		if (mobileActor) {
+			mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::UnequippedEvent(this, mobileActor, item, itemData));
+		}
 
 		return result;
 	}

--- a/MWSE/TES3MobController.cpp
+++ b/MWSE/TES3MobController.cpp
@@ -1,9 +1,14 @@
 #include "TES3MobController.h"
 
+#include "LuaManager.h"
+
 namespace TES3 {
 	const auto TES3_MobController_0x24_checkRadius = reinterpret_cast<void(__thiscall*)(MobController_0x24*, MobileActor*, Iterator<void>*)>(0x5704B0);
 	const auto TES3_MobController_0x24_detectPresence = reinterpret_cast<bool(__thiscall*)(MobController_0x24*, MobileActor*, bool)>(0x570A60);
 	const auto TES3_MobController_0x24_checkPlayerDist = reinterpret_cast<void(__thiscall*)(MobController_0x24*)>(0x56F730);
+
+	const auto TES3_MobController_addMob = reinterpret_cast<void(__thiscall*)(MobController*, Reference*)>(0x5636A0);
+	const auto TES3_MobController_removeMob = reinterpret_cast<void(__thiscall*)(MobController*, Reference*)>(0x5637F0);
 
 	bool MobController_0x24::detectPresence(MobileActor * actor, bool unknown) {
 		return TES3_MobController_0x24_detectPresence(this, actor, unknown);
@@ -15,6 +20,18 @@ namespace TES3 {
 
 	void MobController_0x24::checkPlayerDistance() {
 		TES3_MobController_0x24_checkPlayerDist(this);
+	}
+
+	void MobController::addMob(Reference * reference) {
+		TES3_MobController_addMob(this, reference);
+
+		mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::MobileActorActivatedEvent(reference));
+	}
+
+	void MobController::removeMob(Reference * reference) {
+		TES3_MobController_removeMob(this, reference);
+
+		mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::MobileActorDeactivatedEvent(reference));
 	}
 
 	void MobController::checkPlayerDistance() {

--- a/MWSE/TES3MobController.h
+++ b/MWSE/TES3MobController.h
@@ -89,6 +89,9 @@ namespace TES3 {
 		// Related this-call functions.
 		//
 
+		void addMob(Reference * reference);
+		void removeMob(Reference * reference);
+
 		void checkPlayerDistance();
 
 	};

--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -118,10 +118,17 @@ namespace TES3 {
 			sceneNode->propagatePositionChange();
 		}
 
-		Vector3 * positionPackage = getPosition();
-		positionPackage->x = x;
-		positionPackage->y = y;
-		positionPackage->z = z;
+		// Set local position.
+		position.x = x;
+		position.y = y;
+		position.z = z;
+
+		// Sync position attachment to local position.
+		auto attachment = mwse::tes3::getAttachment<TES3::NewOrientationAttachment>(this, TES3::AttachmentType::NewOrientation);
+		if (attachment) {
+			attachment->position = position;
+		}
+
 		setObjectModified(true);
 	}
 
@@ -141,23 +148,22 @@ namespace TES3 {
 	}
 
 	void Reference::setOrientation(float x, float y, float z) {
-#if false
-		// Ugly workaround to set the angles.
-		mwse::mwscript::SetAngle(this, 'U', x);
-		mwse::mwscript::SetAngle(this, 'V', y);
-		mwse::mwscript::SetAngle(this, 'W', z);
-#else
-		// Doesn't currently work. Non-NPCs/creatures don't change their orientation.
 		Vector3 * orientationPackage = getOrientation();
 		orientationPackage->x = x;
 		orientationPackage->y = y;
 		orientationPackage->z = z;
 
-		Matrix33 tempOutArg;
-		sceneNode->setLocalRotationMatrix(updateSceneMatrix(&tempOutArg));
-		sceneNode->propagatePositionChange();
+		if (orientationPackage != &orientation) {
+			orientation = *orientationPackage;
+		}
+
+		if (sceneNode) {
+			Matrix33 tempOutArg;
+			sceneNode->setLocalRotationMatrix(updateSceneMatrix(&tempOutArg));
+			sceneNode->propagatePositionChange();
+		}
+
 		setObjectModified(true);
-#endif
 	}
 
 	void Reference::setOrientation(Vector3 * value) {

--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -18,6 +18,8 @@
 #define TES3_Reference_addItemDataAttachment 0x4E5360
 
 namespace TES3 {
+	const auto TES3_Reference_setMobileActor = reinterpret_cast<MobileActor* (__thiscall*)(Reference*, MobileActor*)>(0x4E5770);
+
 	void Reference::activate(Reference* activator, int unknown) {
 		// If our event data says to block, don't let the object activate.
 		sol::object response = mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::ActivateEvent(activator, this));
@@ -57,6 +59,21 @@ namespace TES3 {
 
 	Vector3* Reference::getOrientationFromAttachment() {
 		return reinterpret_cast<Vector3* (__thiscall *)(Reference*)>(0x4E5970)(this);
+	}
+
+	MobileActor* Reference::setMobileActor(TES3::MobileActor * mobileActor) {
+		// Call original function.
+		MobileActor* result = TES3_Reference_setMobileActor(this, mobileActor);
+
+		// Fire off associated events.
+		if (mobileActor) {
+			mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::MobileActorAttachedEvent(this, result));
+		}
+		else {
+			mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::MobileActorDetachedEvent(this));
+		}
+
+		return result;
 	}
 
 	void Reference::setPositionFromLua(sol::stack_object value) {

--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -61,21 +61,6 @@ namespace TES3 {
 		return reinterpret_cast<Vector3* (__thiscall *)(Reference*)>(0x4E5970)(this);
 	}
 
-	MobileActor* Reference::setMobileActor(TES3::MobileActor * mobileActor) {
-		// Call original function.
-		MobileActor* result = TES3_Reference_setMobileActor(this, mobileActor);
-
-		// Fire off associated events.
-		if (mobileActor) {
-			mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::MobileActorAttachedEvent(this, result));
-		}
-		else {
-			mwse::lua::LuaManager::getInstance().triggerEvent(new mwse::lua::event::MobileActorDetachedEvent(this));
-		}
-
-		return result;
-	}
-
 	void Reference::setPositionFromLua(sol::stack_object value) {
 		// Is it a vector?
 		if (value.is<Vector3*>()) {

--- a/MWSE/TES3Reference.h
+++ b/MWSE/TES3Reference.h
@@ -33,8 +33,6 @@ namespace TES3 {
 		ItemDataAttachment* addItemDataAttachment(ItemData*);
 		Vector3* getOrientationFromAttachment();
 
-		MobileActor* setMobileActor(TES3::MobileActor * mobileActor);
-
 		//
 		// Other utility functions.
 		//

--- a/MWSE/TES3Reference.h
+++ b/MWSE/TES3Reference.h
@@ -33,6 +33,8 @@ namespace TES3 {
 		ItemDataAttachment* addItemDataAttachment(ItemData*);
 		Vector3* getOrientationFromAttachment();
 
+		MobileActor* setMobileActor(TES3::MobileActor * mobileActor);
+
 		//
 		// Other utility functions.
 		//

--- a/docs/source/lua/event/mobileActivated.rst
+++ b/docs/source/lua/event/mobileActivated.rst
@@ -1,0 +1,30 @@
+
+mobileActivated
+====================================================================================================
+
+This event is called when a `Mobile Actor`_ is activated. This may be the first time that a given `Reference`_ has an associated Mobile Actor attached to it.
+
+Typically this happens when transitioning through cells. When the player enters a cell, the **mobileActivated** event will fire for each new actor. When the player leaves the cell, the `mobileDeactivated`_ event is called.
+
+.. note:: See the `Event Guide`_ for more information on event data, return values, and filters.
+
+
+Event Data
+----------------------------------------------------------------------------------------------------
+
+reference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`Reference`_. The reference that the mobile has been activated for.
+
+
+Filter
+----------------------------------------------------------------------------------------------------
+This event may be filtered by **reference**.
+
+
+.. _`Event Guide`: ../guide/events.html
+
+.. _`mobileDeactivated`: mobileDeactivated.html
+
+.. _`Mobile Actor`: ../type/tes3/mobileActor.html
+.. _`Reference`: ../type/tes3/reference.html

--- a/docs/source/lua/event/mobileDeactivated.rst
+++ b/docs/source/lua/event/mobileDeactivated.rst
@@ -1,0 +1,30 @@
+
+mobileDeactivated
+====================================================================================================
+
+This event is called when a `Mobile Actor`_ is deactivated. 
+
+Typically this happens when transitioning through cells. When the player enters a cell, the `mobileActivated`_ event will fire for each new actor. When the player leaves the cell, the **mobileActivated** event is called.
+
+.. note:: See the `Event Guide`_ for more information on event data, return values, and filters.
+
+
+Event Data
+----------------------------------------------------------------------------------------------------
+
+reference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`Reference`_. The reference that the mobile has been activated for.
+
+
+Filter
+----------------------------------------------------------------------------------------------------
+This event may be filtered by **reference**.
+
+
+.. _`Event Guide`: ../guide/events.html
+
+.. _`mobileActivated`: mobileActivated.html
+
+.. _`Mobile Actor`: ../type/tes3/mobileActor.html
+.. _`Reference`: ../type/tes3/reference.html

--- a/docs/source/lua/event/weaponReadied.rst
+++ b/docs/source/lua/event/weaponReadied.rst
@@ -1,0 +1,29 @@
+
+weaponReadied
+====================================================================================================
+
+This event is called when a weapon is readied, and pairs with the `weaponUnreadied`_ event. It can be used to reliably tell if a specific weapon is readied for attack.
+
+.. attention:: This does not necessarily mean that the animation state has changed for the first time.
+
+.. note:: See the `Event Guide`_ for more information on event data, return values, and filters.
+
+
+Event Data
+----------------------------------------------------------------------------------------------------
+
+reference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`Reference`_. The reference associated with the change in readied weapon.
+
+
+Filter
+----------------------------------------------------------------------------------------------------
+This event may be filtered by **reference**.
+
+
+.. _`Event Guide`: ../guide/events.html
+
+.. _`weaponUnreadied`: weaponUnreadied.html
+
+.. _`Reference`: ../type/tes3/reference.html

--- a/docs/source/lua/event/weaponUnreadied.rst
+++ b/docs/source/lua/event/weaponUnreadied.rst
@@ -1,0 +1,34 @@
+
+weaponUnreadied
+====================================================================================================
+
+This event is called when a weapon is no longer readied, and pairs with the `weaponReadied`_ event. It can be used to reliably tell if a specific weapon is readied for attack.
+
+.. attention:: This does not necessarily mean that the animation state has changed for the first time. If an actor equips a weapon while having their hands up to attack with, the event will fire for the new weapon.
+
+.. note:: See the `Event Guide`_ for more information on event data, return values, and filters.
+
+
+Event Data
+----------------------------------------------------------------------------------------------------
+
+reference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`Reference`_. The reference associated with the change in readied weapon.
+
+weaponStack
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`Equipment Stack`_. The bundle that contains the newly readied weapon and its associated data.
+
+
+Filter
+----------------------------------------------------------------------------------------------------
+This event may be filtered by **reference**.
+
+
+.. _`Event Guide`: ../guide/events.html
+
+.. _`weaponReadied`: weaponReadied.html
+
+.. _`Equipment Stack`: ../type/tes3/equipmentStack.html
+.. _`Reference`: ../type/tes3/reference.html


### PR DESCRIPTION
Contains the following things:

- `mobileAttached` and `mobileDetached` events for when a mobile actor comes and goes.
- `weaponReadied` and `weaponUnreadied` events for when a weapon is not just equipped, but actively wielded.
- Fixes for `reference.position = value`.
- Changes `equipped` and `unequipped` events to not fire if there's no associated mobile actor/reference.

Still needs:

- [x] Remove mobileAdded/mobileDetached.
- [x] Add mobileAdded/mobileRemoved.
- [x] Add ability to remove a controller from an NI::Node.
- [x] Refactoring.
- [x] Documentation.