### PR TITLE
Feature/writefunctioncall converters

### DIFF
--- a/MWSE/MemoryUtilLua.cpp
+++ b/MWSE/MemoryUtilLua.cpp
@@ -441,9 +441,9 @@ namespace mwse {
 			convertFrom["int"] = [](int arg) { return *reinterpret_cast<DWORD*>(&arg); };
 			convertFrom["uint"] = [](unsigned int arg) { return arg; };
 			convertFrom["float"] = [](float arg) { return *reinterpret_cast<DWORD*>(&arg); };
-			convertFrom["tes3object"] = [](void * arg) { return (DWORD)arg; };
-			convertFrom["tes3mobileObject"] = [](void * arg) { return (DWORD)arg; };
-			convertFrom["tes3inventory"] = [](void * arg) { return (DWORD)arg; };
+			convertFrom["tes3object"] = [](TES3::BaseObject* arg) { return (DWORD)arg; };
+			convertFrom["tes3mobileObject"] = [](TES3::MobileObject* arg) { return (DWORD)arg; };
+			convertFrom["tes3inventory"] = [](TES3::Inventory* arg) { return (DWORD)arg; };
 			convertFrom["tes3equipmentStackIterator"] = [](TES3::Iterator<TES3::EquipmentStack>* arg) { return reinterpret_cast<DWORD>(arg); };
 			convertFrom["tes3equipmentStackIteratorNode"] = [](TES3::IteratorNode<TES3::EquipmentStack>* arg) { return reinterpret_cast<DWORD>(arg); };
 			memory["convertFrom"] = convertFrom;

--- a/MWSE/MemoryUtilLua.cpp
+++ b/MWSE/MemoryUtilLua.cpp
@@ -432,6 +432,8 @@ namespace mwse {
 			convertTo["tes3object"] = [](DWORD arg) { return makeLuaObject(reinterpret_cast<TES3::BaseObject*>(arg)); };
 			convertTo["tes3mobileObject"] = [](DWORD arg) { return makeLuaObject(reinterpret_cast<TES3::MobileObject*>(arg)); };
 			convertTo["tes3inventory"] = [](DWORD arg) { return reinterpret_cast<TES3::Inventory*>(arg); };
+			convertTo["tes3equipmentStackIterator"] = [](DWORD arg) { return reinterpret_cast<TES3::Iterator<TES3::EquipmentStack>*>(arg); };
+			convertTo["tes3equipmentStackIteratorNode"] = [](DWORD arg) { return reinterpret_cast<TES3::IteratorNode<TES3::EquipmentStack>*>(arg); };
 			memory["convertTo"] = convertTo;
 
 			auto convertFrom = memory.create();
@@ -442,6 +444,8 @@ namespace mwse {
 			convertFrom["tes3object"] = [](void * arg) { return (DWORD)arg; };
 			convertFrom["tes3mobileObject"] = [](void * arg) { return (DWORD)arg; };
 			convertFrom["tes3inventory"] = [](void * arg) { return (DWORD)arg; };
+			convertFrom["tes3equipmentStackIterator"] = [](TES3::Iterator<TES3::EquipmentStack>* arg) { return reinterpret_cast<DWORD>(arg); };
+			convertFrom["tes3equipmentStackIteratorNode"] = [](TES3::IteratorNode<TES3::EquipmentStack>* arg) { return reinterpret_cast<DWORD>(arg); };
 			memory["convertFrom"] = convertFrom;
 		}
 	}

--- a/MWSE/MemoryUtilLua.cpp
+++ b/MWSE/MemoryUtilLua.cpp
@@ -437,13 +437,13 @@ namespace mwse {
 			memory["convertTo"] = convertTo;
 
 			auto convertFrom = memory.create();
-			convertFrom["bool"] = [](bool arg) { return (DWORD)arg; };
+			convertFrom["bool"] = [](bool arg) { return static_cast<DWORD>(arg); };
 			convertFrom["int"] = [](int arg) { return *reinterpret_cast<DWORD*>(&arg); };
 			convertFrom["uint"] = [](unsigned int arg) { return arg; };
 			convertFrom["float"] = [](float arg) { return *reinterpret_cast<DWORD*>(&arg); };
-			convertFrom["tes3object"] = [](TES3::BaseObject* arg) { return (DWORD)arg; };
-			convertFrom["tes3mobileObject"] = [](TES3::MobileObject* arg) { return (DWORD)arg; };
-			convertFrom["tes3inventory"] = [](TES3::Inventory* arg) { return (DWORD)arg; };
+			convertFrom["tes3object"] = [](TES3::BaseObject* arg) { return reinterpret_cast<DWORD>(arg); };
+			convertFrom["tes3mobileObject"] = [](TES3::MobileObject* arg) { return reinterpret_cast<DWORD>(arg); };
+			convertFrom["tes3inventory"] = [](TES3::Inventory* arg) { return reinterpret_cast<DWORD>(arg); };
 			convertFrom["tes3equipmentStackIterator"] = [](TES3::Iterator<TES3::EquipmentStack>* arg) { return reinterpret_cast<DWORD>(arg); };
 			convertFrom["tes3equipmentStackIteratorNode"] = [](TES3::IteratorNode<TES3::EquipmentStack>* arg) { return reinterpret_cast<DWORD>(arg); };
 			memory["convertFrom"] = convertFrom;


### PR DESCRIPTION
 Adds writeFunctionCall converters for tes3equipmentStackIterator and tes3equipmentStackteratorNode. 
Changes the void pointers in the convertFrom functions for tes3object, tes3mobileObject, and tes3inventory to their respective types.
I also changed the C-style casts in the convert functions to appropriate C++ casts; I find them less ambiguous and more readable. If there's a stylistic desire to use the former, I'll change them back. :-)

