### PR TITLE
hook removal

### DIFF
--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -2717,7 +2717,6 @@ namespace mwse {
 
 			// Event: equip.
 			genCallEnforced(0x5CB8E7, 0x5CE130, reinterpret_cast<DWORD>(OnPCEquip));
-			genCallEnforced(0x5D11D9, 0x5CE130, reinterpret_cast<DWORD>(OnPCEquip));
 			genCallEnforced(0x60E70F, 0x5CE130, reinterpret_cast<DWORD>(OnPCEquip));
 			genCallEnforced(0x60E9BE, 0x5CE130, reinterpret_cast<DWORD>(OnPCEquip));
 			// ui_inventoryEquipItemToPlayer calls


### PR DESCRIPTION
- removed one OnPCEquip hooks when called from
  TES3_ui_inventory_equipInventoryItemToPlayer. It caused the "equip"
  event to fire twice when using quickslots