### PR TITLE
TES3MagicEffect

### DIFF
--- a/MWSE/TES3MagicEffect.cpp
+++ b/MWSE/TES3MagicEffect.cpp
@@ -6,6 +6,8 @@
 #include "TES3GameSetting.h"
 #include "TES3MagicEffectController.h"
 
+#include <cstring>
+
 namespace TES3 {
 	const auto TES3_MagicEffect_ctor = reinterpret_cast<void(__thiscall*)(MagicEffect*)>(0x4A8C90);
 	MagicEffect::MagicEffect() {
@@ -37,6 +39,32 @@ namespace TES3 {
 			return -1;
 		}
 		return reinterpret_cast<int*>(0x79454C)[id];
+	}
+
+	void MagicEffect::setDescription( const char *value )
+	{
+		if( value == nullptr )
+		{
+			if( description != nullptr )
+			{
+				delete[] description;
+				description = nullptr;
+			}
+
+			return;
+		}
+
+		auto size = std::strlen( value ) + 1;
+
+		char *newDescription = new char[ size ];
+
+		if( newDescription == nullptr )
+			return;
+
+		std::strncpy( newDescription, value, size );
+
+		delete[] description;
+		description = newDescription;
 	}
 
 	MagicEffect * Effect::getEffectData() {

--- a/MWSE/TES3MagicEffect.h
+++ b/MWSE/TES3MagicEffect.h
@@ -262,6 +262,7 @@ namespace TES3 {
 		//
 
 		int getNameGMST();
+		void setDescription( const char *value );
 
 	};
 	static_assert(sizeof(MagicEffect) == 0x0110, "TES3::EffectID:: failed size validation");

--- a/MWSE/TES3MagicEffectLua.cpp
+++ b/MWSE/TES3MagicEffectLua.cpp
@@ -117,6 +117,9 @@ namespace mwse {
 
 				// Functions exposed as properties.
 				usertypeDefinition.set("name", sol::readonly_property([](TES3::MagicEffect& self) { return TES3::DataHandler::get()->nonDynamicData->magicEffects->getEffectName(self.id); }));
+				usertypeDefinition.set( "description", sol::property(
+					[]( TES3::MagicEffect &self ) { return self.description; },
+					[]( TES3::MagicEffect &self, const char *value ) { self.setDescription( value ); } ) );
 				usertypeDefinition.set("areaSoundEffect", sol::readonly_property([](TES3::MagicEffect& self) { return self.areaSoundEffect; }));
 				usertypeDefinition.set("boltSoundEffect", sol::readonly_property([](TES3::MagicEffect& self) { return self.boltSoundEffect; }));
 				usertypeDefinition.set("castSoundEffect", sol::readonly_property([](TES3::MagicEffect& self) { return self.castSoundEffect; }));
@@ -126,6 +129,10 @@ namespace mwse {
 					[](TES3::MagicEffect& self, const char* value) { if (strlen(value) < 32) strcpy(self.icon, value); }
 				));
 				usertypeDefinition.set("particleTexture", sol::readonly_property([](TES3::MagicEffect& self) { return self.particleTexture; }));
+
+				// custom functions
+				// that one looks needed (though maybe crap) as setting description to nil using lua is not handled in the property...don't know why, NullCascade, any idea?
+				usertypeDefinition.set( "resetDescription", []( TES3::MagicEffect &self ) { self.setDescription( nullptr ); } );
 
 				// Finish up our usertype.
 				state.set_usertype("tes3magicEffect", usertypeDefinition);


### PR DESCRIPTION
- add simple bindings to set a custom description on an existing magic
  effect and to reset the description to the original vanilla one
- not tested with custom magic effect that could be added by
  MagickaExpanded but as far as I can see, it should work