### PR TITLE
Override tes3faction.id in lua to give id

### DIFF
--- a/MWSE/TES3Faction.cpp
+++ b/MWSE/TES3Faction.cpp
@@ -9,6 +9,10 @@ namespace TES3 {
 		return -1;
 	}
 
+	char * Faction::getFactionId() {
+		return objectID;
+	}
+
 	char * Faction::getName() {
 		return name;
 	}

--- a/MWSE/TES3Faction.h
+++ b/MWSE/TES3Faction.h
@@ -42,6 +42,8 @@ namespace TES3 {
 		// Custom functions.
 		//
 
+		char * getFactionId();
+
 		char * getName();
 		void setName(const char*);
 

--- a/MWSE/TES3FactionLua.cpp
+++ b/MWSE/TES3FactionLua.cpp
@@ -55,6 +55,9 @@ namespace mwse {
 				usertypeDefinition.set(sol::base_classes, sol::bases<TES3::BaseObject>());
 				setUserdataForBaseObject(usertypeDefinition);
 
+				// Override the id property from BaseObject
+				usertypeDefinition.set("id", sol::readonly_property(&TES3::Faction::getFactionId));
+
 				// Basic property binding.
 				usertypeDefinition.set("reactions", sol::readonly_property(&TES3::Faction::reactions));
 				usertypeDefinition.set("playerReputation", &TES3::Faction::playerReputation);


### PR DESCRIPTION
Possible fix for #221

The id property inherited from BaseObject erroneously gave the
faction's name instead of its id.  This overrides that property
with one directly returning the id from the Faction struct.

However, this is just a band-aid fix, and may not be desired as
it appears to be correcting Vanilla functionality.