### PR TITLE
Add tes3.isKeyEqual

### DIFF
--- a/autocomplete/definitions/global/tes3/isKeyEqual.lua
+++ b/autocomplete/definitions/global/tes3/isKeyEqual.lua
@@ -1,6 +1,6 @@
 return {
 	type = "function",
-	description = [[Compares two key objects and returns their equality. Returns true if the object are equal, false otherwise.]],
+	description = [[Compares two key objects and returns their equality. Returns true if the objects are equal, false otherwise.]],
 	arguments = {{
 		name = "params",
 		type = "table",
@@ -14,7 +14,7 @@ return {
 						name = "keyCode",
 						type = "number",
 						default = false,
-						description = "Value of the actual key scan code, such as the letter `p`. Maps to `tes3.scanCode.*`."
+						description = "Value of the actual key scan code, such as the letter `p`. Maps to [`tes3.scanCode.*`](https://mwse.github.io/MWSE/references/scan-codes/)."
 					},
 					{
 						name = "isShiftDown",
@@ -51,7 +51,7 @@ return {
                         name = "keyCode",
                         type = "number",
                         default = false,
-                        description = "Value of the expected key scan code, such as the letter `p`. Maps to `tes3.scanCode.*`."
+                        description = "Value of the expected key scan code, such as the letter `p`. Maps to [`tes3.scanCode.*`](https://mwse.github.io/MWSE/references/scan-codes/)."
                     },
                     {
                         name = "isShiftDown",

--- a/autocomplete/definitions/global/tes3/isKeyEqual.lua
+++ b/autocomplete/definitions/global/tes3/isKeyEqual.lua
@@ -1,0 +1,86 @@
+return {
+	type = "function",
+	description = [[Compares two key objects and returns their equality. Returns true if the object are equal, false otherwise.]],
+	arguments = {{
+		name = "params",
+		type = "table",
+		tableParams = {
+			{
+				name = "actual",
+				type = "table",
+                description = "The key object that is being compared.",
+				tableParams = {
+					{
+						name = "keyCode",
+						type = "number",
+						default = false,
+						description = "Value of the actual key scan code, such as the letter `p`. Maps to `tes3.scanCode.*`."
+					},
+					{
+						name = "isShiftDown",
+						type = "boolean",
+						default = false,
+						description = "Value of whether the shift key is pressed."
+					},
+					{
+						name = "isControlDown",
+						type = "boolean",
+						default = false,
+						description = "Value of whether the control key is pressed."
+					},
+					{
+						name = "isAltDown",
+						type = "boolean",
+						default = false,
+						description = "Value of whether the alt key is pressed."
+					},
+					{
+						name = "isSuperDown",
+						type = "boolean",
+						default = false,
+						description = "Value of whether the super (Windows key) key is pressed."
+					},
+				},
+			},
+			{
+                name = "expected",
+                type = "table",
+                description = "The key object that is being compared against.",
+                tableParams = {
+                    {
+                        name = "keyCode",
+                        type = "number",
+                        default = false,
+                        description = "Value of the expected key scan code, such as the letter `p`. Maps to `tes3.scanCode.*`."
+                    },
+                    {
+                        name = "isShiftDown",
+                        type = "boolean",
+                        default = false,
+                        description = "Value of whether the shift key is expected to be pressed."
+                    },
+                    {
+                        name = "isControlDown",
+                        type = "boolean",
+                        default = false,
+                        description = "Value of whether the control key is expected to be pressed."
+                    },
+                    {
+                        name = "isAltDown",
+                        type = "boolean",
+                        default = false,
+                        description = "Value of whether the alt key is expected to be pressed."
+                    },
+					{
+						name = "isSuperDown",
+						type = "boolean",
+						default = false,
+						description = "Value of whether the super (Windows key) key is pressed."
+					},
+                },
+			},
+		},
+	}},
+	returns = "equal",
+	valuetype = "boolean",
+}

--- a/docs/source/apis/tes3.md
+++ b/docs/source/apis/tes3.md
@@ -2260,6 +2260,36 @@ local isAffectedBy = tes3.isAffectedBy({ reference = ..., effect = ..., object =
 
 ***
 
+### `tes3.isKeyEqual`
+
+Compares two key objects and returns their equality. Returns true if the object are equal, false otherwise.
+
+```lua
+local equal = tes3.isKeyEqual({ actual = ..., expected = ... })
+```
+
+**Parameters**:
+
+* `params` (table)
+	* `actual` (table): The key object that is being compared.
+		* `keyCode` (number): Value of the actual key scan code, such as the letter `p`. Maps to `tes3.scanCode.*`.
+		* `isShiftDown` (boolean): Value of whether the shift key is pressed.
+		* `isControlDown` (boolean): Value of whether the control key is pressed.
+		* `isAltDown` (boolean): Value of whether the alt key is pressed.
+		* `isSuperDown` (boolean): Value of whether the super (Windows key) key is pressed.
+	* `expected` (table): The key object that is being compared against.
+		* `keyCode` (number): Value of the expected key scan code, such as the letter `p`. Maps to `tes3.scanCode.*`.
+		* `isShiftDown` (boolean): Value of whether the shift key is expected to be pressed.
+		* `isControlDown` (boolean): Value of whether the control key is expected to be pressed.
+		* `isAltDown` (boolean): Value of whether the alt key is expected to be pressed.
+		* `isSuperDown` (boolean): Value of whether the super (Windows key) key is pressed.
+
+**Returns**:
+
+* `equal` (boolean)
+
+***
+
 ### `tes3.isModActive`
 
 Determines if the player has a given ESP or ESM file active.

--- a/docs/source/apis/tes3.md
+++ b/docs/source/apis/tes3.md
@@ -2262,7 +2262,7 @@ local isAffectedBy = tes3.isAffectedBy({ reference = ..., effect = ..., object =
 
 ### `tes3.isKeyEqual`
 
-Compares two key objects and returns their equality. Returns true if the object are equal, false otherwise.
+Compares two key objects and returns their equality. Returns true if the objects are equal, false otherwise.
 
 ```lua
 local equal = tes3.isKeyEqual({ actual = ..., expected = ... })
@@ -2272,13 +2272,13 @@ local equal = tes3.isKeyEqual({ actual = ..., expected = ... })
 
 * `params` (table)
 	* `actual` (table): The key object that is being compared.
-		* `keyCode` (number): Value of the actual key scan code, such as the letter `p`. Maps to `tes3.scanCode.*`.
+		* `keyCode` (number): Value of the actual key scan code, such as the letter `p`. Maps to [`tes3.scanCode.*`](https://mwse.github.io/MWSE/references/scan-codes/).
 		* `isShiftDown` (boolean): Value of whether the shift key is pressed.
 		* `isControlDown` (boolean): Value of whether the control key is pressed.
 		* `isAltDown` (boolean): Value of whether the alt key is pressed.
 		* `isSuperDown` (boolean): Value of whether the super (Windows key) key is pressed.
 	* `expected` (table): The key object that is being compared against.
-		* `keyCode` (number): Value of the expected key scan code, such as the letter `p`. Maps to `tes3.scanCode.*`.
+		* `keyCode` (number): Value of the expected key scan code, such as the letter `p`. Maps to [`tes3.scanCode.*`](https://mwse.github.io/MWSE/references/scan-codes/).
 		* `isShiftDown` (boolean): Value of whether the shift key is expected to be pressed.
 		* `isControlDown` (boolean): Value of whether the control key is expected to be pressed.
 		* `isAltDown` (boolean): Value of whether the alt key is expected to be pressed.

--- a/misc/package/Data Files/MWSE/core/lib/tes3/init.lua
+++ b/misc/package/Data Files/MWSE/core/lib/tes3/init.lua
@@ -140,6 +140,18 @@ function tes3.getAttachment(reference, attachment)
 	return reference and reference.attachments and reference.attachments[attachment]
 end
 
+-- Function to compare two keybind objects for equality. Useful in key events.
+function tes3.isKeyEqual(params)
+    if (params.actual.keyCode ~= params.expected.keyCode
+        or (params.actual.isShiftDown or false) ~= (params.expected.isShiftDown or false)
+        or (params.actual.isControlDown or false) ~= (params.expected.isControlDown or false)
+        or (params.actual.isAltDown or false) ~= (params.expected.isAltDown or false)) then
+        return false
+    end
+
+    return true
+end
+
 -- Iterator to use TES3::Iterator in a for loop.
 -- Only returns values, rather than a key-value pair.
 function tes3.iterate(iterator)

--- a/misc/package/Data Files/MWSE/core/lib/tes3/init.lua
+++ b/misc/package/Data Files/MWSE/core/lib/tes3/init.lua
@@ -145,7 +145,8 @@ function tes3.isKeyEqual(params)
     if (params.actual.keyCode ~= params.expected.keyCode
         or (params.actual.isShiftDown or false) ~= (params.expected.isShiftDown or false)
         or (params.actual.isControlDown or false) ~= (params.expected.isControlDown or false)
-        or (params.actual.isAltDown or false) ~= (params.expected.isAltDown or false)) then
+        or (params.actual.isAltDown or false) ~= (params.expected.isAltDown or false)
+        or (params.actual.isSuperDown or false) ~= (params.expected.isSuperDown or false)) then
         return false
     end
 

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -1265,6 +1265,20 @@ function tes3.isAffectedBy(params) end
 --- @field effect number *Optional*. A numerical identifier of the magic effect to perform a check for. Maps to [`tes3.effect`](https://mwse.github.io/MWSE/references/magic-effects/) constant, including those claimed with `tes3.claimSpellEffectId()`, and then added with `tes3.addMagicEffect()`.
 --- @field object tes3alchemy|tes3enchantment|tes3spell|tes3magicEffect|string *Optional*. An object to perform a check for.
 
+--- Compares two key objects and returns their equality. Returns true if the object are equal, false otherwise.
+--- @param params tes3.isKeyEqual.params This table accepts the following values:
+--- 
+--- `actual`: table — The key object that is being compared.
+--- 
+--- `expected`: table — The key object that is being compared against.
+--- @return boolean equal No description yet available.
+function tes3.isKeyEqual(params) end
+
+---Table parameter definitions for `tes3.isKeyEqual`.
+--- @class tes3.isKeyEqual.params
+--- @field actual table The key object that is being compared.
+--- @field expected table The key object that is being compared against.
+
 --- Determines if the player has a given ESP or ESM file active.
 --- @param filename string The filename of the mod to find, including the extension.
 --- @return boolean result No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -1265,7 +1265,7 @@ function tes3.isAffectedBy(params) end
 --- @field effect number *Optional*. A numerical identifier of the magic effect to perform a check for. Maps to [`tes3.effect`](https://mwse.github.io/MWSE/references/magic-effects/) constant, including those claimed with `tes3.claimSpellEffectId()`, and then added with `tes3.addMagicEffect()`.
 --- @field object tes3alchemy|tes3enchantment|tes3spell|tes3magicEffect|string *Optional*. An object to perform a check for.
 
---- Compares two key objects and returns their equality. Returns true if the object are equal, false otherwise.
+--- Compares two key objects and returns their equality. Returns true if the objects are equal, false otherwise.
 --- @param params tes3.isKeyEqual.params This table accepts the following values:
 --- 
 --- `actual`: table — The key object that is being compared.


### PR DESCRIPTION
Adds a new function, `tes3.isKeyEqual` to compare to key objects. Includes updated document files for autocomplete and website docs.