### PR TITLE
Magic effect description

### DIFF
--- a/MWSE/TES3MagicEffect.cpp
+++ b/MWSE/TES3MagicEffect.cpp
@@ -6,6 +6,8 @@
 #include "TES3GameSetting.h"
 #include "TES3MagicEffectController.h"
 
+#include <cstring>
+
 namespace TES3 {
 	const auto TES3_MagicEffect_ctor = reinterpret_cast<void(__thiscall*)(MagicEffect*)>(0x4A8C90);
 	MagicEffect::MagicEffect() {
@@ -37,6 +39,32 @@ namespace TES3 {
 			return -1;
 		}
 		return reinterpret_cast<int*>(0x79454C)[id];
+	}
+
+	void MagicEffect::setDescription( const char *value )
+	{
+		if( value == nullptr )
+		{
+			if( description != nullptr )
+			{
+				delete[] description;
+				description = nullptr;
+			}
+
+			return;
+		}
+
+		auto size = std::strlen( value ) + 1;
+
+		char *newDescription = new char[ size ];
+
+		if( newDescription == nullptr )
+			return;
+
+		std::strncpy( newDescription, value, size );
+
+		delete[] description;
+		description = newDescription;
 	}
 
 	MagicEffect * Effect::getEffectData() {

--- a/MWSE/TES3MagicEffect.cpp
+++ b/MWSE/TES3MagicEffect.cpp
@@ -47,7 +47,7 @@ namespace TES3 {
 		{
 			if( description != nullptr )
 			{
-				delete[] description;
+				mwse::tes3::free( description );
 				description = nullptr;
 			}
 
@@ -56,14 +56,16 @@ namespace TES3 {
 
 		auto size = std::strlen( value ) + 1;
 
-		char *newDescription = new char[ size ];
+		char *newDescription = reinterpret_cast< char * >( mwse::tes3::_new( size ) );
 
 		if( newDescription == nullptr )
 			return;
 
 		std::strncpy( newDescription, value, size );
 
-		delete[] description;
+		if( description != nullptr  )
+			mwse::tes3::free( description );
+
 		description = newDescription;
 	}
 

--- a/MWSE/TES3MagicEffect.cpp
+++ b/MWSE/TES3MagicEffect.cpp
@@ -6,8 +6,6 @@
 #include "TES3GameSetting.h"
 #include "TES3MagicEffectController.h"
 
-#include <cstring>
-
 namespace TES3 {
 	const auto TES3_MagicEffect_ctor = reinterpret_cast<void(__thiscall*)(MagicEffect*)>(0x4A8C90);
 	MagicEffect::MagicEffect() {
@@ -43,30 +41,7 @@ namespace TES3 {
 
 	void MagicEffect::setDescription( const char *value )
 	{
-		if( value == nullptr )
-		{
-			if( description != nullptr )
-			{
-				mwse::tes3::free( description );
-				description = nullptr;
-			}
-
-			return;
-		}
-
-		auto size = std::strlen( value ) + 1;
-
-		char *newDescription = reinterpret_cast< char * >( mwse::tes3::_new( size ) );
-
-		if( newDescription == nullptr )
-			return;
-
-		std::strncpy( newDescription, value, size );
-
-		if( description != nullptr  )
-			mwse::tes3::free( description );
-
-		description = newDescription;
+		mwse::tes3::setDataString( &description, value );
 	}
 
 	MagicEffect * Effect::getEffectData() {

--- a/MWSE/TES3MagicEffect.h
+++ b/MWSE/TES3MagicEffect.h
@@ -262,6 +262,7 @@ namespace TES3 {
 		//
 
 		int getNameGMST();
+		void setDescription( const char *value );
 
 	};
 	static_assert(sizeof(MagicEffect) == 0x0110, "TES3::EffectID:: failed size validation");

--- a/MWSE/TES3MagicEffectController.cpp
+++ b/MWSE/TES3MagicEffectController.cpp
@@ -572,6 +572,10 @@ namespace TES3 {
 		// Clear some more initialization of magic effect IDs.
 		mwse::genNOPUnprotected(0x4B831D, 0x22);
 
+		// Prevent free of spell effect description when help menu display it both for populating enchanting menu and spell making menu
+		mwse::genNOPUnprotected( 0x6231E1, 0x5 );
+		mwse::genNOPUnprotected( 0x5C69C1, 0x5 );
+
 		// When destructing the effect list, 
 		mwse::genCallUnprotected(0x4B821B, (DWORD)DestroyController, 0x20);
 

--- a/MWSE/TES3MagicEffectLua.cpp
+++ b/MWSE/TES3MagicEffectLua.cpp
@@ -119,7 +119,7 @@ namespace mwse {
 				usertypeDefinition.set("name", sol::readonly_property([](TES3::MagicEffect& self) { return TES3::DataHandler::get()->nonDynamicData->magicEffects->getEffectName(self.id); }));
 				usertypeDefinition.set( "description", sol::property(
 					[]( TES3::MagicEffect &self ) { return self.description; },
-					[]( TES3::MagicEffect &self, const char *value ) { self.setDescription( value ); } ) );
+					[]( TES3::MagicEffect &self, sol::optional< const char * >value ) { self.setDescription( value.value_or( nullptr ) ); } ) );
 				usertypeDefinition.set("areaSoundEffect", sol::readonly_property([](TES3::MagicEffect& self) { return self.areaSoundEffect; }));
 				usertypeDefinition.set("boltSoundEffect", sol::readonly_property([](TES3::MagicEffect& self) { return self.boltSoundEffect; }));
 				usertypeDefinition.set("castSoundEffect", sol::readonly_property([](TES3::MagicEffect& self) { return self.castSoundEffect; }));
@@ -129,10 +129,6 @@ namespace mwse {
 					[](TES3::MagicEffect& self, const char* value) { if (strlen(value) < 32) strcpy(self.icon, value); }
 				));
 				usertypeDefinition.set("particleTexture", sol::readonly_property([](TES3::MagicEffect& self) { return self.particleTexture; }));
-
-				// custom functions
-				// that one looks needed (though maybe crap) as setting description to nil using lua is not handled in the property...don't know why, NullCascade, any idea?
-				usertypeDefinition.set( "resetDescription", []( TES3::MagicEffect &self ) { self.setDescription( nullptr ); } );
 
 				// Finish up our usertype.
 				state.set_usertype("tes3magicEffect", usertypeDefinition);

--- a/MWSE/TES3MagicEffectLua.cpp
+++ b/MWSE/TES3MagicEffectLua.cpp
@@ -117,6 +117,9 @@ namespace mwse {
 
 				// Functions exposed as properties.
 				usertypeDefinition.set("name", sol::readonly_property([](TES3::MagicEffect& self) { return TES3::DataHandler::get()->nonDynamicData->magicEffects->getEffectName(self.id); }));
+				usertypeDefinition.set( "description", sol::property(
+					[]( TES3::MagicEffect &self ) { return self.description; },
+					[]( TES3::MagicEffect &self, const char *value ) { self.setDescription( value ); } ) );
 				usertypeDefinition.set("areaSoundEffect", sol::readonly_property([](TES3::MagicEffect& self) { return self.areaSoundEffect; }));
 				usertypeDefinition.set("boltSoundEffect", sol::readonly_property([](TES3::MagicEffect& self) { return self.boltSoundEffect; }));
 				usertypeDefinition.set("castSoundEffect", sol::readonly_property([](TES3::MagicEffect& self) { return self.castSoundEffect; }));
@@ -126,6 +129,10 @@ namespace mwse {
 					[](TES3::MagicEffect& self, const char* value) { if (strlen(value) < 32) strcpy(self.icon, value); }
 				));
 				usertypeDefinition.set("particleTexture", sol::readonly_property([](TES3::MagicEffect& self) { return self.particleTexture; }));
+
+				// custom functions
+				// that one looks needed (though maybe crap) as setting description to nil using lua is not handled in the property...don't know why, NullCascade, any idea?
+				usertypeDefinition.set( "resetDescription", []( TES3::MagicEffect &self ) { self.setDescription( nullptr ); } );
 
 				// Finish up our usertype.
 				state.set_usertype("tes3magicEffect", usertypeDefinition);

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -3291,11 +3291,10 @@ namespace mwse {
 				// Description.
 				sol::optional<std::string> description = params["description"];
 				if (description) {
-					effect->description = new char[description.value().length() + 1];
-					strcpy_s(effect->description, description.value().length() + 1, description.value().c_str());
+					effect->setDescription( description.value().c_str() );
 				}
 				else {
-					effect->description = "No description available.";
+					effect->setDescription( "No description available." );
 				}
 
 				// Set color.


### PR DESCRIPTION
dynamic spell effect description

- used tes3 allocation / deallocation primitive to prevent access violations
- patched code called while populating enchanting and spellmaking menus to prevent spell effect description reset. Therefore spell descriptions can be changed at anytime. No leak has been observed in the MagicEffectController.
- NullCascade, this is my very first patch, should I have missed something or done crappy stuff, I'd appreciate you teach me quickly how things could have been done in a better way : Meta Barj0#4864