### PR TITLE
Fix example links

### DIFF
--- a/autocomplete/builders/emmy.lua
+++ b/autocomplete/builders/emmy.lua
@@ -39,7 +39,7 @@ local function getPackageLink(package)
 		local parentType = package.parent.type
 		if (parentType == "lib") then
 			local token = string.gsub("#" .. package.namespace, "%.", "")
-			tokens = { common.urlBase, "types", package.parent.namespace, token:lower() }
+			tokens = { common.urlBase, "apis", package.parent.namespace, token:lower() }
 		elseif (parentType == "class") then
 			tokens = { common.urlBase, "types", package.parent.key, "#" .. package.key }
 		end

--- a/misc/package/Data Files/MWSE/core/meta/lib/lpeg.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/lpeg.lua
@@ -159,7 +159,7 @@ function lpeg.locale(t) end
 --- either write a loop in Lua or write a pattern that matches anywhere. This second approach is easy 
 --- and quite efficient; see examples in the full documentation for details.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/lpeg/#lpegmatch).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/lpeg/#lpegmatch).
 --- @param p pattern The pattern to match.
 --- @param subject string The string to match against.
 --- @param init number *Optional*. Start the match at this position in subject.
@@ -197,7 +197,7 @@ function lpeg.P(value) end
 --- 
 --- As an example, the pattern lpeg.R("09") matches any digit, and lpeg.R("az", "AZ") matches any ASCII letter.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/lpeg/#lpegr).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/lpeg/#lpegr).
 --- @param p pattern The input pattern.
 --- @return pattern result No description yet available.
 function lpeg.R(p) end

--- a/misc/package/Data Files/MWSE/core/meta/lib/re.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/re.lua
@@ -27,7 +27,7 @@ function re.compile(s, defs) end
 --- An optional numeric argument init makes the search starts at that position in the subject string.
 --- As usual in Lua libraries, a negative value counts from the end. 
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/re/#refind).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/re/#refind).
 --- @param subject string The string to search.
 --- @param pattern string The pattern to search with.
 --- @param init number *Optional*. Start at this position in the subject string.
@@ -36,7 +36,7 @@ function re.find(subject, pattern, init) end
 
 --- Does a global substitution, replacing all occurrences of pattern in the given subject by replacement.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/re/#regsub).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/re/#regsub).
 --- @param subject string The string to search.
 --- @param pattern string The pattern to search with.
 --- @param replacement string Replace all matches with this string.
@@ -45,7 +45,7 @@ function re.gsub(subject, pattern, replacement) end
 
 --- Matches the given pattern against the given subject, returning all captures.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/re/#rematch).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/re/#rematch).
 --- @param subject string The string to search.
 --- @param pattern string The pattern to search with.
 --- @return string result No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/lib/table.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/table.lua
@@ -99,7 +99,7 @@ function table.size(t) end
 --- 
 --- Each "node" is an object with a children table of other "nodes", each of which might have their own children. For example, a sceneNode is made up of niNodes, and each niNodes can have a list of niNode children. This is best used for recursive data structures like UI elements and sceneNodes etc.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/table/#tabletraverse).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/table/#tabletraverse).
 --- @param t table A table to transverse.
 --- @param k unknown *Default*: `children`. The key of a table inside t object.
 --- @return iterator result No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -111,7 +111,7 @@ function tes3.addJournalEntry(params) end
 
 --- This function creates a new custom magic effect. The effect can be scripted through lua. This function should be used inside [`magicEffectsResolved`](https://mwse.github.io/MWSE/events/magicEffectsResolved/) event callback.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3/#tes3addmagiceffect).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3/#tes3addmagiceffect).
 --- @param params tes3.addMagicEffect.params This table accepts the following values:
 --- 
 --- `id`: number — Id of the new effect. Maps to newly claimed `tes3.effect` constants with `tes3.claimSpellEffectId()`. If the effect of this id already exists, an error will be thrown.
@@ -311,7 +311,7 @@ function tes3.addMagicEffect(params) end
 
 --- Causes a misc item to be recognized as a soul gem, so that it can be used for soul trapping.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3/#tes3addsoulgem).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3/#tes3addsoulgem).
 --- @param params tes3.addSoulGem.params This table accepts the following values:
 --- 
 --- `item`: tes3misc|string — The item to recognize as a soul gem.
@@ -496,7 +496,7 @@ function tes3.canRest(params) end
 --- 
 --- When the caster is the player, the target parameter is optional; without a target, the player's touch effects will only hit targets in front of them, and target effects will create a projectile in the direction the player is facing. Currently as a limitation, instant must be true to allow the player to cast spells.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3/#tes3cast).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3/#tes3cast).
 --- @param params tes3.cast.params This table accepts the following values:
 --- 
 --- `reference`: tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string — The caster reference.
@@ -553,7 +553,7 @@ function tes3.clearMarkLocation() end
 
 --- Create an object and returns it. The created object will be part of the saved game. Supported object types are those that have their own create function, such as tes3activator for example.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3/#tes3createobject).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3/#tes3createobject).
 --- @param params tes3.createObject.params This table accepts the following values:
 --- 
 --- `objectType`: number — Maps to [`tes3.objectType`](https://mwse.github.io/MWSE/references/object-types/) constants. Used to filter object type to create.
@@ -759,7 +759,7 @@ function tes3.findGlobal(id) end
 
 --- Fetches the core game object that represents a game setting. While this function accepts a name, it is recommended to use the [`tes3.GMST`](https://mwse.github.io/MWSE/references/gmst/) constants.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3/#tes3findgmst).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3/#tes3findgmst).
 --- @param id number|string No description yet available.
 --- @return tes3gameSetting gameSetting No description yet available.
 function tes3.findGMST(id) end
@@ -885,7 +885,7 @@ function tes3.getDialogueInfo(dialogue, id) end
 
 --- This function returns the total magnitude and total unresisted magnitude of a certain spell effect affecting a reference. It returns a pair of numbers, the first being the post-resistance magnitude (see examples). The unresisted magnitude is the magnitude before the actor's resistances are applied; it is always an integer, so it is used in some UI elements.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3/#tes3geteffectmagnitude).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3/#tes3geteffectmagnitude).
 --- @param params tes3.getEffectMagnitude.params This table accepts the following values:
 --- 
 --- `reference`: tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string — An associated mobile should exist for this function to be able to work.
@@ -907,7 +907,7 @@ function tes3.getEffectMagnitude(params) end
 
 --- Returns an actor's equipped item stack, provided a given filter
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3/#tes3getequippeditem).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3/#tes3getequippeditem).
 --- @param params tes3.getEquippedItem.params This table accepts the following values:
 --- 
 --- `actor`: tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3npc|tes3npcInstance — No description yet available.
@@ -1392,7 +1392,7 @@ function tes3.messageBox(messageOrParams, ...) end
 
 --- Modifies a statistic on a given actor. This should be used instead of manually setting values on the game structures, to ensure that events and GUI elements are properly handled. Either skill, attribute, or name must be provided.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3/#tes3modstatistic).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3/#tes3modstatistic).
 --- @param params tes3.modStatistic.params This table accepts the following values:
 --- 
 --- `reference`: tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3reference|string — No description yet available.
@@ -1586,7 +1586,7 @@ function tes3.random(seed) end
 
 --- Performs a ray test and returns various information related to the result(s). If `findAll` is set, the result will be a table of results, otherwise only the first result is returned.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3/#tes3raytest).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3/#tes3raytest).
 --- @param params tes3.rayTest.params This table accepts the following values:
 --- 
 --- `position`: tes3vector3|table — Position of the ray origin.
@@ -1648,7 +1648,7 @@ function tes3.releaseKey(keyCode) end
 
 --- Removes magic effects from a given reference. Requires that either the `effect` or `castType` parameter be provided.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3/#tes3removeeffects).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3/#tes3removeeffects).
 --- @param reference tes3reference Target reference to remove effects from.
 --- @param effect number *Optional*. Maps to [`tes3.effect`](https://mwse.github.io/MWSE/references/magic-effects/) constants.
 --- @param castType number *Optional*. Maps to [`tes3.spellType`](https://mwse.github.io/MWSE/references/spell-types/) constants.

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
@@ -14,7 +14,7 @@ function tes3ui.acquireTextInput(element) end
 --- 
 --- The capture is always removed when the element is destroyed. The capture may also be removed when the mouse is released, but this is not reliable, as the engine forgets what to do if there is input from any other controller while the mouse is held down.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3ui/#tes3uicapturemousedrag).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3ui/#tes3uicapturemousedrag).
 --- @param capture boolean Turns on mouse capture for the element currently processing a mouse event if true, sending all further mouse events to that element. Turns off capture if false.
 function tes3ui.captureMouseDrag(capture) end
 
@@ -59,7 +59,7 @@ function tes3ui.createMenu(params) end
 
 --- Creates a tooltip menu, which can be an empty menu or an item tooltip. This should be called from within a tooltip event callback. These automatically follow the mouse cursor, and are also destroyed automatically when the mouse leaves the originating element. Creating an item tooltip will invoke the uiObjectTooltip event.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3ui/#tes3uicreatetooltipmenu).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3ui/#tes3uicreatetooltipmenu).
 --- @param params tes3ui.createTooltipMenu.params This table accepts the following values:
 --- 
 --- `item`: tes3alchemy|tes3apparatus|tes3armor|tes3book|tes3clothing|tes3ingredient|tes3light|tes3lockpick|tes3misc|tes3probe|tes3repairTool|tes3weapon|string — *Optional*. The item to create a tooltip for. If not specified, the tooltip will be empty.
@@ -125,14 +125,14 @@ function tes3ui.leaveMenuMode() end
 
 --- Logs a message to the console. The message accepts formatting and additional parameters matching string.format's usage.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3ui/#tes3uilog).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3ui/#tes3uilog).
 --- @param message string No description yet available.
 --- @vararg any *Optional*. No description yet available.
 function tes3ui.log(message, ...) end
 
 --- Logs a message to the console.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/tes3ui/#tes3uilogtoconsole).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3ui/#tes3uilogtoconsole).
 --- @param text string No description yet available.
 --- @param isCommand boolean Passing `true` will make the text in the console selectable by using up arrow key. If it is a valid command, then pressing enter will call it.
 function tes3ui.logToConsole(text, isCommand) end

--- a/misc/package/Data Files/MWSE/core/meta/lib/timer.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/timer.lua
@@ -18,14 +18,14 @@ function timer.delayOneFrame(callback, type) end
 
 --- Registers a named timer with a callback to persist between game sessions. Bear in mind that nothing in MWSE is sandboxed, so all the registered timers are in the global namespace. Consider prefixing your timer with mod name or something else to avoid name collisions. For instance, `iceCreamMod:myTimer`.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/timer/#timerregister).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/timer/#timerregister).
 --- @param name string Name of the registered timer.
 --- @param fn function A callback function for the timer.
 function timer.register(name, fn) end
 
 --- Creates a timer.
 ---
---- [Examples available in online documentation](https://mwse.github.io/MWSE/types/timer/#timerstart).
+--- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/timer/#timerstart).
 --- @param params timer.start.params This table accepts the following values:
 --- 
 --- `type`: number — *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.


### PR DESCRIPTION
Due to an error in emmy.lua, the links in the popups in VS Code were pointing to the wrong place. 

![image](https://user-images.githubusercontent.com/41503714/160112962-c33e6d60-8d9d-491b-a665-4a664bf2947b.png)
