### PR TITLE
Add docs and make log color setting global

### DIFF
--- a/MWSE/MWSEConfig.cpp
+++ b/MWSE/MWSEConfig.cpp
@@ -12,6 +12,7 @@ namespace mwse {
 	bool Configuration::RunInBackground = false;
 	bool Configuration::PatchNiFlipController = true;
 	bool Configuration::LetterboxMovies = false;
+	bool Configuration::EnableLogColors = false;
 
 	// Allow default values to be accessed later.
 	sol::table defaultConfig;
@@ -45,5 +46,6 @@ namespace mwse {
 		DECLARE_CONFIG(RunInBackground)
 		DECLARE_CONFIG(PatchNiFlipController)
 		DECLARE_CONFIG(LetterboxMovies)
+		DECLARE_CONFIG(EnableLogColors)
 	}
 }

--- a/MWSE/MWSEConfig.h
+++ b/MWSE/MWSEConfig.h
@@ -9,6 +9,7 @@ namespace mwse {
 		static bool RunInBackground;
 		static bool PatchNiFlipController;
 		static bool LetterboxMovies;
+		static bool EnableLogColors;
 
 		static sol::table getDefaults();
 

--- a/docs/source/guides/logging.md
+++ b/docs/source/guides/logging.md
@@ -1,0 +1,63 @@
+# Logging
+
+The MWSE Logger library allows you to register a logger for your mod. It provides the following features:
+
+- Mod-specific log levels
+- Change log level via MCM
+- Log messages can be color coded according to log level (via MWSE MCM)
+- Optional setting to print messages to a separate log file
+
+## Log Levels
+
+Log levels are ordered as follows: `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`. Only logs at or below the current log level will be printed to the log file. For example, if log level is set to `INFO`, then `INFO`, `WARN` and `ERROR` messages will be logged, but `TRACE` and `DEBUG` messages will not.
+
+## Log Colors
+
+In the MWSE MCM, there is an option to enable log colors. This will display logs in different colors according to their log level when tailing the log in the console. However, it is recommended that non-modders keep this turned off, as it makes the log file harder to read in a regular text editor.
+
+### Log Level Colors:
+
+- `TRACE`: Bright White
+- `DEBUG`: Green
+- `INFO`: White
+- `WARN`: Yellow
+- `ERROR`: Red
+
+
+## Registering and using your Logger
+
+```lua
+local logger = require("logging.logger")
+local log = logger.new{
+    name = "Test Mod",
+    logLevel = "TRACE",
+}
+log:trace("This is a trace message")
+log:debug("This is a debug message")
+log:info("This is an info message")
+log:warn("This is a warn message")
+log:error("This is an error message")
+
+log:setLogLevel("INFO")
+```
+
+## Creating an MCM to control Log Level
+
+In your MCM configl, create a dropdown with the following options:
+```lua
+settings:createDropdown{
+  label = "Logging Level",
+  description = "Set the log level.",
+  options = {
+    { label = "TRACE", value = "TRACE"},
+    { label = "DEBUG", value = "DEBUG"},
+    { label = "INFO", value = "INFO"},
+    { label = "ERROR", value = "ERROR"},
+    { label = "NONE", value = "NONE"},
+  },
+  variable = mwse.mcm.createTableVariable{ id = "logLevel", table = mcmConfig },
+  callback = function(self)
+    logger:setLogLevel(self.variable.value)
+  end
+}
+```

--- a/misc/package/Data Files/MWSE/core/MWSE MCM/i18n/eng.lua
+++ b/misc/package/Data Files/MWSE/core/MWSE MCM/i18n/eng.lua
@@ -14,4 +14,6 @@ return {
 	["keepAllNetImmerseObjectsAlive.description"] = "WARNING: Only used for debugging purposes. Enabling this without knowing what you're doing WILL lead to memory leaks.\n\nWhen enabled, NetImmerse objects will use the same lua object caching system that TES3 objects use, allowing them to be string-compared or used as table keys.",
 	["enableLegacyLuaMods.label"] = "Enable legacy lua mods?",
 	["enableLegacyLuaMods.description"] = "If enabled, early alpha lua mods will be supported\n\nLegacy lua mods can be found in:\nData Files\\MWSE\\lua folder.",
+	["enableLogColors.label"] = "Enable Log Colors",
+	["enableLogColors.description"] = "If enabled, log colors will be enabled in the console. However, this will make the mwse.log file more difficult to read in a text editor.",
 }

--- a/misc/package/Data Files/MWSE/core/MWSE MCM/main.lua
+++ b/misc/package/Data Files/MWSE/core/MWSE MCM/main.lua
@@ -77,6 +77,16 @@ local config = {
 						table = mwseConfig,
 					},
 				},
+				{
+					class = "OnOffButton",
+					label = i18n("enableLogColors.label"),
+					description = i18n("enableLogColors.description"),
+					variable = {
+						id = "EnableLogColors",
+						class = "TableVariable",
+						table = mwseConfig,
+					},
+				}
 			},
 			sidebarComponents = {
 				{

--- a/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
+++ b/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
@@ -3,7 +3,6 @@ local ansicolors = require("logging.colors")
 ---@field name string Name of mod, also counts as unique id of logger
 ---@field outputFile string Optional. If set, logs will be sent to a file of this name
 ---@field logLevel string Set the log level. Options are: TRACE, DEBUG, INFO, WARN and ERROR
----@field doColors boolean Default true. If true, log messages will be colored according to their level.
 
 ---@class MWSELogger
 ---@field name string Name of mod, also counts as unique id of logger
@@ -29,7 +28,6 @@ local Logger = {}
 local registeredLoggers = {}
 local defaults = {
     logLevel = "INFO",
-    doColors = true
 }
 
 local logLevels = {
@@ -140,7 +138,7 @@ function Logger:write(logLevel, color, message, ...)
         tostring(message):format(...)
     )
     --Add log colors if enabled
-    if self.doColors then
+    if mwse.getConfig("EnableLogColors") then
         output = addColor(output, color)
     end
     --Prints to custom file if defined


### PR DESCRIPTION
Added Logging Guide to the Docs

Made EnableLogColors a global setting, with a new setting in the MWSE MCM. This is set to false by default, so users will not get weird characters in their MWSE.log file.

Please confirm I didn't miss anything adding the new setting to MWSEConfig.cpp, or when adding the new doc page. 