### PR TITLE
Add NiQuaternion bindings.

### DIFF
--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -159,6 +159,7 @@
 #include "NIPickLua.h"
 #include "NIPixelDataLua.h"
 #include "NIPropertyLua.h"
+#include "NIQuaternionLua.h"
 #include "NISkinInstanceLua.h"
 #include "NISourceTextureLua.h"
 #include "NISwitchNodeLua.h"
@@ -515,6 +516,7 @@ namespace mwse::lua {
 		bindNIPick();
 		bindNIPixelData();
 		bindNIProperties();
+		bindNIQuaternion();
 		bindNISkinInstance();
 		bindNISourceTexture();
 		bindNISwitchNode();

--- a/MWSE/MWSE.vcxproj
+++ b/MWSE/MWSE.vcxproj
@@ -15,6 +15,8 @@
     <ClInclude Include="BitUtil.h" />
     <ClInclude Include="BSAnimationManager.h" />
     <ClInclude Include="LuaEquipmentReevaluatedEvent.h" />
+    <ClInclude Include="NIQuaternion.h" />
+    <ClInclude Include="NIQuaternionLua.h" />
     <ClInclude Include="NIScreenPolygon.h" />
     <ClInclude Include="TES3AnimationDataLua.h" />
     <ClInclude Include="TES3CutscenePlayer.h" />
@@ -642,6 +644,8 @@
     <ClCompile Include="NIParticlesLua.cpp" />
     <ClCompile Include="NIParticleSystemController.cpp" />
     <ClCompile Include="NIProperty.cpp" />
+    <ClCompile Include="NIQuaternion.cpp" />
+    <ClCompile Include="NIQuaternionLua.cpp" />
     <ClCompile Include="NIRenderedTexture.cpp" />
     <ClCompile Include="NIRenderer.cpp" />
     <ClCompile Include="NISkinInstance.cpp" />

--- a/MWSE/MWSE.vcxproj.filters
+++ b/MWSE/MWSE.vcxproj.filters
@@ -1569,6 +1569,12 @@
     <ClInclude Include="TES3UIMenuController.h">
       <Filter>Header Files\DataAdapters\TES3\UI</Filter>
     </ClInclude>
+    <ClInclude Include="NIQuaternionLua.h">
+      <Filter>Header Files\Lua\Bindings\NI</Filter>
+    </ClInclude>
+    <ClInclude Include="NIQuaternion.h">
+      <Filter>Header Files\DataAdapters\NI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -3438,6 +3444,12 @@
       <Filter>Source Files\Lua\Events</Filter>
     </ClCompile>
     <ClCompile Include="NIBillboardNode.cpp">
+      <Filter>Source Files\DataAdapters\NI</Filter>
+    </ClCompile>
+    <ClCompile Include="NIQuaternionLua.cpp">
+      <Filter>Source Files\Lua\Bindings\NI</Filter>
+    </ClCompile>
+    <ClCompile Include="NIQuaternion.cpp">
       <Filter>Source Files\DataAdapters\NI</Filter>
     </ClCompile>
   </ItemGroup>

--- a/MWSE/NIDefines.h
+++ b/MWSE/NIDefines.h
@@ -43,6 +43,7 @@ namespace NI {
 	struct PlanarCollider;
 	struct PointLight;
 	struct Property;
+	struct Quaternion;
 	struct RenderedTexture;
 	struct Renderer;
 	struct RotatingParticles;

--- a/MWSE/NIQuaternion.cpp
+++ b/MWSE/NIQuaternion.cpp
@@ -1,0 +1,91 @@
+#include "NIQuaternion.h"
+#include "TES3Vectors.h"
+
+namespace NI {
+
+	const auto NI_Quaternion_multiplyQuaternion = reinterpret_cast<Quaternion*(__thiscall*)(const Quaternion*, Quaternion*, const Quaternion*)>(0x6FB6A0);
+
+	const auto NI_Quaternion_FromRotation = reinterpret_cast<TES3::Matrix33*(__thiscall*)(Quaternion*, const TES3::Matrix33*)>(0x6FBFC0);
+
+	const auto NI_Quaternion_FromAngleAxis = reinterpret_cast<void(__thiscall*)(Quaternion*, float angle, const TES3::Vector3* axis)>(0x6FBDF0);
+	const auto NI_Quaternion_ToAngleAxis = reinterpret_cast<void(__thiscall*)(const Quaternion*, float* angle, const TES3::Vector3* axis)>(0x6FBE20);
+
+	const auto NI_Quaternion_UnitInverse = reinterpret_cast<Quaternion*(__cdecl*)(Quaternion*, const Quaternion*)>(0x6FB730);
+	const auto NI_Quaternion_Slerp = reinterpret_cast<Quaternion*(__cdecl*)(Quaternion*, float, const Quaternion*, const Quaternion*)>(0x6FB7F0);
+
+	Quaternion::Quaternion() :
+		w(0),
+		x(0),
+		y(0),
+		z(0)
+	{
+	}
+
+	Quaternion::Quaternion(float _w, float _x, float _y, float _z) :
+		w(_w),
+		x(_x),
+		y(_y),
+		z(_z)
+	{
+	}
+
+	Quaternion Quaternion::operator*(const Quaternion& q) const {
+		Quaternion result;
+		NI_Quaternion_multiplyQuaternion(this, &result, &q);
+		return result;
+	}
+
+	std::ostream& operator<<(std::ostream& str, const Quaternion& q) {
+		str << "{" << q.w << "," << q.x << "," << q.y << "," << q.z << "}";
+		return str;
+	}
+
+	std::string Quaternion::toString() const {
+		std::ostringstream ss;
+		ss << std::fixed << std::setprecision(2) << std::dec << *this;
+		return std::move(ss.str());
+	}
+
+	std::string Quaternion::toJson() const {
+		std::ostringstream ss;
+		ss << "{\"w\":" << w << ",\"x\":" << x << ",\"y\":" << y << ",\"z\":" << z << "}";
+		return std::move(ss.str());
+	}
+
+	Quaternion Quaternion::copy() const {
+		return Quaternion(w, x, y, z);
+	}
+
+	Quaternion Quaternion::invert() const {
+		Quaternion result;
+		NI_Quaternion_UnitInverse(&result, this);
+		return result;
+	}
+
+	Quaternion Quaternion::slerp(const Quaternion* q, float t) const {
+		Quaternion result;
+		NI_Quaternion_Slerp(&result, t, this, q);
+		return result;
+	}
+
+	void Quaternion::fromAngleAxis(float angle, const TES3::Vector3* axis) {
+		NI_Quaternion_FromAngleAxis(this, angle, axis);
+	}
+
+	std::tuple<float, TES3::Vector3> Quaternion::toAngleAxis() const {
+		float angle;
+		TES3::Vector3 axis;
+		NI_Quaternion_ToAngleAxis(this, &angle, &axis);
+		return std::make_tuple(angle, axis);
+	}
+
+	void Quaternion::fromRotation(const TES3::Matrix33* rotation) {
+		NI_Quaternion_FromRotation(this, rotation);
+	}
+
+	TES3::Matrix33 Quaternion::toRotation() const {
+		TES3::Matrix33 result;
+		result.fromQuaternion(this);
+		return result;
+	}
+}

--- a/MWSE/NIQuaternion.h
+++ b/MWSE/NIQuaternion.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "NIDefines.h"
+#include "TES3Defines.h"
+
+namespace NI {
+	struct Quaternion {
+		float w;
+		float x;
+		float y;
+		float z;
+
+		Quaternion();
+
+		Quaternion(float w, float x, float y, float z);
+
+		Quaternion operator*(const Quaternion& q) const;
+
+		friend std::ostream& operator<<(std::ostream& str, const Quaternion& q);
+		std::string toString() const;
+		std::string toJson() const;
+
+		Quaternion copy() const;
+		Quaternion invert() const;
+		Quaternion slerp(const Quaternion* q, float t) const;
+
+		void fromAngleAxis(float angle, const TES3::Vector3* axis);
+		std::tuple<float, TES3::Vector3> toAngleAxis() const;
+
+		void fromRotation(const TES3::Matrix33* rotation);
+		TES3::Matrix33 toRotation() const;
+	};
+	static_assert(sizeof(Quaternion) == 0x10, "NI::Quaternion failed size validation");
+}

--- a/MWSE/NIQuaternionLua.cpp
+++ b/MWSE/NIQuaternionLua.cpp
@@ -1,0 +1,41 @@
+#include "NIQuaternionLua.h"
+
+#include "LuaManager.h"
+#include "LuaUtil.h"
+
+#include "NIQuaternion.h"
+
+void mwse::lua::bindNIQuaternion() {
+	// Get our lua state.
+	auto stateHandle = LuaManager::getInstance().getThreadSafeStateHandle();
+	sol::state& state = stateHandle.state;
+
+	// NiQuaternion
+	{
+		// Start our usertype.
+		auto usertypeDefinition = state.new_usertype<NI::Quaternion>("niQuaternion");
+		usertypeDefinition["new"] = sol::constructors<NI::Quaternion(), NI::Quaternion(float, float, float, float)>();
+
+		// Operator overloading.
+		usertypeDefinition[sol::meta_function::to_string] = &NI::Quaternion::toString;
+		usertypeDefinition["__tojson"] = &NI::Quaternion::toJson;
+		usertypeDefinition[sol::meta_function::multiplication] = sol::overload(
+			sol::resolve<NI::Quaternion(const NI::Quaternion&) const>(&NI::Quaternion::operator*)
+		);
+
+		// Basic property binding.
+		usertypeDefinition["w"] = &NI::Quaternion::w;
+		usertypeDefinition["x"] = &NI::Quaternion::x;
+		usertypeDefinition["y"] = &NI::Quaternion::y;
+		usertypeDefinition["z"] = &NI::Quaternion::z;
+
+		// Basic function binding.
+		usertypeDefinition["fromRotation"] = &NI::Quaternion::fromRotation;
+		usertypeDefinition["toRotation"] = &NI::Quaternion::toRotation;
+		usertypeDefinition["fromAngleAxis"] = &NI::Quaternion::fromAngleAxis;
+		usertypeDefinition["toAngleAxis"] = &NI::Quaternion::toAngleAxis;
+		usertypeDefinition["invert"] = &NI::Quaternion::invert;
+		usertypeDefinition["slerp"] = &NI::Quaternion::slerp;
+		usertypeDefinition["copy"] = &NI::Quaternion::copy;
+	}
+}

--- a/MWSE/NIQuaternionLua.h
+++ b/MWSE/NIQuaternionLua.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace mwse {
+	namespace lua {
+		void bindNIQuaternion();
+	}
+}

--- a/MWSE/TES3Vectors.cpp
+++ b/MWSE/TES3Vectors.cpp
@@ -1,6 +1,7 @@
 #include "TES3Vectors.h"
 
 #include "NIColor.h"
+#include "NIQuaternion.h"
 
 namespace TES3 {
 	constexpr double MATH_PI = 3.14159265358979323846;
@@ -373,6 +374,8 @@ namespace TES3 {
 
 	const auto TES3_Matrix33_reorthogonalize = reinterpret_cast<bool(__thiscall*)(Matrix33*)> (0x6E84A0);
 
+	const auto NI_Quaternion_FromRotation = reinterpret_cast<TES3::Matrix33 * (__thiscall*)(const NI::Quaternion*, TES3::Matrix33*)>(0x6FBEF0);
+
 	Matrix33::Matrix33() : m0(), m1(), m2() {
 
 	}
@@ -572,6 +575,16 @@ namespace TES3 {
 		float x, y, z = 0.0f;
 		bool isUnique = toEulerZYX(&x, &y, &z);
 		return std::make_tuple(Vector3(x, y, z), isUnique);
+	}
+
+	void Matrix33::fromQuaternion(const NI::Quaternion* q) {
+		NI_Quaternion_FromRotation(q, this);
+	}
+
+	NI::Quaternion Matrix33::toQuaternion() {
+		NI::Quaternion result;
+		result.fromRotation(this);
+		return result;
 	}
 
 	//

--- a/MWSE/TES3Vectors.h
+++ b/MWSE/TES3Vectors.h
@@ -172,6 +172,9 @@ namespace TES3 {
 		bool toEulerZYX(float* x, float* y, float* z) const;
 		std::tuple<Vector3, bool> toEulerZYX_lua() const;
 
+		void fromQuaternion(const NI::Quaternion* q);
+		NI::Quaternion toQuaternion();
+
 		bool reorthogonalize();
 
 	};

--- a/MWSE/TES3VectorsLua.cpp
+++ b/MWSE/TES3VectorsLua.cpp
@@ -5,6 +5,7 @@
 #include "TES3Vectors.h"
 
 #include "NIColor.h"
+#include "NIQuaternion.h"
 
 namespace mwse::lua {
 	void bindTES3Vectors() {
@@ -179,6 +180,7 @@ namespace mwse::lua {
 			// Basic function binding.
 			usertypeDefinition["copy"] = &TES3::Matrix33::copy;
 			usertypeDefinition["fromEulerXYZ"] = &TES3::Matrix33::fromEulerXYZ;
+			usertypeDefinition["fromQuaternion"] = &TES3::Matrix33::fromQuaternion;
 			usertypeDefinition["reorthogonalize"] = &TES3::Matrix33::reorthogonalize;
 			usertypeDefinition["toIdentity"] = &TES3::Matrix33::toIdentity;
 			usertypeDefinition["toRotation"] = &TES3::Matrix33::toRotation;
@@ -192,6 +194,7 @@ namespace mwse::lua {
 			usertypeDefinition["invert"] = &TES3::Matrix33::invert_lua;
 			usertypeDefinition["toEulerXYZ"] = &TES3::Matrix33::toEulerXYZ_lua;
 			usertypeDefinition["toEulerZYX"] = &TES3::Matrix33::toEulerZYX_lua;
+			usertypeDefinition["toQuaternion"] = &TES3::Matrix33::toQuaternion;
 		}
 
 		// Binding for TES3::Matrix44.

--- a/autocomplete/definitions/namedTypes/niQuaternion.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion.lua
@@ -1,0 +1,4 @@
+return {
+	type = "class",
+	description = [[A rotation in quaternion representation.]],
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/copy.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/copy.lua
@@ -1,0 +1,5 @@
+return {
+	type = "method",
+	description = [[Creates a copy of the quaternion.]],
+	valuetype = "niQuaternion",
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/fromAxisAngle.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/fromAxisAngle.lua
@@ -1,0 +1,8 @@
+return {
+	type = "method",
+	description = [[Fill the quaternion by converting an angle-axis rotation. The angle must be within the interval [0, PI] and the axis must be unit length.]],
+	arguments = {
+		{ name = "angle", type = "float" },
+		{ name = "axis", type = "tes3vector3" },
+	},
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/fromRotation.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/fromRotation.lua
@@ -1,0 +1,7 @@
+return {
+	type = "method",
+	description = [[Fill the quaternion by converting a rotation matrix.]],
+	arguments = {
+		{ name = "matrix", type = "tes3matrix33" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/slerp.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/slerp.lua
@@ -1,0 +1,11 @@
+return {
+	type = "method",
+	description = [[Calculates the spherical linear interpolate between this quaternion and another.]],
+	arguments = {
+		{ name = "target", type = "niQuaternion", description = "The quaternion to interpolate towards." },
+		{ name = "transition", type = "number", description = "The interpolation value. Must be between `0.0` (closer to this quaternion) and `1.0` (closer to the other quaternion)." },
+	},
+	returns = {
+		{ name = "result", type = "niQuaternion", description = "The calculated result." },
+	},
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/toAxisAngle.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/toAxisAngle.lua
@@ -1,0 +1,8 @@
+return {
+	type = "method",
+	description = [[Convert this quaternion into an angle-axis rotation.]],
+	returns = {
+		{ name = "angle", type = "float" },
+		{ name = "axis", type = "tes3vector3" }
+	},
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/toRotation.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/toRotation.lua
@@ -1,0 +1,5 @@
+return {
+	type = "method",
+	description = [[Convert this quaternion into a rotation matrix.]],
+	valuetype = "tes3matrix33",
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/w.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/w.lua
@@ -1,0 +1,5 @@
+return {
+	type = "value",
+	description = [[The W component of the quaternion.]],
+	valuetype = "number",
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/x.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/x.lua
@@ -1,0 +1,5 @@
+return {
+	type = "value",
+	description = [[The X component of the quaternion.]],
+	valuetype = "number",
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/y.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/y.lua
@@ -1,0 +1,5 @@
+return {
+	type = "value",
+	description = [[The Y component of the quaternion.]],
+	valuetype = "number",
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/z.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/z.lua
@@ -1,0 +1,5 @@
+return {
+	type = "value",
+	description = [[The Z component of the quaternion.]],
+	valuetype = "number",
+}

--- a/autocomplete/definitions/namedTypes/tes3matrix33/fromQuaternion.lua
+++ b/autocomplete/definitions/namedTypes/tes3matrix33/fromQuaternion.lua
@@ -1,0 +1,7 @@
+return {
+	type = "method",
+	description = [[Fill the matrix by converting a quaternion.]],
+	arguments = {
+		{ name = "quaternion", type = "niQuaternion" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3matrix33/toQuaternion.lua
+++ b/autocomplete/definitions/namedTypes/tes3matrix33/toQuaternion.lua
@@ -1,0 +1,7 @@
+return {
+	type = "method",
+	description = [[Convert the matrix into a quaternion.]],
+	returns = {
+		{ name = "result", type = "niQuaternion" },
+	},
+}

--- a/docs/source/types/niQuaternion.md
+++ b/docs/source/types/niQuaternion.md
@@ -1,0 +1,139 @@
+# niQuaternion
+
+A rotation in quaternion representation.
+
+## Properties
+
+### `w`
+
+The W component of the quaternion.
+
+**Returns**:
+
+* `result` (number)
+
+***
+
+### `x`
+
+The X component of the quaternion.
+
+**Returns**:
+
+* `result` (number)
+
+***
+
+### `y`
+
+The Y component of the quaternion.
+
+**Returns**:
+
+* `result` (number)
+
+***
+
+### `z`
+
+The Z component of the quaternion.
+
+**Returns**:
+
+* `result` (number)
+
+***
+
+## Methods
+
+### `copy`
+
+Creates a copy of the quaternion.
+
+```lua
+local result = niQuaternion:copy()
+```
+
+**Returns**:
+
+* `result` ([niQuaternion](../../types/niQuaternion))
+
+***
+
+### `fromAxisAngle`
+
+Fill the quaternion by converting an angle-axis rotation. The angle must be within the interval [0, PI] and the axis must be unit length.
+
+```lua
+niQuaternion:fromAxisAngle(angle, axis)
+```
+
+**Parameters**:
+
+* `angle` (float)
+* `axis` ([tes3vector3](../../types/tes3vector3))
+
+***
+
+### `fromRotation`
+
+Fill the quaternion by converting a rotation matrix.
+
+```lua
+niQuaternion:fromRotation(matrix)
+```
+
+**Parameters**:
+
+* `matrix` ([tes3matrix33](../../types/tes3matrix33))
+
+***
+
+### `slerp`
+
+Calculates the spherical linear interpolate between this quaternion and another.
+
+```lua
+local result = niQuaternion:slerp(target, transition)
+```
+
+**Parameters**:
+
+* `target` ([niQuaternion](../../types/niQuaternion)): The quaternion to interpolate towards.
+* `transition` (number): The interpolation value. Must be between `0.0` (closer to this quaternion) and `1.0` (closer to the other quaternion).
+
+**Returns**:
+
+* `result` ([niQuaternion](../../types/niQuaternion)): The calculated result.
+
+***
+
+### `toAxisAngle`
+
+Convert this quaternion into an angle-axis rotation.
+
+```lua
+local angle, axis = niQuaternion:toAxisAngle()
+```
+
+**Returns**:
+
+* `angle` (float)
+* `axis` ([tes3vector3](../../types/tes3vector3))
+
+***
+
+### `toRotation`
+
+Convert this quaternion into a rotation matrix.
+
+```lua
+local result = niQuaternion:toRotation()
+```
+
+**Returns**:
+
+* `result` ([tes3matrix33](../../types/tes3matrix33))
+
+***
+

--- a/docs/source/types/tes3matrix33.md
+++ b/docs/source/types/tes3matrix33.md
@@ -82,6 +82,20 @@ tes3matrix33:fromEulerZYX(z, y, x)
 
 ***
 
+### `fromQuaternion`
+
+Fill the matrix by converting a quaternion.
+
+```lua
+tes3matrix33:fromQuaternion(quaternion)
+```
+
+**Parameters**:
+
+* `quaternion` ([niQuaternion](../../types/niQuaternion))
+
+***
+
 ### `invert`
 
 Inverts the matrix.
@@ -148,6 +162,20 @@ Converts the matrix to the identity matrix's values.
 ```lua
 tes3matrix33:toIdentity()
 ```
+
+***
+
+### `toQuaternion`
+
+Convert the matrix into a quaternion.
+
+```lua
+local result = tes3matrix33:toQuaternion()
+```
+
+**Returns**:
+
+* `result` ([niQuaternion](../../types/niQuaternion))
 
 ***
 

--- a/misc/package/Data Files/MWSE/core/meta/class/niQuaternion.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niQuaternion.lua
@@ -1,0 +1,38 @@
+--- @meta
+
+--- A rotation in quaternion representation.
+--- @class niQuaternion
+--- @field w number The W component of the quaternion.
+--- @field x number The X component of the quaternion.
+--- @field y number The Y component of the quaternion.
+--- @field z number The Z component of the quaternion.
+niQuaternion = {}
+
+--- Creates a copy of the quaternion.
+--- @return niQuaternion result No description yet available.
+function niQuaternion:copy() end
+
+--- Fill the quaternion by converting an angle-axis rotation. The angle must be within the interval [0, PI] and the axis must be unit length.
+--- @param angle float No description yet available.
+--- @param axis tes3vector3 No description yet available.
+function niQuaternion:fromAxisAngle(angle, axis) end
+
+--- Fill the quaternion by converting a rotation matrix.
+--- @param matrix tes3matrix33 No description yet available.
+function niQuaternion:fromRotation(matrix) end
+
+--- Calculates the spherical linear interpolate between this quaternion and another.
+--- @param target niQuaternion The quaternion to interpolate towards.
+--- @param transition number The interpolation value. Must be between `0.0` (closer to this quaternion) and `1.0` (closer to the other quaternion).
+--- @return niQuaternion result The calculated result.
+function niQuaternion:slerp(target, transition) end
+
+--- Convert this quaternion into an angle-axis rotation.
+--- @return float angle No description yet available.
+--- @return tes3vector3 axis No description yet available.
+function niQuaternion:toAxisAngle() end
+
+--- Convert this quaternion into a rotation matrix.
+--- @return tes3matrix33 result No description yet available.
+function niQuaternion:toRotation() end
+

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3matrix33.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3matrix33.lua
@@ -23,6 +23,10 @@ function tes3matrix33:fromEulerXYZ(x, y, z) end
 --- @param x number No description yet available.
 function tes3matrix33:fromEulerZYX(z, y, x) end
 
+--- Fill the matrix by converting a quaternion.
+--- @param quaternion niQuaternion No description yet available.
+function tes3matrix33:fromQuaternion(quaternion) end
+
 --- Inverts the matrix.
 --- @return tes3matrix33 matrix No description yet available.
 --- @return boolean valid No description yet available.
@@ -44,6 +48,10 @@ function tes3matrix33:toEulerZYX() end
 
 --- Converts the matrix to the identity matrix's values.
 function tes3matrix33:toIdentity() end
+
+--- Convert the matrix into a quaternion.
+--- @return niQuaternion result No description yet available.
+function tes3matrix33:toQuaternion() end
 
 --- No description yet available.
 --- @param angle number No description yet available.


### PR DESCRIPTION
Adds bindings to `NiQuaternion` and exposes a few methods to lua. Also adds some convenience methods to `TES3::Matrix33` for converting to/from quaternions.