### PR TITLE
Always raise trapDisarm on probe attempt

### DIFF
--- a/MWSE/LuaDisarmTrapEvent.cpp
+++ b/MWSE/LuaDisarmTrapEvent.cpp
@@ -10,14 +10,15 @@
 namespace mwse {
 	namespace lua {
 		namespace event {
-			DisarmTrapEvent::DisarmTrapEvent(TES3::Reference * reference, TES3::LockAttachmentNode * lockData, TES3::MobileNPC * disarmer, TES3::Item * tool, TES3::ItemData * itemData, float chance) :
+			DisarmTrapEvent::DisarmTrapEvent(TES3::Reference * reference, TES3::LockAttachmentNode * lockData, TES3::MobileNPC * disarmer, TES3::Item * tool, TES3::ItemData * itemData, float chance, bool trapPresent) :
 				ObjectFilteredEvent("trapDisarm", reference->baseObject),
 				m_Reference(reference),
 				m_LockData(lockData),
 				m_Disarmer(disarmer),
 				m_Tool(tool),
 				m_ItemData(itemData),
-				m_Chance(chance)
+				m_Chance(chance),
+				m_TrapPresent(trapPresent)
 			{
 
 			}
@@ -36,6 +37,7 @@ namespace mwse {
 				eventData["toolItemData"] = m_ItemData;
 
 				eventData["chance"] = m_Chance;
+				eventData["trapPresent"] = m_TrapPresent;
 
 				return eventData;
 			}

--- a/MWSE/LuaDisarmTrapEvent.h
+++ b/MWSE/LuaDisarmTrapEvent.h
@@ -8,7 +8,7 @@ namespace mwse {
 		namespace event {
 			class DisarmTrapEvent : public ObjectFilteredEvent, public DisableableEvent<DisarmTrapEvent> {
 			public:
-				DisarmTrapEvent(TES3::Reference * reference, TES3::LockAttachmentNode * lockData, TES3::MobileNPC * disarmer, TES3::Item * tool, TES3::ItemData * itemData, float chance);
+				DisarmTrapEvent(TES3::Reference * reference, TES3::LockAttachmentNode * lockData, TES3::MobileNPC * disarmer, TES3::Item * tool, TES3::ItemData * itemData, float chance, bool trapPresent);
 				sol::table createEventTable();
 
 			protected:
@@ -18,6 +18,7 @@ namespace mwse {
 				TES3::Item * m_Tool;
 				TES3::ItemData * m_ItemData;
 				float m_Chance;
+				bool m_TrapPresent;
 			};
 		}
 	}

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -472,7 +472,7 @@ namespace mwse {
 			luaState["mwse"]["disableableEvents"] = &m_DisableableEventManager;
 
 			// Fix the bit library to support mwse bitsets.
-			luaState["bit"]["band"] = [](sol::object input, unsigned int flag) {
+			luaState["bit"]["band"] = [](sol::object input, unsigned int flag) -> unsigned long {
 				if (input.is<unsigned int>()) {
 					return input.as<unsigned int>() & flag;
 				}
@@ -488,7 +488,7 @@ namespace mwse {
 
 				throw std::invalid_argument("First value must be an unsigned integer or a bitset.");
 			};
-			luaState["bit"]["bor"] = [](sol::object input, unsigned long flag) {
+			luaState["bit"]["bor"] = [](sol::object input, unsigned long flag) -> unsigned long {
 				if (input.is<unsigned int>()) {
 					return input.as<unsigned int>() | flag;
 				}


### PR DESCRIPTION
Previously, trapDisarm would only be raised when the reference has attached lockData, and that lockData had a trap.  Now it is raised every time the player uses a probe.

Adds a new event data item to trapDisarm: trapPresent (bool) - true if there was a trap present; false otherwise.

Adds a new output event data item to trapDisarm: clearTarget.  When this is set in the event handler, the player's target is cleared, the same as when a successful disarm occurs.

Also fixes a build error I had on my system by adding explicit type annotations to two lambda expressions for bit.band and bit.bor

