### PR TITLE
Damage(d) event autocomplete

### DIFF
--- a/autocomplete/definitions/events/standard/damage.lua
+++ b/autocomplete/definitions/events/standard/damage.lua
@@ -15,5 +15,35 @@ return {
 			readonly = true,
 			description = "mobile’s associated reference.",
 		},
+		attacker = {
+            type = "tes3mobileActor",
+            readonly = true,
+            description = "The mobile actor dealing the damage. Can be nil.",
+        },
+		attackerReference = {
+            type = "tes3reference",
+            readonly = true,
+            description = "attacker mobile's associated reference. Can be nil.",
+        },
+		projectile = {
+            type = "tes3projectile", -- check this one
+            readonly = true,
+            description = "Projectile that dealt the damage. Can be nil.",
+        },
+        activeMagicEffect = {
+            type = "tes3magicEffect",
+            readonly = true,
+            description = "tes3magicEffect which caused damage. Can be nil.",
+        },
+        magicSourceInstance = {
+            type = "tes3magicSourceInstance",
+            readonly = true ,
+            description = "tes3magicSourceInstance of a spell that caused damage. Can be nil.",
+        },
+        source = {
+            type ="damageSourceType",   -- Maybe change this
+            readonly = true,
+            description = "The origin of damage. Values of this variable can be: \"script\", \"fall\", \"suffocation\", \"attack\", \"magic\" or \"shield\".",
+        },
 	},
 }

--- a/autocomplete/definitions/events/standard/damage.lua
+++ b/autocomplete/definitions/events/standard/damage.lua
@@ -16,34 +16,34 @@ return {
 			description = "mobile’s associated reference.",
 		},
 		attacker = {
-         	   type = "tes3mobileActor",
-         	   readonly = true,
-         	   description = "The mobile actor dealing the damage. Can be nil.",
-        	},
+			type = "tes3mobileActor",
+			readonly = true,
+			description = "The mobile actor dealing the damage. Can be nil.",
+		},
 		attackerReference = {
-        	    type = "tes3reference",
-        	    readonly = true,
-        	    description = "attacker mobile's associated reference. Can be nil.",
-        	},
+			type = "tes3reference",
+			readonly = true,
+			description = "attacker mobile's associated reference. Can be nil.",
+		},
 		projectile = {
-	            type = "tes3projectile", -- check this one
-	            readonly = true,
-	            description = "Projectile that dealt the damage. Can be nil.",
-	        },
-	        activeMagicEffect = {
-	            type = "tes3magicEffect",
-	            readonly = true,
-	            description = "tes3magicEffect which caused damage. Can be nil.",
-	        },
-	        magicSourceInstance = {
-	            type = "tes3magicSourceInstance",
-	            readonly = true ,
-	            description = "tes3magicSourceInstance of a spell that caused damage. Can be nil.",
-	        },
-	        source = {
-	            type ="damageSourceType",   -- Maybe change this
-	            readonly = true,
-	            description = "The origin of damage. Values of this variable can be: \"script\", \"fall\", \"suffocation\", \"attack\", \"magic\" or \"shield\".",
-	        },
+	        type = "tes3mobileProjectile",
+			readonly = true,
+			description = "Projectile that dealt the damage. Can be nil.",
+	    },
+		activeMagicEffect = {
+			type = "tes3magicEffect",
+			readonly = true,
+			description = "tes3magicEffect which caused damage. Can be nil.",
+		},
+		magicSourceInstance = {
+			type = "tes3magicSourceInstance",
+			readonly = true ,
+			description = "tes3magicSourceInstance of a spell that caused damage. Can be nil.",
+		},
+		source = {
+			type ="damageSourceType",
+			readonly = true,
+			description = "The origin of damage. Values of this variable can be: \"script\", \"fall\", \"suffocation\", \"attack\", \"magic\", \"shield\" or nil.",
+		},
 	},
 }

--- a/autocomplete/definitions/events/standard/damage.lua
+++ b/autocomplete/definitions/events/standard/damage.lua
@@ -26,10 +26,10 @@ return {
 			description = "attacker mobile's associated reference. Can be nil.",
 		},
 		projectile = {
-	        type = "tes3mobileProjectile",
+			type = "tes3mobileProjectile",
 			readonly = true,
 			description = "Projectile that dealt the damage. Can be nil.",
-	    },
+		},
 		activeMagicEffect = {
 			type = "tes3magicEffect",
 			readonly = true,

--- a/autocomplete/definitions/events/standard/damage.lua
+++ b/autocomplete/definitions/events/standard/damage.lua
@@ -16,34 +16,34 @@ return {
 			description = "mobile’s associated reference.",
 		},
 		attacker = {
-            type = "tes3mobileActor",
-            readonly = true,
-            description = "The mobile actor dealing the damage. Can be nil.",
-        },
+         	   type = "tes3mobileActor",
+         	   readonly = true,
+         	   description = "The mobile actor dealing the damage. Can be nil.",
+        	},
 		attackerReference = {
-            type = "tes3reference",
-            readonly = true,
-            description = "attacker mobile's associated reference. Can be nil.",
-        },
+        	    type = "tes3reference",
+        	    readonly = true,
+        	    description = "attacker mobile's associated reference. Can be nil.",
+        	},
 		projectile = {
-            type = "tes3projectile", -- check this one
-            readonly = true,
-            description = "Projectile that dealt the damage. Can be nil.",
-        },
-        activeMagicEffect = {
-            type = "tes3magicEffect",
-            readonly = true,
-            description = "tes3magicEffect which caused damage. Can be nil.",
-        },
-        magicSourceInstance = {
-            type = "tes3magicSourceInstance",
-            readonly = true ,
-            description = "tes3magicSourceInstance of a spell that caused damage. Can be nil.",
-        },
-        source = {
-            type ="damageSourceType",   -- Maybe change this
-            readonly = true,
-            description = "The origin of damage. Values of this variable can be: \"script\", \"fall\", \"suffocation\", \"attack\", \"magic\" or \"shield\".",
-        },
+	            type = "tes3projectile", -- check this one
+	            readonly = true,
+	            description = "Projectile that dealt the damage. Can be nil.",
+	        },
+	        activeMagicEffect = {
+	            type = "tes3magicEffect",
+	            readonly = true,
+	            description = "tes3magicEffect which caused damage. Can be nil.",
+	        },
+	        magicSourceInstance = {
+	            type = "tes3magicSourceInstance",
+	            readonly = true ,
+	            description = "tes3magicSourceInstance of a spell that caused damage. Can be nil.",
+	        },
+	        source = {
+	            type ="damageSourceType",   -- Maybe change this
+	            readonly = true,
+	            description = "The origin of damage. Values of this variable can be: \"script\", \"fall\", \"suffocation\", \"attack\", \"magic\" or \"shield\".",
+	        },
 	},
 }

--- a/autocomplete/definitions/events/standard/damaged.lua
+++ b/autocomplete/definitions/events/standard/damaged.lua
@@ -27,7 +27,7 @@ return {
 			description = "attacker mobile's associated reference. Can be nil.",
 		},
 		projectile = {
-	        type = "tes3mobileProjectile",
+			type = "tes3mobileProjectile",
 			readonly = true,
 			description = "Projectile that dealt the damage. Can be nil.",
 	    },

--- a/autocomplete/definitions/events/standard/damaged.lua
+++ b/autocomplete/definitions/events/standard/damaged.lua
@@ -16,5 +16,40 @@ return {
 			readonly = true,
 			description = "mobile’s associated reference.",
 		},
+		attacker = {
+            type = "tes3mobileActor",
+            readonly = true,
+            description = "The mobile actor dealing the damage. Can be nil.",
+        },
+		attackerReference = {
+            type = "tes3reference",
+            readonly = true,
+            description = "attacker mobile's associated reference. Can be nil.",
+        },
+		projectile = {
+            type = "tes3projectile", -- check this one
+            readonly = true,
+            description = "Projectile that dealt the damage. Can be nil.",
+        },
+        activeMagicEffect = {
+            type = "tes3magicEffect",
+            readonly = true,
+            description = "tes3magicEffect which caused damage. Can be nil.",
+        },
+        magicSourceInstance = {
+            type = "tes3magicSourceInstance",
+            readonly = true ,
+            description = "tes3magicSourceInstance of a spell that caused damage. Can be nil.",
+        },
+        source = {
+            type ="damageSourceType",   -- Maybe change this
+            readonly = true,
+            description = "The origin of damage. Values of this variable can be: \"script\", \"fall\", \"suffocation\", \"attack\", \"magic\" or \"shield\".",
+        },
+        checkForKnockdown = {   --Not sure what this one does
+            type ="bool",
+            readonly = true,
+            description = ""
+        },
 	},
 }

--- a/autocomplete/definitions/events/standard/damaged.lua
+++ b/autocomplete/definitions/events/standard/damaged.lua
@@ -17,39 +17,39 @@ return {
 			description = "mobile’s associated reference.",
 		},
 		attacker = {
-            type = "tes3mobileActor",
-            readonly = true,
-            description = "The mobile actor dealing the damage. Can be nil.",
-        },
+    		        type = "tes3mobileActor",
+    		        readonly = true,
+			description = "The mobile actor dealing the damage. Can be nil.",
+		},
 		attackerReference = {
-            type = "tes3reference",
-            readonly = true,
-            description = "attacker mobile's associated reference. Can be nil.",
-        },
+			type = "tes3reference",
+    		        readonly = true,
+			description = "attacker mobile's associated reference. Can be nil.",
+		},
 		projectile = {
-            type = "tes3projectile", -- check this one
-            readonly = true,
-            description = "Projectile that dealt the damage. Can be nil.",
-        },
-        activeMagicEffect = {
-            type = "tes3magicEffect",
-            readonly = true,
-            description = "tes3magicEffect which caused damage. Can be nil.",
-        },
-        magicSourceInstance = {
-            type = "tes3magicSourceInstance",
-            readonly = true ,
-            description = "tes3magicSourceInstance of a spell that caused damage. Can be nil.",
-        },
-        source = {
-            type ="damageSourceType",   -- Maybe change this
-            readonly = true,
-            description = "The origin of damage. Values of this variable can be: \"script\", \"fall\", \"suffocation\", \"attack\", \"magic\" or \"shield\".",
-        },
-        checkForKnockdown = {   --Not sure what this one does
-            type ="bool",
-            readonly = true,
-            description = ""
-        },
+			type = "tes3projectile", -- check this one
+			readonly = true,
+			description = "Projectile that dealt the damage. Can be nil.",
+        	},
+        	activeMagicEffect = {
+			type = "tes3magicEffect",
+			readonly = true,
+			description = "tes3magicEffect which caused damage. Can be nil.",
+		},
+      		magicSourceInstance = {
+            		type = "tes3magicSourceInstance",
+            		readonly = true ,
+            		description = "tes3magicSourceInstance of a spell that caused damage. Can be nil.",
+        	},
+        	source = {
+            		type ="damageSourceType",   -- Maybe change this
+            		readonly = true,
+            		description = "The origin of damage. Values of this variable can be: \"script\", \"fall\", \"suffocation\", \"attack\", \"magic\" or \"shield\".",
+        	},
+        	checkForKnockdown = {   --Not sure what this one does
+            		type ="bool",
+            		readonly = true,
+            	description = ""
+        	},
 	},
 }

--- a/autocomplete/definitions/events/standard/damaged.lua
+++ b/autocomplete/definitions/events/standard/damaged.lua
@@ -30,7 +30,7 @@ return {
 			type = "tes3mobileProjectile",
 			readonly = true,
 			description = "Projectile that dealt the damage. Can be nil.",
-	    },
+		},
 		activeMagicEffect = {
 			type = "tes3magicEffect",
 			readonly = true,

--- a/autocomplete/definitions/events/standard/damaged.lua
+++ b/autocomplete/definitions/events/standard/damaged.lua
@@ -49,7 +49,7 @@ return {
         	checkForKnockdown = {   --Not sure what this one does
             		type ="bool",
             		readonly = true,
-            	description = ""
+            		description = ""
         	},
 	},
 }

--- a/autocomplete/definitions/events/standard/damaged.lua
+++ b/autocomplete/definitions/events/standard/damaged.lua
@@ -17,39 +17,39 @@ return {
 			description = "mobile’s associated reference.",
 		},
 		attacker = {
-    		        type = "tes3mobileActor",
-    		        readonly = true,
+			type = "tes3mobileActor",
+			readonly = true,
 			description = "The mobile actor dealing the damage. Can be nil.",
 		},
 		attackerReference = {
 			type = "tes3reference",
-    		        readonly = true,
+			readonly = true,
 			description = "attacker mobile's associated reference. Can be nil.",
 		},
 		projectile = {
-			type = "tes3projectile", -- check this one
+	        type = "tes3mobileProjectile",
 			readonly = true,
 			description = "Projectile that dealt the damage. Can be nil.",
-        	},
-        	activeMagicEffect = {
+	    },
+		activeMagicEffect = {
 			type = "tes3magicEffect",
 			readonly = true,
 			description = "tes3magicEffect which caused damage. Can be nil.",
 		},
-      		magicSourceInstance = {
-            		type = "tes3magicSourceInstance",
-            		readonly = true ,
-            		description = "tes3magicSourceInstance of a spell that caused damage. Can be nil.",
-        	},
-        	source = {
-            		type ="damageSourceType",   -- Maybe change this
-            		readonly = true,
-            		description = "The origin of damage. Values of this variable can be: \"script\", \"fall\", \"suffocation\", \"attack\", \"magic\" or \"shield\".",
-        	},
-        	checkForKnockdown = {   --Not sure what this one does
-            		type ="bool",
-            		readonly = true,
-            		description = ""
-        	},
+		magicSourceInstance = {
+			type = "tes3magicSourceInstance",
+			readonly = true ,
+			description = "tes3magicSourceInstance of a spell that caused damage. Can be nil.",
+		},
+		source = {
+			type ="damageSourceType",
+			readonly = true,
+			description = "The origin of damage. Values of this variable can be: \"script\", \"fall\", \"suffocation\", \"attack\", \"magic\", \"shield\" or nil.",
+		},
+		checkForKnockdown = {
+			type ="boolean",
+			readonly = true,
+			description = "If true, the damage can cause a knockdown.",
+		},
 	},
 }

--- a/autocomplete/definitions/global/tes3/playSound.lua
+++ b/autocomplete/definitions/global/tes3/playSound.lua
@@ -11,6 +11,7 @@ return {
 			{ name = "mixChannel", type = "number", default = "tes3.audioMixType.effects", description = "The channel to base volume off of. Maps to tes3.audioMixType constants." },
 			{ name = "volume", type = "number", default = "1.0", description = "A value between 0.0 and 1.0 to scale the volume off of." },
 			{ name = "pitch", type = "number", default = "1.0", description = "The pitch-shift multiplier. For 22kHz audio (most typical) it can have the range [0.005, 4.5]; for 44kHz audio it can have the range [0.0025, 2.25]." },
+			{ name = "soundPath", type = "string", description = "The path to a custom soundfile (useful for playing sounds that are not registered in the Construction Set). Starts in Data Files\\Sound.", optional = true },
 		},
 	}},
 	returns = {{ name = "executed", type = "boolean" }},

--- a/autocomplete/definitions/global/timer/game.lua
+++ b/autocomplete/definitions/global/timer/game.lua
@@ -1,4 +1,4 @@
 return {
 	type = "value",
-	description = [[Constant to represent timers that run based on in-world time.]],
+	description = [[Constant to represent timers that run based on in-world time. Duration measured in game-scale hours.]],
 }

--- a/autocomplete/definitions/global/timer/simulate.lua
+++ b/autocomplete/definitions/global/timer/simulate.lua
@@ -1,4 +1,4 @@
 return {
 	type = "value",
-	description = [[Constant to represent timers that run when the game isn't paused.]],
+	description = [[Constant to represent timers that run when the game isn't paused. Duration is measured in seconds.]],
 }


### PR DESCRIPTION
Added autocomplete update for damage and damaged events. 

Thing to resolve:

1. source on both events - What should I put as type and is the description ok?
2. Is type = "tes3projectile" correct?
3. What about checkForKnockdown in damaged event?