### PR TITLE
Add getPlayerEyePosition and getPlayerEyeVector.

### DIFF
--- a/MWSE/TES3PlayerAnimationData.h
+++ b/MWSE/TES3PlayerAnimationData.h
@@ -6,7 +6,7 @@
 
 namespace TES3 {
 	struct PlayerAnimationData : ActorAnimationData {
-		int unknown_0xD4;
+		NI::Camera * firstPersonHeadCameraNode; // 0xD4
 		TES3::Vector3 unknown_0xD8;
 		void * pickData; // 0xE4
 		bool is3rdPerson; // 0xE8

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -46,6 +46,7 @@
 #include "TES3MobileCreature.h"
 #include "TES3MobilePlayer.h"
 #include "TES3NPC.h"
+#include "TES3PlayerAnimationData.h" 
 #include "TES3Reference.h"
 #include "TES3Region.h"
 #include "TES3Script.h"
@@ -583,6 +584,28 @@ namespace mwse {
 					return worldController->worldCamera.camera->worldBoundOrigin;
 				}
 				return sol::optional<TES3::Vector3>();
+			};
+
+			// Bind function: tes3.getPlayerEyePosition
+			state["tes3"]["getPlayerEyePosition"] = []() {
+				auto * worldController = TES3::WorldController::get();
+				if (worldController) {
+					auto * mobilePlayer = worldController->getMobilePlayer();
+					if (mobilePlayer) {
+						return mobilePlayer->animationData.asPlayer->firstPersonHeadCameraNode->worldTransform.translation;
+					}
+				}
+				return TES3::Vector3();
+			};
+
+			// Bind function: tes3.getPlayerEyeVector
+			state["tes3"]["getPlayerEyeVector"] = []() {
+				auto * worldController = TES3::WorldController::get();
+				if (worldController) {
+					auto rotation = worldController->armCamera.cameraRoot->localRotation;
+					return TES3::Vector3(rotation->m0.y, rotation->m1.y, rotation->m2.y);
+				}
+				return TES3::Vector3();
 			};
 
 			// Bind function: tes3.getCameraPosition

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -578,7 +578,7 @@ namespace mwse {
 			};
 
 			// Bind function: tes3.getCameraPosition
-			state["tes3"]["getCameraPosition"] = [](sol::optional<sol::table> params) -> sol::optional<TES3::Vector3> {
+			state["tes3"]["getCameraPosition"] = []() -> sol::optional<TES3::Vector3> {
 				TES3::WorldController * worldController = TES3::WorldController::get();
 				if (worldController) {
 					return worldController->worldCamera.camera->worldBoundOrigin;
@@ -587,25 +587,25 @@ namespace mwse {
 			};
 
 			// Bind function: tes3.getPlayerEyePosition
-			state["tes3"]["getPlayerEyePosition"] = []() {
-				auto * worldController = TES3::WorldController::get();
+			state["tes3"]["getPlayerEyePosition"] = []() -> sol::optional<TES3::Vector3> {
+				auto worldController = TES3::WorldController::get();
 				if (worldController) {
-					auto * mobilePlayer = worldController->getMobilePlayer();
+					auto mobilePlayer = worldController->getMobilePlayer();
 					if (mobilePlayer) {
 						return mobilePlayer->animationData.asPlayer->firstPersonHeadCameraNode->worldTransform.translation;
 					}
 				}
-				return TES3::Vector3();
+				return sol::optional<TES3::Vector3>();
 			};
 
 			// Bind function: tes3.getPlayerEyeVector
-			state["tes3"]["getPlayerEyeVector"] = []() {
-				auto * worldController = TES3::WorldController::get();
+			state["tes3"]["getPlayerEyeVector"] = []() -> sol::optional<TES3::Vector3> {
+				auto worldController = TES3::WorldController::get();
 				if (worldController) {
 					auto rotation = worldController->armCamera.cameraRoot->localRotation;
 					return TES3::Vector3(rotation->m0.y, rotation->m1.y, rotation->m2.y);
 				}
-				return TES3::Vector3();
+				return sol::optional<TES3::Vector3>();
 			};
 
 			// Bind function: tes3.getCameraPosition


### PR DESCRIPTION
Add tes3.getPlayerEyePosition() and tes3.getPlayerEyeVector() functions.

Usage test:
```
event.register("simulate", function()
    if tes3.is3rdPerson() then tes3.player.sceneNode.appCulled = true end

    local eyepos = tes3.getPlayerEyePosition()
    local eyevec = tes3.getPlayerEyeVector()
    local rayhit = tes3.rayTest{position=eyepos, direction=eyevec}
    if rayhit then
        tes3.messageBox("%s", rayhit.reference)
    end

    if tes3.is3rdPerson() then tes3.player.sceneNode.appCulled = false end
end)
```

The messagebox should accurately match the native targeting mechanic. This differs from raycasting with getCameraPosition/getCameraVector, which have undesired behavior when in 3rd person or using the vanity camera.