### PR TITLE
tes3enchantment.create binding

### DIFF
--- a/MWSE/LuaObject.cpp
+++ b/MWSE/LuaObject.cpp
@@ -13,6 +13,8 @@ std::unique_ptr< ObjectCreatorBase > makeObjectCreator( TES3::ObjectType::Object
 		return std::make_unique< ObjectCreator< TES3::Misc > >();
 	case TES3::ObjectType::Static:
 		return std::make_unique< ObjectCreator< TES3::Static > >();
+	case TES3::ObjectType::Enchantment:
+		return std::make_unique< ObjectCreator< TES3::Enchantment> >();
 	default:
 		return std::make_unique< InvalidObjectCreator >();
 	}

--- a/MWSE/TES3Enchantment.cpp
+++ b/MWSE/TES3Enchantment.cpp
@@ -1,6 +1,25 @@
 #include "TES3Enchantment.h"
 
 namespace TES3 {
+	const auto TES3_Enchantment_ctor = reinterpret_cast< void( __thiscall * )( Enchantment * ) >( 0x4AADA0 );
+	Enchantment::Enchantment() :
+		objectID{},
+		castType{},
+		chargeCost{},
+		maxCharge{},
+		pad_32{},
+		effects{},
+		flags{}
+	{
+		TES3_Enchantment_ctor( this );
+	}
+
+	const auto TES3_Enchantment_dtor = reinterpret_cast< void( __thiscall * )( Enchantment * ) >( 0x4AAEA0 );
+	Enchantment::~Enchantment()
+	{
+		TES3_Enchantment_dtor( this );
+	}
+
 	size_t Enchantment::getActiveEffectCount() {
 		size_t count = 0;
 		for (size_t i = 0; i < 8; i++) {

--- a/MWSE/TES3Enchantment.h
+++ b/MWSE/TES3Enchantment.h
@@ -10,17 +10,14 @@ namespace TES3 {
 		Once,
 		OnStrike,
 		OnUse,
-		Constant
+		Constant,
+		Invalid
 	};
 
-	namespace EnchantmentFlags {
-		typedef unsigned int value_type;
-
-		enum Flag : value_type {
-		};
-	}
-
 	struct Enchantment : Object {
+		Enchantment();
+		~Enchantment();
+
 		char * objectID; // 0x28
 		EnchantmentCastType castType; // 0x2C
 		unsigned short chargeCost; // 0x2E

--- a/MWSE/TES3EnchantmentLua.cpp
+++ b/MWSE/TES3EnchantmentLua.cpp
@@ -4,9 +4,15 @@
 #include "TES3ObjectLua.h"
 
 #include "TES3Enchantment.h"
+#include "LuaObject.h"
 
 namespace mwse {
 	namespace lua {
+		auto createEnchantment( sol::table params )
+		{
+			return makeObjectCreator( TES3::ObjectType::Enchantment )->create( params, false );
+		}
+
 		void bindTES3Enchantment() {
 			// Get our lua state.
 			auto stateHandle = LuaManager::getInstance().getThreadSafeStateHandle();
@@ -32,6 +38,9 @@ namespace mwse {
 
 			// Indirect bindings to unions and arrays.
 			usertypeDefinition.set("effects", sol::readonly_property([](TES3::Enchantment& self) { return std::ref(self.effects); }));
+
+			// utility function bindings
+			usertypeDefinition.set( "create", &createEnchantment );
 
 			// Finish up our usertype.
 			state.set_usertype("tes3enchantment", usertypeDefinition);

--- a/autocomplete/definitions/namedTypes/tes3enchantment/create.lua
+++ b/autocomplete/definitions/namedTypes/tes3enchantment/create.lua
@@ -1,0 +1,16 @@
+return {
+	type = "function",
+	description = [[Creates a new enchantment object, which will be stored as part of the current saved game.]],
+	arguments = {{
+		name = "params",
+		type = "table",
+		tableParams = {
+			{ name = "id", type = "string", optional = true, description = "The new object's ID. Must be unique if provided." },
+			{ name = "castType", type = "number", optional = false, description = "The enchantment castType. See tes3.enchantmentType." },
+			{ name = "chargeCost", type = "number", optional = false, description = "The new enchantment charge cost. Must be greater than 0." },
+			{ name = "maxCharge", type = "number", optional = false, description = "The new enchantment maximum charge. Must be greater than 0" },
+			{ name = "flags", type = "number", optional = true, description = "The new enchantment flags." },
+			{ name = "objectFlags", type = "number", default = 0, description = "The object flags initially set. Force set as modified." }
+		},
+	}},
+}

--- a/autocomplete/definitions/namedTypes/tes3enchantment/create/description.rst
+++ b/autocomplete/definitions/namedTypes/tes3enchantment/create/description.rst
@@ -1,0 +1,16 @@
+Create a new `tes3enchantment`_ object which will be stored as part of the current saved game.
+
+The example below create an enchantment object that could be used to be bound on an item later on.
+.. code-block:: lua
+	:linenos:
+
+local enchantmentId = "_dynamic_enchantment_id"
+
+local enchantment = tes3enchantment.create( {
+  id = enchantmentId,
+  castType = tes3.enchantmentType.castOnce,
+  chargeCost = 2,
+  maxCharge = 12
+} )
+
+-- effects can be set later on using enchantment.effects table


### PR DESCRIPTION
- added tes3enchantment.create and extended the tes3.createObject
  binding counterpart
- id parameter for object creation (all handled types) is now optional