### PR TITLE
RemoveFromLev*

### DIFF
--- a/MWSE/ScriptUtil.cpp
+++ b/MWSE/ScriptUtil.cpp
@@ -522,6 +522,42 @@ namespace mwse
 			setScriptSecondObject(cachedSecondObject);
 		}
 
+		void RemoveFromLevCreature(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* leveledList, TES3::Actor* actor, unsigned short level) {
+			// Cache destination values.
+			TES3::BaseObject* cachedSecondObject = getScriptSecondObject();
+			TES3::BaseObject* cachedDataBufferObject = getDataBufferObject();
+			float cachedDestinationX = getScriptDestinationX();
+
+			// Call original opcode.
+			setScriptSecondObject(leveledList);
+			setDataBufferObject(actor);
+			setScriptDestinationX(level);
+			RunOriginalOpCode(script, reference, OpCode::RemoveFromLevCreature);
+
+			// Restore destination values.
+			setScriptSecondObject(cachedSecondObject);
+			setDataBufferObject(cachedDataBufferObject);
+			setScriptDestinationX(cachedDestinationX);
+		}
+
+		void RemoveFromLevItem(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* leveledList, TES3::PhysicalObject* item, unsigned short level) {
+			// Cache destination values.
+			TES3::BaseObject* cachedSecondObject = getScriptSecondObject();
+			TES3::BaseObject* cachedDataBufferObject = getDataBufferObject();
+			float cachedDestinationX = getScriptDestinationX();
+
+			// Call original opcode.
+			setScriptSecondObject(leveledList);
+			setDataBufferObject(item);
+			setScriptDestinationX(level);
+			RunOriginalOpCode(script, reference, OpCode::RemoveFromLevItem);
+
+			// Restore destination values.
+			setScriptSecondObject(cachedSecondObject);
+			setDataBufferObject(cachedDataBufferObject);
+			setScriptDestinationX(cachedDestinationX);
+		}
+
 		void RemoveItem(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* itemTemplate, long count) {
 			// Cache previous script variables.
 			long cachedVarIndex = getScriptVariableIndex();

--- a/MWSE/ScriptUtil.h
+++ b/MWSE/ScriptUtil.h
@@ -154,6 +154,10 @@ namespace mwse
 
 		void PositionCell(TES3::Script* script, TES3::Reference* reference, float x, float y, float z, float rotation, const char* cell);
 
+		void RemoveFromLevCreature(TES3::Script*, TES3::Reference*, TES3::BaseObject*, TES3::Actor*, unsigned short);
+
+		void RemoveFromLevItem(TES3::Script*, TES3::Reference*, TES3::BaseObject*, TES3::PhysicalObject*, unsigned short);
+
 		void RemoveItem(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* itemTemplate, long count);
 
 		void RemoveSpell(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* spellTemplate);

--- a/MWSE/ScriptUtilLua.cpp
+++ b/MWSE/ScriptUtilLua.cpp
@@ -371,6 +371,32 @@ namespace mwse {
 				mwscript::PositionCell(script, reference, x, y, z, rotation, cell.c_str());
 				return true;
 			};
+			state["mwscript"]["removeFromLevCreature"] = [](sol::optional<sol::table> params) {
+				TES3::Script* script = getOptionalParamExecutionScript(params);
+				TES3::Reference* reference = getOptionalParamExecutionReference(params);
+				TES3::LeveledCreature* list = getOptionalParamObject<TES3::LeveledCreature>(params, "list");
+				TES3::Actor* actor = getOptionalParamObject<TES3::Actor>(params, "creature");
+				short level = getOptionalParam<double>(params, "level", 0.0);
+				if (list == NULL || actor == NULL || level <= 0) {
+					return false;
+				}
+
+				mwscript::RemoveFromLevCreature(script, reference, list, actor, level);
+				return true;
+			};
+			state["mwscript"]["removeFromLevItem"] = [](sol::optional<sol::table> params) {
+				TES3::Script* script = getOptionalParamExecutionScript(params);
+				TES3::Reference* reference = getOptionalParamExecutionReference(params);
+				TES3::BaseObject* list = getOptionalParamObject<TES3::BaseObject>(params, "list");
+				TES3::Item* item = getOptionalParamObject<TES3::Item>(params, "item");
+				short level = getOptionalParam<double>(params, "level", 0.0);
+				if (list == NULL || item == NULL || level <= 0) {
+					return false;
+				}
+
+				mwscript::RemoveFromLevItem(script, reference, list, item, level);
+				return true;
+			};
 			state["mwscript"]["removeItem"] = [](sol::optional<sol::table> params) {
 				TES3::Script* script = getOptionalParamExecutionScript(params);
 				TES3::Reference* reference = getOptionalParamExecutionReference(params);

--- a/autocomplete/definitions/global/mwscript/addToLevItem.lua
+++ b/autocomplete/definitions/global/mwscript/addToLevItem.lua
@@ -5,7 +5,7 @@ return {
 		name = "params",
 		type = "table",
 		tableParams = {
-			{ name = "list", type = "tes3leveledItem|string", description = "Leveled item list to add a creature to." },
+			{ name = "list", type = "tes3leveledItem|string", description = "Leveled item list to add an item to." },
 			{ name = "item", type = "tes3item|string", description = "Item to add to the list." },
 			{ name = "level", type = "number", default = 0, description = "Minimum level for the item to spawn." },
 		},

--- a/autocomplete/definitions/global/mwscript/removeFromLevCreature.lua
+++ b/autocomplete/definitions/global/mwscript/removeFromLevCreature.lua
@@ -1,0 +1,14 @@
+return {
+	type = "function",
+	description = [[Wrapper for the RemoveFromLevCreature mwscript function.]],
+	arguments = {{
+		name = "params",
+		type = "table",
+		tableParams = {
+			{ name = "list", type = "tes3leveledCreature|string", description = "Leveled creature list to remove a creature from." },
+			{ name = "creature", type = "tes3actor|string", description = "Creature to remove from the list." },
+			{ name = "level", type = "number", default = 0, description = "Minimum level for the creature to spawn." },
+		},
+	}},
+	returns = {{ name = "executed", type = "boolean" }},
+}

--- a/autocomplete/definitions/global/mwscript/removeFromLevItem.lua
+++ b/autocomplete/definitions/global/mwscript/removeFromLevItem.lua
@@ -1,0 +1,14 @@
+return {
+	type = "function",
+	description = [[Wrapper for the RemoveFromLevItem mwscript function.]],
+	arguments = {{
+		name = "params",
+		type = "table",
+		tableParams = {
+			{ name = "list", type = "tes3leveledItem|string", description = "Leveled item list to remove an item from." },
+			{ name = "item", type = "tes3item|string", description = "Item to remove from the list." },
+			{ name = "level", type = "number", default = 0, description = "Minimum level for the item to spawn." },
+		},
+	}},
+	returns = {{ name = "executed", type = "boolean" }},
+}

--- a/docs/source/lua/api/mwscript.rst
+++ b/docs/source/lua/api/mwscript.rst
@@ -38,6 +38,8 @@ Functions
     mwscript/playSound
     mwscript/position
     mwscript/positionCell
+    mwscript/removeFromLevCreature
+    mwscript/removeFromLevItem
     mwscript/removeItem
     mwscript/removeSpell
     mwscript/scriptRunning

--- a/docs/source/lua/api/mwscript/addToLevItem.rst
+++ b/docs/source/lua/api/mwscript/addToLevItem.rst
@@ -14,7 +14,7 @@ Parameters
 Accepts parameters through a table with the given keys:
 
 list (`tes3leveledItem`_, `string`_)
-    Leveled item list to add a creature to.
+    Leveled item list to add an item to.
 
 item (`tes3item`_, `string`_)
     Item to add to the list.

--- a/docs/source/lua/api/mwscript/removeFromLevCreature.rst
+++ b/docs/source/lua/api/mwscript/removeFromLevCreature.rst
@@ -1,0 +1,135 @@
+mwscript.removeFromLevCreature
+====================================================================================================
+
+Wrapper for the RemoveFromLevCreature mwscript function.
+
+Returns
+----------------------------------------------------------------------------------------------------
+
+`boolean`_.
+
+Parameters
+----------------------------------------------------------------------------------------------------
+
+Accepts parameters through a table with the given keys:
+
+list (`tes3leveledCreature`_, `string`_)
+    Leveled creature list to remove a creature from.
+
+creature (`tes3actor`_, `string`_)
+    Creature to remove from the list.
+
+level (`number`_)
+    Default: ``0``. Minimum level for the creature to spawn.
+
+.. _`tes3creature`: ../../../lua/type/tes3creature.html
+.. _`niObject`: ../../../lua/type/niObject.html
+.. _`tes3npc`: ../../../lua/type/tes3npc.html
+.. _`tes3book`: ../../../lua/type/tes3book.html
+.. _`tes3matrix33`: ../../../lua/type/tes3matrix33.html
+.. _`tes3actor`: ../../../lua/type/tes3actor.html
+.. _`tes3inputConfig`: ../../../lua/type/tes3inputConfig.html
+.. _`tes3itemStack`: ../../../lua/type/tes3itemStack.html
+.. _`tes3globalVariable`: ../../../lua/type/tes3globalVariable.html
+.. _`tes3containerInstance`: ../../../lua/type/tes3containerInstance.html
+.. _`tes3magicSourceInstance`: ../../../lua/type/tes3magicSourceInstance.html
+.. _`niAVObject`: ../../../lua/type/niAVObject.html
+.. _`tes3iterator`: ../../../lua/type/tes3iterator.html
+.. _`tes3raceHeightWeight`: ../../../lua/type/tes3raceHeightWeight.html
+.. _`tes3class`: ../../../lua/type/tes3class.html
+.. _`tes3mobileProjectile`: ../../../lua/type/tes3mobileProjectile.html
+.. _`tes3apparatus`: ../../../lua/type/tes3apparatus.html
+.. _`tes3door`: ../../../lua/type/tes3door.html
+.. _`tes3directInputMouseState`: ../../../lua/type/tes3directInputMouseState.html
+.. _`niRTTI`: ../../../lua/type/niRTTI.html
+.. _`tes3weatherThunder`: ../../../lua/type/tes3weatherThunder.html
+.. _`niObjectNET`: ../../../lua/type/niObjectNET.html
+.. _`tes3weatherSnow`: ../../../lua/type/tes3weatherSnow.html
+.. _`tes3weatherRain`: ../../../lua/type/tes3weatherRain.html
+.. _`tes3light`: ../../../lua/type/tes3light.html
+.. _`tes3clothing`: ../../../lua/type/tes3clothing.html
+.. _`tes3armor`: ../../../lua/type/tes3armor.html
+.. _`tes3weatherController`: ../../../lua/type/tes3weatherController.html
+.. _`tes3npcInstance`: ../../../lua/type/tes3npcInstance.html
+.. _`tes3mobilePlayer`: ../../../lua/type/tes3mobilePlayer.html
+.. _`nil`: ../../../lua/type/nil.html
+.. _`tes3dataHandler`: ../../../lua/type/tes3dataHandler.html
+.. _`tes3rangeInt`: ../../../lua/type/tes3rangeInt.html
+.. _`tes3dialogueInfo`: ../../../lua/type/tes3dialogueInfo.html
+.. _`tes3weatherBlizzard`: ../../../lua/type/tes3weatherBlizzard.html
+.. _`tes3weatherAsh`: ../../../lua/type/tes3weatherAsh.html
+.. _`tes3container`: ../../../lua/type/tes3container.html
+.. _`tes3weather`: ../../../lua/type/tes3weather.html
+.. _`tes3dialogue`: ../../../lua/type/tes3dialogue.html
+.. _`tes3gameFile`: ../../../lua/type/tes3gameFile.html
+.. _`tes3faction`: ../../../lua/type/tes3faction.html
+.. _`tes3wearablePart`: ../../../lua/type/tes3wearablePart.html
+.. _`tes3inputController`: ../../../lua/type/tes3inputController.html
+.. _`tes3lockpick`: ../../../lua/type/tes3lockpick.html
+.. _`tes3combatSession`: ../../../lua/type/tes3combatSession.html
+.. _`boolean`: ../../../lua/type/boolean.html
+.. _`tes3vector4`: ../../../lua/type/tes3vector4.html
+.. _`tes3magicEffect`: ../../../lua/type/tes3magicEffect.html
+.. _`string`: ../../../lua/type/string.html
+.. _`tes3referenceList`: ../../../lua/type/tes3referenceList.html
+.. _`tes3iteratorNode`: ../../../lua/type/tes3iteratorNode.html
+.. _`tes3fader`: ../../../lua/type/tes3fader.html
+.. _`tes3quest`: ../../../lua/type/tes3quest.html
+.. _`tes3nonDynamicData`: ../../../lua/type/tes3nonDynamicData.html
+.. _`tes3ingredient`: ../../../lua/type/tes3ingredient.html
+.. _`tes3race`: ../../../lua/type/tes3race.html
+.. _`tes3gameSetting`: ../../../lua/type/tes3gameSetting.html
+.. _`tes3vector2`: ../../../lua/type/tes3vector2.html
+.. _`table`: ../../../lua/type/table.html
+.. _`tes3travelDestinationNode`: ../../../lua/type/tes3travelDestinationNode.html
+.. _`tes3transform`: ../../../lua/type/tes3transform.html
+.. _`tes3mobileNPC`: ../../../lua/type/tes3mobileNPC.html
+.. _`tes3soulGemData`: ../../../lua/type/tes3soulGemData.html
+.. _`tes3vector3`: ../../../lua/type/tes3vector3.html
+.. _`tes3reference`: ../../../lua/type/tes3reference.html
+.. _`tes3raceSkillBonus`: ../../../lua/type/tes3raceSkillBonus.html
+.. _`tes3activator`: ../../../lua/type/tes3activator.html
+.. _`tes3raceBodyParts`: ../../../lua/type/tes3raceBodyParts.html
+.. _`tes3inventory`: ../../../lua/type/tes3inventory.html
+.. _`tes3boundingBox`: ../../../lua/type/tes3boundingBox.html
+.. _`tes3markData`: ../../../lua/type/tes3markData.html
+.. _`tes3raceBaseAttribute`: ../../../lua/type/tes3raceBaseAttribute.html
+.. _`tes3creatureInstance`: ../../../lua/type/tes3creatureInstance.html
+.. _`tes3effect`: ../../../lua/type/tes3effect.html
+.. _`tes3game`: ../../../lua/type/tes3game.html
+.. _`tes3probe`: ../../../lua/type/tes3probe.html
+.. _`tes3physicalObject`: ../../../lua/type/tes3physicalObject.html
+.. _`tes3object`: ../../../lua/type/tes3object.html
+.. _`tes3weatherClear`: ../../../lua/type/tes3weatherClear.html
+.. _`number`: ../../../lua/type/number.html
+.. _`tes3moon`: ../../../lua/type/tes3moon.html
+.. _`tes3weatherCloudy`: ../../../lua/type/tes3weatherCloudy.html
+.. _`tes3mobileObject`: ../../../lua/type/tes3mobileObject.html
+.. _`tes3misc`: ../../../lua/type/tes3misc.html
+.. _`tes3leveledListNode`: ../../../lua/type/tes3leveledListNode.html
+.. _`tes3mobileCreature`: ../../../lua/type/tes3mobileCreature.html
+.. _`tes3mobileActor`: ../../../lua/type/tes3mobileActor.html
+.. _`function`: ../../../lua/type/function.html
+.. _`tes3magicEffectInstance`: ../../../lua/type/tes3magicEffectInstance.html
+.. _`tes3baseObject`: ../../../lua/type/tes3baseObject.html
+.. _`tes3bodyPart`: ../../../lua/type/tes3bodyPart.html
+.. _`tes3factionRank`: ../../../lua/type/tes3factionRank.html
+.. _`mwseTimer`: ../../../lua/type/mwseTimer.html
+.. _`tes3weatherBlight`: ../../../lua/type/tes3weatherBlight.html
+.. _`tes3packedColor`: ../../../lua/type/tes3packedColor.html
+.. _`bool`: ../../../lua/type/boolean.html
+.. _`tes3equipmentStack`: ../../../lua/type/tes3equipmentStack.html
+.. _`tes3weatherFoggy`: ../../../lua/type/tes3weatherFoggy.html
+.. _`mwseTimerController`: ../../../lua/type/mwseTimerController.html
+.. _`tes3leveledCreature`: ../../../lua/type/tes3leveledCreature.html
+.. _`tes3lockNode`: ../../../lua/type/tes3lockNode.html
+.. _`tes3activeMagicEffect`: ../../../lua/type/tes3activeMagicEffect.html
+.. _`tes3cellExteriorData`: ../../../lua/type/tes3cellExteriorData.html
+.. _`tes3weatherOvercast`: ../../../lua/type/tes3weatherOvercast.html
+.. _`tes3leveledItem`: ../../../lua/type/tes3leveledItem.html
+.. _`tes3alchemy`: ../../../lua/type/tes3alchemy.html
+.. _`tes3enchantment`: ../../../lua/type/tes3enchantment.html
+.. _`tes3cell`: ../../../lua/type/tes3cell.html
+.. _`tes3actionData`: ../../../lua/type/tes3actionData.html
+.. _`tes3itemData`: ../../../lua/type/tes3itemData.html
+.. _`tes3factionReaction`: ../../../lua/type/tes3factionReaction.html

--- a/docs/source/lua/api/mwscript/removeFromLevItem.rst
+++ b/docs/source/lua/api/mwscript/removeFromLevItem.rst
@@ -1,0 +1,135 @@
+mwscript.removeFromLevItem
+====================================================================================================
+
+Wrapper for the RemoveFromLevItem mwscript function.
+
+Returns
+----------------------------------------------------------------------------------------------------
+
+`boolean`_.
+
+Parameters
+----------------------------------------------------------------------------------------------------
+
+Accepts parameters through a table with the given keys:
+
+list (`tes3leveledItem`_, `string`_)
+    Leveled item list to remove an item from.
+
+item (`tes3item`_, `string`_)
+    Item to remove from the list.
+
+level (`number`_)
+    Default: ``0``. Minimum level for the item to spawn.
+
+.. _`tes3creature`: ../../../lua/type/tes3creature.html
+.. _`niObject`: ../../../lua/type/niObject.html
+.. _`tes3npc`: ../../../lua/type/tes3npc.html
+.. _`tes3book`: ../../../lua/type/tes3book.html
+.. _`tes3matrix33`: ../../../lua/type/tes3matrix33.html
+.. _`tes3actor`: ../../../lua/type/tes3actor.html
+.. _`tes3inputConfig`: ../../../lua/type/tes3inputConfig.html
+.. _`tes3itemStack`: ../../../lua/type/tes3itemStack.html
+.. _`tes3globalVariable`: ../../../lua/type/tes3globalVariable.html
+.. _`tes3containerInstance`: ../../../lua/type/tes3containerInstance.html
+.. _`tes3magicSourceInstance`: ../../../lua/type/tes3magicSourceInstance.html
+.. _`niAVObject`: ../../../lua/type/niAVObject.html
+.. _`tes3iterator`: ../../../lua/type/tes3iterator.html
+.. _`tes3raceHeightWeight`: ../../../lua/type/tes3raceHeightWeight.html
+.. _`tes3class`: ../../../lua/type/tes3class.html
+.. _`tes3mobileProjectile`: ../../../lua/type/tes3mobileProjectile.html
+.. _`tes3apparatus`: ../../../lua/type/tes3apparatus.html
+.. _`tes3door`: ../../../lua/type/tes3door.html
+.. _`tes3directInputMouseState`: ../../../lua/type/tes3directInputMouseState.html
+.. _`niRTTI`: ../../../lua/type/niRTTI.html
+.. _`tes3weatherThunder`: ../../../lua/type/tes3weatherThunder.html
+.. _`niObjectNET`: ../../../lua/type/niObjectNET.html
+.. _`tes3weatherSnow`: ../../../lua/type/tes3weatherSnow.html
+.. _`tes3weatherRain`: ../../../lua/type/tes3weatherRain.html
+.. _`tes3light`: ../../../lua/type/tes3light.html
+.. _`tes3clothing`: ../../../lua/type/tes3clothing.html
+.. _`tes3armor`: ../../../lua/type/tes3armor.html
+.. _`tes3weatherController`: ../../../lua/type/tes3weatherController.html
+.. _`tes3npcInstance`: ../../../lua/type/tes3npcInstance.html
+.. _`tes3mobilePlayer`: ../../../lua/type/tes3mobilePlayer.html
+.. _`nil`: ../../../lua/type/nil.html
+.. _`tes3dataHandler`: ../../../lua/type/tes3dataHandler.html
+.. _`tes3rangeInt`: ../../../lua/type/tes3rangeInt.html
+.. _`tes3dialogueInfo`: ../../../lua/type/tes3dialogueInfo.html
+.. _`tes3weatherBlizzard`: ../../../lua/type/tes3weatherBlizzard.html
+.. _`tes3weatherAsh`: ../../../lua/type/tes3weatherAsh.html
+.. _`tes3container`: ../../../lua/type/tes3container.html
+.. _`tes3weather`: ../../../lua/type/tes3weather.html
+.. _`tes3dialogue`: ../../../lua/type/tes3dialogue.html
+.. _`tes3gameFile`: ../../../lua/type/tes3gameFile.html
+.. _`tes3faction`: ../../../lua/type/tes3faction.html
+.. _`tes3wearablePart`: ../../../lua/type/tes3wearablePart.html
+.. _`tes3inputController`: ../../../lua/type/tes3inputController.html
+.. _`tes3lockpick`: ../../../lua/type/tes3lockpick.html
+.. _`tes3combatSession`: ../../../lua/type/tes3combatSession.html
+.. _`boolean`: ../../../lua/type/boolean.html
+.. _`tes3vector4`: ../../../lua/type/tes3vector4.html
+.. _`tes3magicEffect`: ../../../lua/type/tes3magicEffect.html
+.. _`string`: ../../../lua/type/string.html
+.. _`tes3referenceList`: ../../../lua/type/tes3referenceList.html
+.. _`tes3iteratorNode`: ../../../lua/type/tes3iteratorNode.html
+.. _`tes3fader`: ../../../lua/type/tes3fader.html
+.. _`tes3quest`: ../../../lua/type/tes3quest.html
+.. _`tes3nonDynamicData`: ../../../lua/type/tes3nonDynamicData.html
+.. _`tes3ingredient`: ../../../lua/type/tes3ingredient.html
+.. _`tes3race`: ../../../lua/type/tes3race.html
+.. _`tes3gameSetting`: ../../../lua/type/tes3gameSetting.html
+.. _`tes3vector2`: ../../../lua/type/tes3vector2.html
+.. _`table`: ../../../lua/type/table.html
+.. _`tes3travelDestinationNode`: ../../../lua/type/tes3travelDestinationNode.html
+.. _`tes3transform`: ../../../lua/type/tes3transform.html
+.. _`tes3mobileNPC`: ../../../lua/type/tes3mobileNPC.html
+.. _`tes3soulGemData`: ../../../lua/type/tes3soulGemData.html
+.. _`tes3vector3`: ../../../lua/type/tes3vector3.html
+.. _`tes3reference`: ../../../lua/type/tes3reference.html
+.. _`tes3raceSkillBonus`: ../../../lua/type/tes3raceSkillBonus.html
+.. _`tes3activator`: ../../../lua/type/tes3activator.html
+.. _`tes3raceBodyParts`: ../../../lua/type/tes3raceBodyParts.html
+.. _`tes3inventory`: ../../../lua/type/tes3inventory.html
+.. _`tes3boundingBox`: ../../../lua/type/tes3boundingBox.html
+.. _`tes3markData`: ../../../lua/type/tes3markData.html
+.. _`tes3raceBaseAttribute`: ../../../lua/type/tes3raceBaseAttribute.html
+.. _`tes3creatureInstance`: ../../../lua/type/tes3creatureInstance.html
+.. _`tes3effect`: ../../../lua/type/tes3effect.html
+.. _`tes3game`: ../../../lua/type/tes3game.html
+.. _`tes3probe`: ../../../lua/type/tes3probe.html
+.. _`tes3physicalObject`: ../../../lua/type/tes3physicalObject.html
+.. _`tes3object`: ../../../lua/type/tes3object.html
+.. _`tes3weatherClear`: ../../../lua/type/tes3weatherClear.html
+.. _`number`: ../../../lua/type/number.html
+.. _`tes3moon`: ../../../lua/type/tes3moon.html
+.. _`tes3weatherCloudy`: ../../../lua/type/tes3weatherCloudy.html
+.. _`tes3mobileObject`: ../../../lua/type/tes3mobileObject.html
+.. _`tes3misc`: ../../../lua/type/tes3misc.html
+.. _`tes3leveledListNode`: ../../../lua/type/tes3leveledListNode.html
+.. _`tes3mobileCreature`: ../../../lua/type/tes3mobileCreature.html
+.. _`tes3mobileActor`: ../../../lua/type/tes3mobileActor.html
+.. _`function`: ../../../lua/type/function.html
+.. _`tes3magicEffectInstance`: ../../../lua/type/tes3magicEffectInstance.html
+.. _`tes3baseObject`: ../../../lua/type/tes3baseObject.html
+.. _`tes3bodyPart`: ../../../lua/type/tes3bodyPart.html
+.. _`tes3factionRank`: ../../../lua/type/tes3factionRank.html
+.. _`mwseTimer`: ../../../lua/type/mwseTimer.html
+.. _`tes3weatherBlight`: ../../../lua/type/tes3weatherBlight.html
+.. _`tes3packedColor`: ../../../lua/type/tes3packedColor.html
+.. _`bool`: ../../../lua/type/boolean.html
+.. _`tes3equipmentStack`: ../../../lua/type/tes3equipmentStack.html
+.. _`tes3weatherFoggy`: ../../../lua/type/tes3weatherFoggy.html
+.. _`mwseTimerController`: ../../../lua/type/mwseTimerController.html
+.. _`tes3leveledCreature`: ../../../lua/type/tes3leveledCreature.html
+.. _`tes3lockNode`: ../../../lua/type/tes3lockNode.html
+.. _`tes3activeMagicEffect`: ../../../lua/type/tes3activeMagicEffect.html
+.. _`tes3cellExteriorData`: ../../../lua/type/tes3cellExteriorData.html
+.. _`tes3weatherOvercast`: ../../../lua/type/tes3weatherOvercast.html
+.. _`tes3leveledItem`: ../../../lua/type/tes3leveledItem.html
+.. _`tes3alchemy`: ../../../lua/type/tes3alchemy.html
+.. _`tes3enchantment`: ../../../lua/type/tes3enchantment.html
+.. _`tes3cell`: ../../../lua/type/tes3cell.html
+.. _`tes3actionData`: ../../../lua/type/tes3actionData.html
+.. _`tes3itemData`: ../../../lua/type/tes3itemData.html
+.. _`tes3factionReaction`: ../../../lua/type/tes3factionReaction.html


### PR DESCRIPTION
I guess `mwscript` in Lua is deprecated, but as far as I can tell there is no way to access leveled lists through `tes3`.

 - added `RemoveFromLevCreature` and `RemoveFromLevItem` to MWSE, and `mwscript`
 - corrected typos in `AddToLev*` Lua docs
