### PR TITLE
MagicEffect binding

### DIFF
--- a/MWSE/TES3MagicEffect.cpp
+++ b/MWSE/TES3MagicEffect.cpp
@@ -48,6 +48,11 @@ namespace TES3 {
 		mwse::tes3::setDataString( &description, value );
 	}
 
+	const char* MagicEffect::getDescription() const noexcept
+	{
+		return description;
+	}
+
 	const char* MagicEffect::getIcon() const {
 		return icon;
 	}

--- a/MWSE/TES3MagicEffect.h
+++ b/MWSE/TES3MagicEffect.h
@@ -263,6 +263,7 @@ namespace TES3 {
 		const char* getName() const;
 		int getNameGMST() const;
 		void setDescription( const char *value );
+		const char* getDescription() const noexcept;
 
 		const char* getIcon() const;
 		void setIcon(const char* path);

--- a/MWSE/TES3MagicEffectLua.cpp
+++ b/MWSE/TES3MagicEffectLua.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 				usertypeDefinition["boltVisualEffect"] = &TES3::MagicEffect::boltEffect;
 				usertypeDefinition["castSoundEffect"] = sol::property(&TES3::MagicEffect::getCastSoundEffect, &TES3::MagicEffect::setCastSoundEffect);
 				usertypeDefinition["castVisualEffect"] = &TES3::MagicEffect::castEffect;
-				usertypeDefinition["description"] = sol::property(&TES3::MagicEffect::description, &TES3::MagicEffect::setDescription);
+				usertypeDefinition["description"] = sol::property(&TES3::MagicEffect::getDescription, &TES3::MagicEffect::setDescription);
 				usertypeDefinition["flags"] = &TES3::MagicEffect::flags;
 				usertypeDefinition["hitSoundEffect"] = sol::property(&TES3::MagicEffect::getHitSoundEffect, &TES3::MagicEffect::setHitSoundEffect);
 				usertypeDefinition["hitVisualEffect"] = &TES3::MagicEffect::hitEffect;


### PR DESCRIPTION
- fix the 'description' property. Perhaps due to sol3 migration, it
  worked improperly with a getter on a field and a setter on a method.
  Now, getter and setter are methods.