### PR TITLE
Added event for the player being underwater.

### DIFF
--- a/MWSE/LuaDisableableEventManager.cpp
+++ b/MWSE/LuaDisableableEventManager.cpp
@@ -52,6 +52,7 @@
 #include "LuaInfoGetTextEvent.h"
 #include "LuaInfoResponseEvent.h"
 #include "LuaIsGuardEvent.h"
+#include "LuaIsMobilePlayerUnderwaterEvent.h"
 #include "LuaItemDroppedEvent.h"
 #include "LuaItemTileUpdatedEvent.h"
 #include "LuaJournalEvent.h"
@@ -171,6 +172,7 @@ namespace mwse {
 				usertypeDefinition.set("infoGetText", sol::property(&InfoGetTextEvent::getEventEnabled, &InfoGetTextEvent::setEventEnabled));
 				usertypeDefinition.set("infoResponse", sol::property(&InfoResponseEvent::getEventEnabled, &InfoResponseEvent::setEventEnabled));
 				usertypeDefinition.set("isGuard", sol::property(&IsGuardEvent::getEventEnabled, &IsGuardEvent::setEventEnabled));
+				usertypeDefinition.set("isMobilePlayerUnderwater", sol::property(&IsMobilePlayerUnderwaterEvent::getEventEnabled, &IsMobilePlayerUnderwaterEvent::setEventEnabled));
 				usertypeDefinition.set("itemDropped", sol::property(&ItemDroppedEvent::getEventEnabled, &ItemDroppedEvent::setEventEnabled));
 				usertypeDefinition.set("itemTileUpdated", sol::property(&ItemTileUpdatedEvent::getEventEnabled, &ItemTileUpdatedEvent::setEventEnabled));
 				usertypeDefinition.set("journal", sol::property(&JournalEvent::getEventEnabled, &JournalEvent::setEventEnabled));

--- a/MWSE/LuaIsMobilePlayerUnderwaterEvent.cpp
+++ b/MWSE/LuaIsMobilePlayerUnderwaterEvent.cpp
@@ -1,0 +1,32 @@
+#include "LuaIsMobilePlayerUnderwaterEvent.h"
+
+#include "LuaManager.h"
+#include "LuaUtil.h"
+
+#include "TES3MobilePlayer.h"
+
+namespace mwse {
+    namespace lua {
+        namespace event {
+            IsMobilePlayerUnderwaterEvent::IsMobilePlayerUnderwaterEvent(TES3::MobilePlayer* mobilePlayer, bool isUnderwater) :
+                GenericEvent("isMobilePlayerUnderwater"),
+                m_MobilePlayer(mobilePlayer),
+                m_IsUnderwater(isUnderwater)
+            {
+
+            }
+
+            sol::table IsMobilePlayerUnderwaterEvent::createEventTable() {
+                auto stateHandle = LuaManager::getInstance().getThreadSafeStateHandle();
+                sol::state& state = stateHandle.state;
+                sol::table eventData = state.create_table();
+
+                eventData["isUnderwater"] = m_IsUnderwater;
+
+                return eventData;
+            }
+
+            bool IsMobilePlayerUnderwaterEvent::m_EventEnabled = false;
+        }
+    }
+}

--- a/MWSE/LuaIsMobilePlayerUnderwaterEvent.h
+++ b/MWSE/LuaIsMobilePlayerUnderwaterEvent.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "TES3MobilePlayer.h"
+
+#include "LuaGenericEvent.h"
+#include "LuaDisableableEvent.h"
+
+namespace mwse {
+	namespace lua {
+		namespace event {
+			class IsMobilePlayerUnderwaterEvent : public GenericEvent, public DisableableEvent<IsMobilePlayerUnderwaterEvent> {
+			public:
+				IsMobilePlayerUnderwaterEvent(TES3::MobilePlayer* mobilePlayer, bool isUnderwater);
+				sol::table createEventTable();
+
+			protected:
+				TES3::MobilePlayer* m_MobilePlayer;
+				bool m_IsUnderwater;
+			};
+		}
+	}
+}

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -3657,6 +3657,11 @@ namespace mwse {
 			// Allow overriding of sun damage calculation.
 			auto weatherControllerCalcSunDamageScalar = &TES3::WeatherController::calcSunDamageScalar;
 			genCallEnforced(0x0464C1C, 0x440630, *reinterpret_cast<DWORD*>(&weatherControllerCalcSunDamageScalar));
+			
+			// Allow overriding of player underwater calculation.
+			auto mobilePlayerIsUnderwater = &TES3::MobilePlayer::isUnderwater;
+			genCallEnforced(0x568114, 0x5299F0, *reinterpret_cast<DWORD*>(&mobilePlayerIsUnderwater));
+
 
 			// Allow defining certain objects as sourceless.
 			auto isSourcelessObject = &TES3::BaseObject::isSourcelessObject;

--- a/MWSE/MWSE.vcxproj
+++ b/MWSE/MWSE.vcxproj
@@ -68,6 +68,7 @@
     <ClInclude Include="LuaInfoGetTextEvent.h" />
     <ClInclude Include="LuaInfoResponseEvent.h" />
     <ClInclude Include="LuaIsGuardEvent.h" />
+    <ClInclude Include="LuaIsMobilePlayerUnderwaterEvent.h" />
     <ClInclude Include="LuaItemDroppedEvent.h" />
     <ClInclude Include="LuaItemTileUpdatedEvent.h" />
     <ClInclude Include="LuaJournalEvent.h" />
@@ -468,6 +469,7 @@
     <ClCompile Include="LuaInfoGetTextEvent.cpp" />
     <ClCompile Include="LuaInfoResponseEvent.cpp" />
     <ClCompile Include="LuaIsGuardEvent.cpp" />
+    <ClCompile Include="LuaIsMobilePlayerUnderwaterEvent.cpp" />
     <ClCompile Include="LuaItemDroppedEvent.cpp" />
     <ClCompile Include="LuaItemTileUpdatedEvent.cpp" />
     <ClCompile Include="LuaJournalEvent.cpp" />

--- a/MWSE/MWSE.vcxproj.filters
+++ b/MWSE/MWSE.vcxproj.filters
@@ -1380,6 +1380,9 @@
     <ClInclude Include="TES3BirthsignLua.h">
       <Filter>Header Files\Lua\Bindings\TES3</Filter>
     </ClInclude>
+    <ClInclude Include="LuaIsMobilePlayerUnderwaterEvent.h">
+      <Filter>Header Files\Lua\Events</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -2980,6 +2983,9 @@
     </ClCompile>
     <ClCompile Include="TES3BirthsignLua.cpp">
       <Filter>Source Files\Lua\Bindings\TES3</Filter>
+    </ClCompile>
+    <ClCompile Include="LuaIsMobilePlayerUnderwaterEvent.cpp">
+      <Filter>Source Files\Lua\Events</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/MWSE/TES3MobilePlayer.h
+++ b/MWSE/TES3MobilePlayer.h
@@ -91,6 +91,7 @@ namespace TES3 {
 		void onDeath();
 		bool is3rdPerson();
 		int getGold();
+		bool isUnderwater();
 
 		int getBounty();
 		void setBounty(int value);


### PR DESCRIPTION
The event is triggering in lua correctly, but it appears to not be binding the event output correctly. In my demo, I set `e.isUnderwater = true` each event, but the result is that the game never registers me as being underwater for the breathing mechanics. I think it is because I have the wrong return type but I am not sure. The function in IDA returns a char of 0 or 1. I setup my event to expect and return a bool. Is that incorrect?