### PR TITLE
Proposed fix for warning in mwse_init.lua

### DIFF
--- a/autocomplete/builders/emmy.lua
+++ b/autocomplete/builders/emmy.lua
@@ -164,7 +164,9 @@ local function build(package)
 	local file = assert(io.open(outPath, "w"))
 
 	-- Mark the file as a meta file.
-	file:write("--- @meta\n\n")
+	file:write("--- @meta\n")
+	-- Removes warnings for missing definitions
+	file:write("--- @diagnostic disable:undefined-doc-name\n\n")
 
 	-- Write description.
 	if (package.type == "lib") then

--- a/misc/package/Data Files/MWSE/core/MWSE MCM/main.lua
+++ b/misc/package/Data Files/MWSE/core/MWSE MCM/main.lua
@@ -1,3 +1,6 @@
+-- Removes "Undefined global `mwseConfig`." warnings
+--- @diagnostic disable:undefined-global
+
 local function saveConfig()
 	local values = {}
 	for k, _ in pairs(mwseConfig.getDefaults()) do

--- a/misc/package/Data Files/MWSE/core/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/lib/event.lua
@@ -28,6 +28,7 @@ local function eventSorter(a, b)
 	return eventPriorities[a] > eventPriorities[b]
 end
 
+---@diagnostic disable-next-line:undefined-global
 local disableableEvents = mwseDisableableEventManager
 
 function this.register(eventType, callback, options)

--- a/misc/package/Data Files/MWSE/core/meta/class/ioFile.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/ioFile.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that represents an open file.
 --- @class ioFile

--- a/misc/package/Data Files/MWSE/core/meta/class/lfsLock.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/lfsLock.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that represents a file lock.
 --- @class lfsLock

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseLuaExecutor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseLuaExecutor.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A handle to a command excuted using `os.execute` configured to run asynchronously.
 --- @class mwseLuaExecutor

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseTimer.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseTimer.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A Timer is a class used to keep track of callback that should be invoked at a later time.
 --- @class mwseTimer

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseTimerController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseTimerController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A Timer Controller is a class used to sort and trigger callbacks based on an arbitrary timekeeping mechanic.
 --- @class mwseTimerController

--- a/misc/package/Data Files/MWSE/core/meta/class/niAVObject.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niAVObject.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The typical base type for most NetImmerse scene graph objects.
 --- @class niAVObject : niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niAlphaProperty.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niAlphaProperty.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A rendering property that manages alpha blending, enabling and disabling it, and setting blending functions. The property affects alpha testing, which can provide a performance boost.
 --- @class niAlphaProperty : niProperty, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niAmbientLight.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niAmbientLight.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that represents an ambient light. This object is fairly simple, and has no location, direction, or attenuation.
 --- @class niAmbientLight : niLight, niDynamicEffect, niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niBillboardNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niBillboardNode.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This node adjusts its render-time orientation so that the local z axis will face the camera. It supports multiple modes: camera parallel, or rotation around the local Y axis.
 --- @class niBillboardNode : niNode, niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niCamera.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niCamera.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Object that represent a camera. Position and orientation is determined by parent properties.
 --- @class niCamera : niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niCollisionSwitch.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niCollisionSwitch.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that specifies if the collision system is enabled.
 --- @class niCollisionSwitch : niNode, niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niColor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niColor.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that represents a RGB color.
 --- @class niColor

--- a/misc/package/Data Files/MWSE/core/meta/class/niColorA.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niColorA.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that represents a RGB color with alpha channel support.
 --- @class niColorA

--- a/misc/package/Data Files/MWSE/core/meta/class/niDirectionalLight.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niDirectionalLight.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that represents a light with light traveling in a given direction. The light may be pointed in any direction by rotating the light.
 --- @class niDirectionalLight : niLight, niDynamicEffect, niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niDynamicEffect.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niDynamicEffect.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Base class for dynamic effects such as NiLights or projected textures effects.
 --- @class niDynamicEffect : niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niDynamicEffectLinkedList.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niDynamicEffectLinkedList.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A linked list of dynamic effects.
 --- @class niDynamicEffectLinkedList

--- a/misc/package/Data Files/MWSE/core/meta/class/niFogProperty.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niFogProperty.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A rendering property that controls the appearance of fogging.
 --- @class niFogProperty : niProperty, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niFormatPrefs.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niFormatPrefs.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A class that represents a set of preferences for texture formats. These preferences dictate levels of pixel accuracy.
 --- @class niFormatPrefs

--- a/misc/package/Data Files/MWSE/core/meta/class/niGeometry.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niGeometry.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Base class for most geometric objects. Includes basic vertex and normal management.
 --- 	

--- a/misc/package/Data Files/MWSE/core/meta/class/niGeometryData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niGeometryData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- NiGeometryData objects contain the geometry data necessary to render an NiGeometry object. When an NiGeometry-based object is created, the actual geometry data is stored in an attached NiGeometryData object.
 --- @class niGeometryData : niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niLight.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niLight.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Base class that represents light sources in a scene graph. This includes the ambient, diffuse, and specular colors of a light, as well as its intensity.
 --- @class niLight : niDynamicEffect, niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niLookAtController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niLookAtController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Orients an axis of the controlled object towards a lookAt target. The axis is selectable.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/class/niMaterialProperty.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niMaterialProperty.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A rendering property that controls the surface properties of objects affected by the property. These surface properties include translucency, ambient reflective color, diffuse reflective color, emissive color intensity, and specular color.
 --- @class niMaterialProperty : niProperty, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niNode.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Base class that represents the nodes of a scene graph. A node can have any number of child nodes.
 --- @class niNode : niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niObject.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niObject.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The base-most object from which almost all NetImmerse structures are derived from.
 --- @class niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niObjectNET.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niObjectNET.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that has a name, extra data, and controllers.
 --- @class niObjectNET : niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niPackedColor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niPackedColor.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that represents a RGB color with alpha channel support. Unlike other color values, this is compressed into 4 bytes. Values are not from 0 to 1, but from 0 to 255.
 --- @class niPackedColor

--- a/misc/package/Data Files/MWSE/core/meta/class/niPick.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niPick.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Class used in the picking intersection system within the game engine.  Using a ray, the engine performs picking operations on a scene graph or any subtree. Given a ray and a subtree, the subtree is traversed and matching nodes are added to an array.
 --- @class niPick

--- a/misc/package/Data Files/MWSE/core/meta/class/niPickRecord.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niPickRecord.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A nested class of NiPick that stores the results of previous picking operations for use by the game engine.
 --- @class niPickRecord

--- a/misc/package/Data Files/MWSE/core/meta/class/niPixelData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niPixelData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Represents 2D arrays of pixel values, as well as pyramids of multiple mipmap levels, each of 2D arrays of pixel values. Also contains information representing the format of the pixels and dimensions of the arrays.
 --- @class niPixelData : niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niPointLight.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niPointLight.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Represents a point light source in a scene. Point lights have a specific location in space and a distance attenuation function. Point lights project light in all directions from their position. They can be moved by changing the translation of the light.
 --- @class niPointLight : niLight, niDynamicEffect, niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niProperty.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niProperty.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A base class representing all rendering properties.
 --- @class niProperty : niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niPropertyLinkedList.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niPropertyLinkedList.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A linked list of properties.
 --- @class niPropertyLinkedList

--- a/misc/package/Data Files/MWSE/core/meta/class/niQuaternion.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niQuaternion.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A rotation in quaternion representation.
 --- @class niQuaternion

--- a/misc/package/Data Files/MWSE/core/meta/class/niRTTI.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niRTTI.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Runtime type information for NetImmerse structures.
 --- @class niRTTI

--- a/misc/package/Data Files/MWSE/core/meta/class/niSourceTexture.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niSourceTexture.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Represents all texture objects that are created from a file or a block of in-memory pixel data. NiSourceTexture objects represent both static and dynamic content, as NiSourceTexture data objects can have their pixel data modified on the fly to implement dynamic texture behavior.
 --- @class niSourceTexture : niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niSpotLight.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niSpotLight.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Represents a spotlight in a scene. Spotlights have a specific location and direction, as well as a distance attenuation and angle attenuation functions. The light direction is handled in the same way as in `niDirectionalLight`.
 --- @class niSpotLight : niPointLight, niLight, niDynamicEffect, niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niStencilProperty.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niStencilProperty.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A rendering property that controls the use of a stencil buffer when rendering. It also includes a draw-mode setting to allows the game engine to control the culling mode of a set of geometry.
 --- @class niStencilProperty : niProperty, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niSwitchNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niSwitchNode.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Represents groups of multiple scene graph subtrees, only one of which is visible at any given time. They are useful for showing different states of a model depending on engine / lua logic. If you detach the active subtree, the switch node will set the active subtree to none, or to an index of -1.
 --- @class niSwitchNode : niNode, niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niTexturingProperty.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niTexturingProperty.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A rendering property that controls the methods used to filter texture pixels, and blend texture colors and vertex colors.
 --- @class niTexturingProperty : niProperty, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niTexturingPropertyMap.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niTexturingPropertyMap.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A combination of a texture, a filter mode, a clamping mode, and an index to a set of texture coordinates.
 --- @class niTexturingPropertyMap

--- a/misc/package/Data Files/MWSE/core/meta/class/niTimeController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niTimeController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Controls the timing and update functions for animation controllers.
 --- @class niTimeController : niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niTriBasedGeometry.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niTriBasedGeometry.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Base class for all geometry that uses triangles.
 --- @class niTriBasedGeometry : niGeometry, niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niTriBasedGeometryData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niTriBasedGeometryData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Contains the actual geometry data for a `NiTriBasedGeometry` object.
 --- @class niTriBasedGeometryData : niGeometryData, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niTriShape.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niTriShape.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that allows the sharing of vertices between triangles to create shapes.
 --- @class niTriShape : niTriBasedGeometry, niGeometry, niAVObject, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niTriShapeData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niTriShapeData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Contains the geometry data for an `NiTriShape` object.
 --- @class niTriShapeData : niTriBasedGeometryData, niGeometryData, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/niVertexColorProperty.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niVertexColorProperty.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A rendering property that allows the application to control the method used to compute colors for each vertex in a geometry object.  This class enables effects such as static pre-lighting, dynamic lighting, etc.
 --- @class niVertexColorProperty : niProperty, niObjectNET, niObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3actionData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3actionData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A substructure of mobile actors that provides information about the current or previous action.
 --- @class tes3actionData

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3activator.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3activator.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An activator game object.
 --- @class tes3activator : tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3activeMagicEffect.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3activeMagicEffect.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An active magic effect.
 --- @class tes3activeMagicEffect

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3actor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3actor.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An Actor (not to be confused with a Mobile Actor) is an object that can be cloned and that has an inventory. Creatures, NPCs, and containers are all considered actors.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3actorAnimationController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3actorAnimationController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Works in conjuction with mobile AI to perform idle, movement, and attack animations. Holds data on the status of the current and next desired animation states for the different body sections that can be animated.
 --- @class tes3actorAnimationController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3aiConfig.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3aiConfig.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A game object which contains AI configuration inforamtion for an actor. This includes: alarm, fight, flee, hello values, which services the actor provides, goods types the actor trades in, and possible destinations this actor can take the player to.
 --- @class tes3aiConfig

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackage.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackage.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An AI package game object.
 --- @class tes3aiPackage

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageActivate.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageActivate.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An AI Activate package game object. Sets an actor to activate a reference.
 --- @class tes3aiPackageActivate : tes3aiPackage

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageEscort.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageEscort.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An AI Escort package game object. Sets an actor to follow another actor to a destination.
 --- @class tes3aiPackageEscort : tes3aiPackage

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageFollow.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageFollow.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An AI Follow package game object. Sets an actor to follow another actor at a certain distance.
 --- @class tes3aiPackageFollow : tes3aiPackage

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageTravel.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageTravel.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An AI Travel package game object. Sets an actor to travel to a certain destination.
 --- @class tes3aiPackageTravel : tes3aiPackage

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageWander.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageWander.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An AI Wander package game object. Sets an actor to wander around a cell at certain points called idle nodes.
 --- @class tes3aiPackageWander : tes3aiPackage

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageWanderIdleNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3aiPackageWanderIdleNode.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An AI Wander package idle node game object. Contains information on the chance that the actor will wander at that idle node.
 --- @class tes3aiPackageWanderIdleNode

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3aiPlanner.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3aiPlanner.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A game object which contains information on actor's current and assigned AI packages.
 --- @class tes3aiPlanner

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3alchemy.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3alchemy.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An alchemy game object.
 --- @class tes3alchemy : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3apparatus.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3apparatus.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An apparatus game object.
 --- @class tes3apparatus : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3armor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3armor.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An armor game object.
 --- @class tes3armor : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3audioController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3audioController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A controller for audio. It holds data on the status of the current and next music tracks, volume settings and other related facilities. All the volumes are expressed in range [0, 1].
 --- @class tes3audioController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3baseObject.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3baseObject.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Almost anything that can be represented in the Construction Set is based on this structure.
 --- @class tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3birthsign.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3birthsign.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object representing a birthsign.
 --- @class tes3birthsign : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPart.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPart.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A body part game object.
 --- @class tes3bodyPart : tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPartManager.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPartManager.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A game object which holds information about body parts.
 --- @class tes3bodyPartManager

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPartManagerActiveBodyPart.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPartManagerActiveBodyPart.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A game object which holds information about an active body part, it's associated item and scene node.
 --- @class tes3bodyPartManagerActiveBodyPart

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPartManagerAttachNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPartManagerAttachNode.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A game object which holds information about equipment attachments to the actor's skeleton.
 --- @class tes3bodyPartManagerAttachNode

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3book.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3book.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A book game object.
 --- @class tes3book : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3boundingBox.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3boundingBox.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A pair of vectors marking a bounding box.
 --- @class tes3boundingBox

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3cell.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3cell.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An exterior or interior game area.
 --- @class tes3cell : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3cellExteriorData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3cellExteriorData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains a cell and its grid coordinates.
 --- @class tes3cellExteriorData

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3class.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3class.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core object representing a character class.
 --- @class tes3class : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3clothing.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3clothing.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A clothing game object.
 --- @class tes3clothing : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3combatSession.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3combatSession.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that keeps track of combat session data.
 --- @class tes3combatSession

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3container.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3container.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A container object that has not been cloned. Typically represents the raw information edited in the construction set.
 --- @class tes3container : tes3actor, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3containerInstance.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3containerInstance.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A container object that has been cloned. Typically represents a container that has been instanced by being opened by the player.
 --- @class tes3containerInstance : tes3actor, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3creature.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3creature.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A creature object that has not been cloned. Typically represents the raw information edited in the construction set.
 --- @class tes3creature : tes3actor, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3creatureInstance.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3creatureInstance.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A creature object that has been cloned. Typically represents a creature that has been instanced in the world.
 --- @class tes3creatureInstance : tes3actor, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3dataHandler.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3dataHandler.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core game object used for storing both active and non-dynamic gameplay data.
 --- @class tes3dataHandler

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3dialogue.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3dialogue.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A parent-level dialogue, such as a topic, voice, greeting, persuasion response, or journal.
 --- @class tes3dialogue : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3dialogueInfo.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3dialogueInfo.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A child for a given dialogue. Whereas a dialogue may be a conversation topic, a `tes3dialogueInfo` would be an individual response.
 --- @class tes3dialogueInfo : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3directInputMouseState.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3directInputMouseState.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A raw DirectInput mouse state.
 --- @class tes3directInputMouseState

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3door.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3door.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A door game object. Data specific to a single door is stored on the door reference as destination and lock attachments. See ``tes3reference`` for details.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3effect.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3effect.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that defines information for an effect and its associated variables, typically found on spells, alchemy, and enchantments.
 --- @class tes3effect

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3enchantment.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3enchantment.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An enchantment game object.
 --- @class tes3enchantment : tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3equipmentStack.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3equipmentStack.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A simple container that holds a relationship between an item, and any associated item data.
 --- @class tes3equipmentStack

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3faction.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3faction.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A faction game object.
 --- @class tes3faction : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3factionRank.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3factionRank.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A container describing an individual rank inside a faction. In Morrowind, the player needs to meet all the requirements to advance to a rank in a faction. These include two of the faction's favored attributes, any two of the faction's favored skills and reputation requirement.
 --- @class tes3factionRank

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3factionReaction.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3factionReaction.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A container mapping a reputation for an associated faction.
 --- @class tes3factionReaction

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3fader.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3fader.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object that applies a graphical effect on the screen, such as screen glare or damage coloring.
 --- @class tes3fader

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3game.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3game.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core game object used for storing game settings.
 --- @class tes3game

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3gameFile.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3gameFile.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Represents a loaded ESM, ESP, or ESS file.
 --- @class tes3gameFile

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3gameSetting.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3gameSetting.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A GMST game object.
 --- @class tes3gameSetting : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3globalScript.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3globalScript.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A global script object. Any script (in mwscript) that is not attached to any object is a global script.
 --- @class tes3globalScript

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3globalVariable.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3globalVariable.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A global variable game object.
 --- @class tes3globalVariable : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3ingredient.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3ingredient.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An ingredient game object.
 --- @class tes3ingredient : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3inputConfig.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3inputConfig.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that represents a configured key binding.
 --- @class tes3inputConfig

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3inputController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3inputController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A data structure, off of the world controller, that handles input.
 --- @class tes3inputController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3inventory.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3inventory.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An inventory composes of an iterator, and flags caching the state of the inventory.
 --- @class tes3inventory

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3inventoryTile.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3inventoryTile.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An inventory tile, connecting an item, its data, and various related UI elements.
 --- @class tes3inventoryTile

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3item.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3item.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An item object.
 --- @class tes3item : tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3itemData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3itemData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A set of variables that differentiates one item from another.
 --- @class tes3itemData

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3itemStack.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3itemStack.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A complex container that holds a relationship between an item, and zero or more associated item datas.
 --- @class tes3itemStack

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3iterator.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3iterator.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A collection that can be iterated over Contains items in a simple linked list, and stores its head/tail.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3iteratorNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3iteratorNode.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A node from a collection, which has a link to the previous and next node, as well as its contained data.
 --- @class tes3iteratorNode

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3leveledCreature.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3leveledCreature.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A leveled creature game object.
 --- @class tes3leveledCreature : tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3leveledItem.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3leveledItem.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A leveled creature game object.
 --- @class tes3leveledItem : tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3leveledListNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3leveledListNode.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A simple collection that maps an object in a leveled list to a level required for that object to spawn.
 --- @class tes3leveledListNode

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3light.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3light.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core light object. This isn't actually a light in the rendering engine, but something like a lamp or torch.
 --- @class tes3light : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3lightNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3lightNode.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An attachment-capable structure that maintains dynamic lights.
 --- @class tes3lightNode

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3lockNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3lockNode.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An attachment-capable structure that maintains lock and trap data.
 --- @class tes3lockNode

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3lockpick.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3lockpick.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core lockpick object.
 --- @class tes3lockpick : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3magicEffect.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3magicEffect.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core magic effect definition.
 --- @class tes3magicEffect

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3magicEffectInstance.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3magicEffectInstance.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Represents an individual instance of a magic effect being applied to a reference.
 --- @class tes3magicEffectInstance

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3magicSourceInstance.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3magicSourceInstance.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A game structure that keeps track of a magic source on an object.
 --- @class tes3magicSourceInstance : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3markData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3markData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A simple structure to hold mark/recall data.
 --- @class tes3markData

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3matrix33.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3matrix33.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A 3 by 3 matrix.
 --- @class tes3matrix33

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3matrix44.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3matrix44.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A 4 by 4 matrix.
 --- @class tes3matrix44

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3misc.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3misc.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core miscellaneous object.
 --- @class tes3misc : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3mobController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3mobController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The controller responsible for mobile objects and collision.
 --- @class tes3mobController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3mobileActor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3mobileActor.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A mobile object for a creature, NPC, or the player.
 --- @class tes3mobileActor : tes3mobileObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3mobileCreature.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3mobileCreature.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A mobile object for a creature.
 --- @class tes3mobileCreature : tes3mobileActor, tes3mobileObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3mobileNPC.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3mobileNPC.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A mobile object for an NPC.
 --- @class tes3mobileNPC : tes3mobileActor, tes3mobileObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3mobileObject.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3mobileObject.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The base object from which all other mobiles (AI/movement using) structures derive.
 --- @class tes3mobileObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3mobilePlayer.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3mobilePlayer.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A mobile object for a the player.
 --- @class tes3mobilePlayer : tes3mobileNPC, tes3mobileActor, tes3mobileObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3mobileProjectile.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3mobileProjectile.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A mobile object for a physical projectile.
 --- @class tes3mobileProjectile : tes3mobileObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3mobileSpellProjectile.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3mobileSpellProjectile.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A mobile object for a spell projectile.
 --- @class tes3mobileSpellProjectile : tes3mobileProjectile, tes3mobileObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3moon.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3moon.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that keeps track of information related two the game's two moons.
 --- @class tes3moon

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3nonDynamicData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3nonDynamicData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A child container from [`tes3dataHandler`](https://mwse.github.io/MWSE/types/tes3dataHandler/), where game data is stored.
 --- @class tes3nonDynamicData

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3npc.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3npc.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An NPC object that has not been cloned. Typically represents the raw information edited in the construction set.
 --- @class tes3npc : tes3actor, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3npcInstance.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3npcInstance.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An NPC object that has been cloned. Typically represents an NPC that has been instanced in the world.
 --- @class tes3npcInstance : tes3actor, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3object.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3object.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Almost anything that can be represented in the Construction Set is based on this structure.
 --- @class tes3object : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3packedColor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3packedColor.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A densely packed structure for single-byte red, green, blue and alpha values.
 --- @class tes3packedColor

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3physicalObject.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3physicalObject.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Almost anything that can be represented in the Construction Set is based on this structure.
 --- @class tes3physicalObject : tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3playerAnimationController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3playerAnimationController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Works in conjuction with mobile AI to perform idle, movement, and attack animations. Holds data on the status of the current and next desired animation states for the different body sections that can be animated.
 --- @class tes3playerAnimationController : tes3actorAnimationController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3probe.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3probe.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core lockpick object.
 --- @class tes3probe : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3processManager.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3processManager.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- 
 --- @class tes3processManager

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3projectileController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3projectileController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A game structure which holds all active projectiles.
 --- @class tes3projectileController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3quest.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3quest.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A representation of a quest, with associated dialogue and info.
 --- @class tes3quest : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3quickKey.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3quickKey.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A configuration detailing a quick key.
 --- @class tes3quickKey

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3race.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3race.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core object representing a character race.
 --- @class tes3race : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3raceBaseAttribute.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3raceBaseAttribute.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A substructure for a race, storing a base attribute value for male and female actors.
 --- @class tes3raceBaseAttribute

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3raceBodyParts.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3raceBodyParts.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A substructure for a race, storing the used body parts for a given sex.
 --- @class tes3raceBodyParts

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3raceHeightWeight.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3raceHeightWeight.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A substructure for a race, storing a height or weight for male and female actors.
 --- @class tes3raceHeightWeight

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3raceSkillBonus.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3raceSkillBonus.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A substructure for a race, storing up to 7 skill bonuses.
 --- @class tes3raceSkillBonus

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3rangeInt.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3rangeInt.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A simple pair of integers, typically used to define a range.
 --- @class tes3rangeInt

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3rechargingItem.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3rechargingItem.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Data for a recharging item. Not necessarily an item owned by the player.
 --- @class tes3rechargingItem

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3reference.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3reference.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A reference is a sort of container structure for objects. It holds a base object, as well as various variables associated with that object that make it unique.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3referenceList.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3referenceList.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A collection for references, holding a cell and a linked list of references contained in the cell.
 --- @class tes3referenceList

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3region.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3region.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains region information.
 --- @class tes3region : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3regionSound.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3regionSound.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains region sound information.
 --- @class tes3regionSound

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3repairTool.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3repairTool.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core repair tool object.
 --- @class tes3repairTool : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3script.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3script.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A script object.
 --- @class tes3script : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3scriptContext.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3scriptContext.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A script context object, which allows variables to be get/set using the variable name.
 --- @class tes3scriptContext

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3skill.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3skill.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A skill object.
 --- @class tes3skill : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3soulGemData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3soulGemData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that holds (sometimes redundant) information on a soul gem.
 --- @class tes3soulGemData

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3sound.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3sound.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A sound object created in the TES3 CS.
 --- @class tes3sound : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3soundGenerator.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3soundGenerator.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A sound generator object created in the TES3 CS
 --- @class tes3soundGenerator : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3spell.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3spell.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A spell game object.
 --- @class tes3spell : tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3spellList.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3spellList.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A list of spells. Used by actors, birthsigns, and races.
 --- @class tes3spellList

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3splashController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3splashController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core game controller responsible for controlling temporary graphics.
 --- @class tes3splashController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3splashControllerActiveSplash.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3splashControllerActiveSplash.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object representing an active splash, such as a blood particle.
 --- @class tes3splashControllerActiveSplash

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3startScript.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3startScript.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An object representing a script which autostarts at the game load.
 --- @class tes3startScript : tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3static.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3static.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A static game object. A non-animated object like a building or rock.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3statistic.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3statistic.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that holds statistical information relating to the current and base values of a statistic such as health, fatigue, magicka, or attributes.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3statisticSkill.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3statisticSkill.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that holds statistical information relating to the current and base values of a skill statistic.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3transform.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3transform.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A rotation matrix, translation vector, and scale that marks an object's transformation.
 --- @class tes3transform

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3travelDestinationNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3travelDestinationNode.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- An attachment-capable structure to manage a travel destination. This is either exposed as a destination attachment for a door or as part of a list of possible travel services in an actor's AI configuration.
 --- @class tes3travelDestinationNode

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiButton.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiButton.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure containing properties specific to buttons.
 --- @class tes3uiButton

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiElement.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiElement.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A UI element, the main building block of the UI system. All elements are created with methods on a parent Element.  Elements are very configurable, and have many HTML-like layout features. All layout properties can be set to `nil` to reset them to the default value, which will deactivate any related layout mode.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiEventData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiEventData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Contains information from a standard UI callback. This is the parameter passed to callbacks when using `:register`, `:registerBefore`, or `:registerAfter`.
 --- @class tes3uiEventData

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiFillBar.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiFillBar.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure containing properties specific to fillbars.
 --- @class tes3uiFillBar

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiFontColor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiFontColor.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Contains color information of a font.
 --- @class tes3uiFontColor

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiMenuController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiMenuController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The controller responsible for the menu system.
 --- @class tes3uiMenuController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiMenuInputController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiMenuInputController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core came structure responsible for managing the input around menu elements.
 --- @class tes3uiMenuInputController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiParagraphInput.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiParagraphInput.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure containing properties specific to paragraph inputs.
 --- @class tes3uiParagraphInput

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiProperty.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiProperty.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- 
 --- @class tes3uiProperty

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiScrollPane.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiScrollPane.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure containing properties specific to scroll panes.
 --- @class tes3uiScrollPane

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiSlider.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiSlider.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure containing properties specific to sliders.
 --- @class tes3uiSlider

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiTextInput.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiTextInput.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure containing properties specific to text inputs.
 --- @class tes3uiTextInput

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiTextSelect.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiTextSelect.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure containing properties specific to text selects.
 --- @class tes3uiTextSelect

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3vector2.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3vector2.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A simple pair of floating-point numbers.
 --- @class tes3vector2

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3vector3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3vector3.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A simple trio of floating-point numbers.
 --- @class tes3vector3

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3vector4.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3vector4.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A set of 4 floating-point numbers.
 --- @class tes3vector4

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weapon.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weapon.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A weapon game object.
 --- @class tes3weapon : tes3item, tes3physicalObject, tes3object, tes3baseObject

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3wearablePart.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3wearablePart.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A container class that maps a body part id to its male and female body parts.
 --- @class tes3wearablePart

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weather.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weather.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains base weather information shared by inheriting weather structures.
 --- @class tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherAsh.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherAsh.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains weather information for the ashstorm weather type.
 --- @class tes3weatherAsh : tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherBlight.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherBlight.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains weather information for the blightstorm weather type.
 --- @class tes3weatherBlight : tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherBlizzard.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherBlizzard.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains weather information for the blizzard weather type.
 --- @class tes3weatherBlizzard : tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherClear.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherClear.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains weather information for the clear skies weather type.
 --- @class tes3weatherClear : tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherCloudy.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherCloudy.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains weather information for the cloudy weather type.
 --- @class tes3weatherCloudy : tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A data structure that handles the weather.
 --- @class tes3weatherController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherFoggy.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherFoggy.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains weather information for the foggy weather type.
 --- @class tes3weatherFoggy : tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherOvercast.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherOvercast.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains weather information for the overcast weather type.
 --- @class tes3weatherOvercast : tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherRain.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherRain.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains weather information for the rain weather type.
 --- @class tes3weatherRain : tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherSnow.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherSnow.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains weather information for the snow weather type.
 --- @class tes3weatherSnow : tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherThunder.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherThunder.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A structure that contains weather information for the thunder weather type.
 --- @class tes3weatherThunder : tes3weather

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3worldController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3worldController.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core game object used for storing world simulation data.
 --- @class tes3worldController

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3worldControllerRenderCamera.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3worldControllerRenderCamera.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core game object used for storing camera objects.
 --- @class tes3worldControllerRenderCamera

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3worldControllerRenderCameraData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3worldControllerRenderCameraData.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- A core game object used for storing additional data for camera objects.
 --- @class tes3worldControllerRenderCameraData

--- a/misc/package/Data Files/MWSE/core/meta/event/absorbedMagic.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/absorbedMagic.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered after magic absorption absorbs and cancels a magic effect, and just before magic absorption gives magicka to the target. It can control the amount of magicka restored.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/activate.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/activate.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is invoked whenever something is activated, typically by the player. Activation is usually done with the associated activate/use key, but may also be forced by scripts.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/activationTargetChanged.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/activationTargetChanged.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is raised when the potential activation target for the player changes.
 --- @class activationTargetChangedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/addSound.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/addSound.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when a sound is played by the game or when `tes3.playSound()` is called.
 --- @class addSoundEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/addTempSound.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/addTempSound.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- 
 --- @class addTempSoundEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/attack.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/attack.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is invoked whenever an actor makes an attack with their fists or a weapon, or a creature makes any attack. It occurs at the release time of the attack, such as the downstroke of a melee weapon or when an arrow is shot. Lockpicks and probes do not invoke this event.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/attackStart.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/attackStart.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is invoked whenever an actor starts an attack with their fists or a weapon, or a creature makes any attack. More precisely, it is when the actor raises a melee weapon or draws an arrow. There is not necessarily a target in range, or any target at all for the player.
 --- @class attackStartEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/barterOffer.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/barterOffer.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when a potentially successful barter offer is made by the player. Potentially successful means both parties have the required funds to make the trade.
 --- @class barterOfferEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/bodyPartAssigned.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/bodyPartAssigned.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Allows reading and overwriting body part assignments.
 --- @class bodyPartAssignedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/bodyPartsUpdated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/bodyPartsUpdated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when an actor's body parts have finished updating. This typically triggers when an actor is first rendered, or when their equipment changes.
 --- @class bodyPartsUpdatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/bookGetText.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/bookGetText.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is raised when a book's text is about to be displayed. By providing your own text, you can overwrite what is going to be displayed.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/buttonPressed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/buttonPressed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The buttonPressed event is unique in that it is invoked only when using `tes3.messageBox` to present buttons to the player.
 --- @class buttonPressedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcArmorPieceHit.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcArmorPieceHit.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is raised just after determining which armor piece, if any, was hit with an attack. The slots can be modified, to draw focus onto specific armor slots.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/calcArmorRating.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcArmorRating.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is fired before an actor's armor rating has been calculated, and can be used to override the armor that the actor is given.
 --- @class calcArmorRatingEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcBarterPrice.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcBarterPrice.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is raised when an item price is being determined when bartering.
 --- @class calcBarterPriceEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcFlySpeed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcFlySpeed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- One of the movement events, **calcFlySpeed** is used when calculating movement speeds when levitating or otherwise flying.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/calcHitChance.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcHitChance.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is raised when determining the hit chance for an actor.
 --- @class calcHitChanceEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcMoveSpeed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcMoveSpeed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when an actor’s movement speed is calculated. The event allows modification of this value, to dehardcode actor movement speeds. Invoked after all other movement speed events are finished.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/calcRepairPrice.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcRepairPrice.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when determining the price of repairing an item. It can be used to override the repair cost.
 --- @class calcRepairPriceEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcRestInterrupt.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcRestInterrupt.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when the player is about to start resting. The hour and count of creatures can be modified, or disabled. Blocking this event blocks any interrupting spawn.
 --- @class calcRestInterruptEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcRunSpeed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcRunSpeed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- One of the movement events, **calcRunSpeed** is used when calculating when the player is running, but not swimming or flying.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/calcSoulValue.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcSoulValue.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is raised when determining the value of a soul, unmodified by GMSTs. The value can be modified, or used to provide a soul value to NPCs who would normally not be allowed one.
 --- @class calcSoulValueEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcSpellPrice.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcSpellPrice.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when determining the cost of purchasing a spell. The price can be modified.
 --- @class calcSpellPriceEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcSunDamageScalar.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcSunDamageScalar.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- calcSunDamageScalar is used when calculating the amount of damage to apply for the Sun Damage magic effect.
 --- @class calcSunDamageScalarEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcSwimRunSpeed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcSwimRunSpeed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- One of the movement events, **calcSwimRunSpeed** is used when calculating the movement speed while in water when running.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/calcSwimSpeed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcSwimSpeed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- One of the movement events, **calcSwimSpeed** is used when calculating the movement speed while in water when running.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/calcTrainingPrice.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcTrainingPrice.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when determining the cost of training, and can be used to modify the given price.
 --- @class calcTrainingPriceEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcTravelPrice.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcTravelPrice.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when determining the price of traveling, and can be used to modify the given price.
 --- @class calcTravelPriceEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/calcWalkSpeed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/calcWalkSpeed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- One of the movement events, **calcWalkSpeed** is used when calculating the base walk speed. Nearly every other movement speed event starts with this, with the exception of [calcFlySpeed](https://mwse.github.io/MWSE/events/calcFlySpeed).
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/cellActivated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/cellActivated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when a cell is activated.
 --- @class cellActivatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/cellChanged.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/cellChanged.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The cellChanged event is occurs when the player changes cells. This might occur from going through a door, using intervention or recall spells, or from scripted repositioning.
 --- @class cellChangedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/cellDeactivated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/cellDeactivated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when a cell is deactivated.
 --- @class cellDeactivatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/collideWater.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/collideWater.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when a mobile object collides with water and all the frames during the collision.
 --- @class collideWaterEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/collision.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/collision.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered on a collision and all the frames during the collision.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/combatStart.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/combatStart.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The combatStart event occurs when combat is about to begin between two actors. This event allows scripts to prevent combat from starting.
 --- @class combatStartEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/combatStarted.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/combatStarted.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The **combatStarted** event occurs after combat has began between two actors. This event is preceded by the [combatStart](https://mwse.github.io/MWSE/events/combatStart) event.
 --- @class combatStartedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/combatStop.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/combatStop.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The combatStop event occurs when an actor is about to leave combat. This event allows scripts to prevent combat from stopping.
 --- @class combatStopEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/combatStopped.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/combatStopped.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The **combatStopped** event occurs after an actor has left combat. This event is preceded by the [combatStop](https://mwse.github.io/MWSE/events/combatStop) event.
 --- @class combatStoppedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/containerClosed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/containerClosed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is raised when a container is closed.
 --- @class containerClosedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/convertReferenceToItem.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/convertReferenceToItem.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is raised when an in-world `tes3reference` for an item is about to be converted to fit into a `tes3itemStack`.
 --- @class convertReferenceToItemEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/crimeWitnessed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/crimeWitnessed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when a crime is witnessed by an actor.
 --- @class crimeWitnessedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/damage.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/damage.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The damage event triggers before an actor is damaged. The damage value can be modified, or the damage can be prevented completely by blocking the event.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/damageHandToHand.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/damageHandToHand.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The damageHandToHand event triggers before an actor takes fatigue damage from hand-to-hand combat. It does not trigger on health damage, but the `damage` event will. The `fatigueDamage` value can be modified, or can be prevented completely by blocking the event. The player as attacker will gain hand-to-hand experience only if `fatigueDamage` is greater than zero.
 --- @class damageHandToHandEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/damaged.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/damaged.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The damaged event triggers after an actor has been damaged.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/damagedHandToHand.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/damagedHandToHand.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The damagedHandToHand event triggers after an actor takes fatigue damage from hand-to-hand combat. It does not trigger on health damage, but the `damaged` event will.
 --- @class damagedHandToHandEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/death.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/death.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event triggers when an actor dies.
 --- @class deathEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/detectSneak.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/detectSneak.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is invoked whenever an actor is checking if they can detect another actor sneaking.
 --- @class detectSneakEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/determineAction.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/determineAction.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when an actor determines an action in a combat session.
 --- @class determineActionEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/determinedAction.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/determinedAction.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when an actor has determined an action in a combat session.
 --- @class determinedActionEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/enchantChargeUse.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/enchantChargeUse.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered just before an on-strike or on-use enchantment is used by any actor, and also by the UI system to label enchant charges. It allows modification of the charge required to use an enchantment.
 --- @class enchantChargeUseEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/enterFrame.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/enterFrame.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The enterFrame event occurs at the start of every frame, including when the game is paused or in menu mode.
 --- @class enterFrameEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/equip.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/equip.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The equip event fires when an actor is about to equip an item, i.e. just before the item is equipped. This event allows scripts to block equipping. See `equipped`_ for the post-equip event.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/equipmentReevaluated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/equipmentReevaluated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The **equipmentReevaluated** event fires after an actor has gone through its items and determined if anything in its inventory is better than what it currently has equipped. This event can be used to force equip new, custom equipment slots if needed.
 --- @class equipmentReevaluatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/equipped.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/equipped.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The **equipped** event fires after an actor has successfully equipped an item. This event is preceded by the [equip](https://mwse.github.io/MWSE/events/equip) event.
 --- @class equippedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/exerciseSkill.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/exerciseSkill.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is invoked whenever the player gains experience in a skill. The event can be blocked to prevent progress. Additionally, both the skill gaining experience and the progress gained can be changed.
 --- @class exerciseSkillEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/filterBarterMenu.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/filterBarterMenu.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when an item in the barter menu is filtered.
 --- @class filterBarterMenuEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/filterContentsMenu.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/filterContentsMenu.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when an item in the contents menu is filtered.
 --- @class filterContentsMenuEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/filterInventory.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/filterInventory.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when an item in the inventory is filtered.
 --- @class filterInventoryEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/filterInventorySelect.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/filterInventorySelect.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when an inventory filter has been selected for an item.
 --- @class filterInventorySelectEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/filterSoulGemTarget.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/filterSoulGemTarget.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when a soul gem target is filtered
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/infoFilter.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/infoFilter.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when a dialogue info object is filtered.
 --- @class infoFilterEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/infoGetText.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/infoGetText.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when a dialogue info object text is retrieved. That can be when starting a conversation with an NPC, a service was refused to the player, NPC's responses to player persuading them and if the subtitles are enabled, getting the text for the subtitle will also trigger `infoGetText` event.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/infoLinkResolve.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/infoLinkResolve.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when a dialogue hyperlink is being resolved to a topic, during UI layout (not on link activation).
 --- @class infoLinkResolveEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/infoResponse.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/infoResponse.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when a dialogue response is triggered.
 --- @class infoResponseEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/initialized.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/initialized.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The initialized event fires when game code has finished initializing, and all .esm and .esp files have been loaded.
 --- @class initializedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/isGuard.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/isGuard.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The isGuard event triggers whenever the game engine checks if an NPC object is a guard. The guard status can be modified. This alone will not make an NPC behave like a guard, though.
 --- @class isGuardEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/itemDropped.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/itemDropped.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when an item is dropped.
 --- @class itemDroppedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/itemTileUpdated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/itemTileUpdated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is fired whenever an inventory item tile is updated, as well as when the tile is created. This can be used to easily manipulate or extend the appearance of inventory tiles.
 --- @class itemTileUpdatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/journal.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/journal.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The journal event is invoked when a journal state progresses.
 --- @class journalEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/key.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/key.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The key event fires when a key up or key down input is detected. It is preferred that the keyDown and keyUp events are used instead.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/keyDown.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/keyDown.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The key event fires when a key is pressed.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/keyUp.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/keyUp.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The key event fires when a key is released.
 --- @class keyUpEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/keyframesLoad.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/keyframesLoad.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered before a keyframes file is loaded. The path can be changed to instead load a different keyframes file.
 --- @class keyframesLoadEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/levelUp.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/levelUp.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This even is called whenever the player successfully finishes leveling up.
 --- @class levelUpEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/leveledCreaturePicked.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/leveledCreaturePicked.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called after any leveled creature list is resolved. The event may be filtered by its list, and its pick can be overwritten. While this event allows for customization, the leveled list may be altered directly as well.
 --- @class leveledCreaturePickedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/leveledItemPicked.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/leveledItemPicked.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called after any leveled item list is resolved.
 --- @class leveledItemPickedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/load.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/load.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The load event fires when the game is about to load. This event allows scripts to block loading.
 --- @class loadEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/loaded.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/loaded.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The loaded event fires after the game has been successfully loaded. This event is preceded by the load event.
 --- @class loadedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/lockPick.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/lockPick.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when a lock is being picked.
 --- @class lockPickEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/magicCasted.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/magicCasted.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when any spell or enchant is cast successfully, or when any alchemy item is used. This includes spells cast via scripts. For spells, this occurs at the end of the casting animation. For spells and enchants, it is just after the magic projectile has been constructed.
 --- @class magicCastedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/magicEffectsResolved.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/magicEffectsResolved.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event triggers after all magic effect links have been resolved. This event is used to add new spell effect by using [`tes3.addSpellEffect()`](https://mwse.github.io/MWSE/apis/tes3/#tes3addmagiceffect) function. For examples of this event in practice see [`tes3.addMagicEffect()`](https://mwse.github.io/MWSE/apis/tes3/#tes3addmagiceffect) example.
 --- @class magicEffectsResolvedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/menuEnter.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/menuEnter.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The menuEnter event fires when the player enters menu mode.
 --- @class menuEnterEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/menuExit.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/menuExit.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The menuExit event fires when the player leaves menu mode.
 --- @class menuExitEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/meshLoad.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/meshLoad.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered before a mesh is loaded. The path can be changed to instead load a different mesh.
 --- @class meshLoadEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/meshLoaded.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/meshLoaded.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when a mesh is loaded.
 --- @class meshLoadedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/mobileActivated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/mobileActivated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when a Mobile Actor is activated. This may be the first time that a given Reference has an associated Mobile Actor attached to it. Typically this happens when transitioning through cells. When the player enters a cell, the `mobileActivated` event will fire for each new actor. When the player leaves the cell, the `mobileDeactivated` event is called.
 --- @class mobileActivatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/mobileDeactivated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/mobileDeactivated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when a Mobile Actor is deactivated. Typically this happens when transitioning through cells. When the player enters a cell, the `mobileActivated` event will fire for each new actor. When the player leaves the cell, the `mobileDeactivated` event is called.
 --- @class mobileDeactivatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/modConfigReady.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/modConfigReady.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires once MWSE's internal mod configuration menu code has initialized. This event is used in mods to register settings configuration menu using MCM API.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/mouseAxis.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/mouseAxis.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The mouseAxis event fires when the mouse is moved, providing deltaX and deltaY values.
 --- @class mouseAxisEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/mouseButtonDown.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/mouseButtonDown.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The mouseButtonDown event fires when a button on the mouse is pressed.
 --- @class mouseButtonDownEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/mouseButtonUp.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/mouseButtonUp.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The mouseButtonDown event fires when a button on the mouse is released.
 --- @class mouseButtonUpEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/mouseWheel.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/mouseWheel.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The mouseWheel event fires when the mouse wheel is used, providing a delta value.
 --- @class mouseWheelEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/musicSelectTrack.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/musicSelectTrack.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The musicSelectTrack event occurs when new music is needed after a playing music track ends, or the combat situation changes. It allows you to select your own music for the current conditions by setting eventData.music. However, it does not control transitions to combat music, which in the future will be available in another event.
 --- @class musicSelectTrackEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/objectInvalidated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/objectInvalidated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is raised when reference is invalidated. This includes being removed from memory. This event can be used to safely remove references from tables.
 --- @class objectInvalidatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/playGroup.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/playGroup.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- 
 --- @class playGroupEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/playItemSound.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/playItemSound.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- 
 --- @class playItemSoundEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/postInfoResponse.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/postInfoResponse.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires immediately after a dialogue response is processed.
 --- @class postInfoResponseEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/potionBrewFailed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/potionBrewFailed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The potionBrewFailed event is raised when the player fails a potion brew attempt.
 --- @class potionBrewFailedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/potionBrewSkillCheck.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/potionBrewSkillCheck.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when the player attempts to brew a potion. It controls both the strength of the potion's effects, and if the brew is successful. These both use the player's stats, so the game combines them into one function. Because the potion effects are not determined yet, the potion data is not available. When using this event, use the example as a template for your own code.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/potionBrewed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/potionBrewed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The potionBrewed event is raised when the player brews a new potion.
 ---

--- a/misc/package/Data Files/MWSE/core/meta/event/powerRecharged.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/powerRecharged.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event triggers when a power is recharged, and may be used again. In Morrowind, powers are a type of spells which may be cast once per day and don't cost any magicka.
 --- @class powerRechargedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/preLevelUp.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/preLevelUp.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered just before the player levels up.
 --- @class preLevelUpEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/preventRest.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/preventRest.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event can be used to prevent the player from resting by returning false.
 --- @class preventRestEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/projectileExpire.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/projectileExpire.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The projectileExpire event fires just prior to a fired projectile expiring.
 --- @class projectileExpireEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/projectileHitActor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/projectileHitActor.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The projectileHitActor event fires when a projectile collides with an actor.
 --- @class projectileHitActorEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/projectileHitObject.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/projectileHitObject.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The projectileHitObject event fires when a projectile collides with an object.
 --- @class projectileHitObjectEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/projectileHitTerrain.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/projectileHitTerrain.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The projectileHitTerrain event fires when a projectile collides with terrain.
 --- @class projectileHitTerrainEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/referenceActivated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/referenceActivated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when a reference is activated.
 --- @class referenceActivatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/referenceDeactivated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/referenceDeactivated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when a reference is deactivated.
 --- @class referenceDeactivatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/referenceSceneNodeCreated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/referenceSceneNodeCreated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when a SceneNode is created for a reference.
 --- @class referenceSceneNodeCreatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/restInterrupt.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/restInterrupt.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is invoked when a rest is about to be interrupted. The ambushing spawn can be overridden by changing the creature parameter.
 --- @class restInterruptEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/save.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/save.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The save event fires when the game is about to save. This event allows scripts to block saving.
 --- @class saveEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/saved.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/saved.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The saved event fires after the game has successfully been saved. This event is preceded by the save event.
 --- @class savedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/simulate.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/simulate.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The simulate event occurs at the start of every frame, excluding when the game is paused or in menu mode.
 --- @class simulateEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/skillRaised.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/skillRaised.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is invoked whenever the player naturally gains a new level a skill. This is typically through exercise, training, or reading books.
 --- @class skillRaisedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/soundObjectPlay.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/soundObjectPlay.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- 
 --- @class soundObjectPlayEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/spellCast.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/spellCast.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered just before a spell cast is resolved, at the end of the casting animation. It can control the success chance of the spell cast.
 --- @class spellCastEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/spellCasted.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/spellCasted.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when any spell is cast successfully; this includes spells cast via scripts. This occurs at the end of the casting animation, just after the magic projectile has been constructed.
 --- @class spellCastedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/spellCastedFailure.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/spellCastedFailure.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when any spell fails to cast due to failing the cast chance check. It does not trigger when there is insufficient magicka.
 --- @class spellCastedFailureEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/spellCreated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/spellCreated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered when a new spell is created using spellmaking services or by a script using `tes3spell.create()`.
 --- @class spellCreatedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/spellMagickaUse.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/spellMagickaUse.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is triggered just before a spell or power is used by any actor. It allows modification of the magicka required to cast the spell. Magicka cost change is not reflected in the UI system, because the UI does not expect spell costs to change.
 --- @class spellMagickaUseEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/spellResist.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/spellResist.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is used when calculating a creature's spell resistance, and allows Lua scripts to override the behavior of spell resistance by changing the resistedPercent value. This can be used to enable willpower-based resistance checks, provide specific resistances to specific spells, spells that heal instead of harm, and a variety of new mechanics.
 --- @class spellResistEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/spellTick.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/spellTick.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The spellTick event happens every frame that an effect is active on a target. This can be used to aid in scripted spells, cancel active spells, or otherwise monitor spell activity on actors.
 --- @class spellTickEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/topicAdded.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/topicAdded.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is raised when the player gains access to a new dialogue topic.
 --- @class topicAddedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/trapDisarm.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/trapDisarm.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event fires when a trap is being disarmed.
 --- @class trapDisarmEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/uiActivated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/uiActivated.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is invoked after a UI menu has been built or made visible, at the point that all menu elements contain updated data.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/uiEvent.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/uiEvent.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- uiEvent is triggered through various UI events. This includes scrolling through panes, clicking buttons, selecting icons, or a host of other UI-related activities.
 --- @class uiEventEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/uiObjectTooltip.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/uiObjectTooltip.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The uiObjectTooltip event triggers when a new tooltip is displayed for all in-world objects and items, and inventory tiles in all dialogues. The tooltip will be already be built. Tooltips for inventory tiles are built on mouseover, while tooltips for in-world objects are rebuilt every frame.
 --- @class uiObjectTooltipEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/uiPreEvent.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/uiPreEvent.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- uiPreEvent is triggered through various UI events. This includes scrolling through panes, clicking buttons, selecting icons, or a host of other UI-related activities. This event fires before uiEvent, and has the additional advantage of being able to be blocked.
 --- @class uiPreEventEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/uiRefreshed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/uiRefreshed.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is invoked after a UI menu has been created or recreated. This can be useful for when important game subcomponents are destroyed and remade, without the entire UI being activated.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/uiShowRestMenu.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/uiShowRestMenu.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The uiShowRestMenu event is raised when the rest menu is about to be displayed. It allows the callback to change if sleeping is allowed, or to prevent the UI from showing at all.
 --- @class uiShowRestMenuEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/uiSpellTooltip.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/uiSpellTooltip.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The uiSpellTooltip event triggers when a new tooltip is displayed for a spell. The tooltip will be already be built.
 --- @class uiSpellTooltipEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/unequipped.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/unequipped.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The unequipped event fires after an actor has successfully equipped an item.
 --- @class unequippedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/weaponReadied.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/weaponReadied.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when a weapon is readied, and pairs with the weaponUnreadied event. It can be used to reliably tell if a specific weapon is readied for attack. This does not necessarily mean that the animation state has changed for the first time.
 --- @class weaponReadiedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/weaponUnreadied.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/weaponUnreadied.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This event is called when a weapon is no longer readied, and pairs with the weaponReadied event. It can be used to reliably tell if a specific weapon is readied for attack. This does not necessarily mean that the animation state has changed for the first time. If an actor equips a weapon while having their hands up to attack with, the event will fire for the new weapon.
 --- @class weaponUnreadiedEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/weatherChangedImmediate.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/weatherChangedImmediate.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The weatherChangedImmediate event occurs when the currently simulated weather is changed without transition. This can occur when going from an interior to an exterior in a new region, or while resting. This can interrupt weather transitions, which means the `weatherTransitionFinished` event will not be triggered.
 --- @class weatherChangedImmediateEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/weatherCycled.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/weatherCycled.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The **weatherCycled** event occurs when region weathers are randomized. This occurs at an interval set by the ini option “Hours Between Weather Changes”. Regions may select the same weather as before, and there will be no transition in this case.
 --- @class weatherCycledEventData

--- a/misc/package/Data Files/MWSE/core/meta/event/weatherTransitionFinished.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/weatherTransitionFinished.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The **weatherTransitionFinished** event occurs when the currently simulated weather finished transitioning to a new weather.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/weatherTransitionImmediate.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/weatherTransitionImmediate.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The **weatherChangedImmediate** event occurs when the currently simulated weather is changed without transition. This can occur when going from an interior to an exterior in a new region, or while resting.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/event/weatherTransitionStarted.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/weatherTransitionStarted.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The **weatherTransitionStarted** event occurs when the currently simulated weather has started to gradually transition to a new weather. This can occur when moving between regions, or when the weather cycles.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/function/dofile.lua
+++ b/misc/package/Data Files/MWSE/core/meta/function/dofile.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Reads, loads, and excutes a lua file at a given path. Similar to the `require` and `include` functions, `dofile` allows the use of periods as a path delimiter. Unlike `require`, a path relative to Morrowind.exe may be given.
 --- @param path string No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/function/include.lua
+++ b/misc/package/Data Files/MWSE/core/meta/function/include.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Loads the given module. This functions identically to `require`, but will return `nil` instead of erroring if the module couldn't be found. If there is another error is found inside the included file, it will still cause an error in the `include`ing file.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/lib/debug.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/debug.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This is an extension of Lua Debug library.
 --- @class debuglib

--- a/misc/package/Data Files/MWSE/core/meta/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/event.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The event library helps to instruct mwse to call a given function when a specific action is taken in the game.
 --- @class eventlib

--- a/misc/package/Data Files/MWSE/core/meta/lib/json.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/json.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Provides support for interacting with json data through an extended dkjson module.
 --- @class jsonlib

--- a/misc/package/Data Files/MWSE/core/meta/lib/lfs.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/lfs.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- LuaFileSystem is a Lua library developed to complement the set of functions related to file systems offered by the standard Lua distribution. This library has been further extended by MWSE.
 --- @class lfslib

--- a/misc/package/Data Files/MWSE/core/meta/lib/lpeg.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/lpeg.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Provides pattern-matching based on Parsing Expression Grammars (PEGs).
 --- 	

--- a/misc/package/Data Files/MWSE/core/meta/lib/math.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/math.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This library is an interface to the standard C math library. This library has been further extended by MWSE. The functions implemented by MWSE are listed here. It provides all its functions inside the table math.
 --- @class mathlib

--- a/misc/package/Data Files/MWSE/core/meta/lib/mge.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mge.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The mge library allows MGE XE mwscript functions to be called. This is not always ideal, and this library is deprecated.
 --- @class mgelib

--- a/misc/package/Data Files/MWSE/core/meta/lib/mwscript.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mwscript.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The mwscript library allows vanilla mwscript functions to be called. This is not always ideal, and this library is deprecated. Avoid using it if at all possible.
 --- @class mwscriptlib

--- a/misc/package/Data Files/MWSE/core/meta/lib/mwse.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mwse.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The mwse library provides methods for interacting with MWSE itself, rather than direct TES3 objects.
 --- @class mwselib

--- a/misc/package/Data Files/MWSE/core/meta/lib/os.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/os.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Provides various OS-specific functions.
 --- @class oslib

--- a/misc/package/Data Files/MWSE/core/meta/lib/re.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/re.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- Provides a regular expression style syntax for pattern usage with lpeg.
 --- 	

--- a/misc/package/Data Files/MWSE/core/meta/lib/string.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/string.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This library provides generic functions for string manipulation, such as finding and extracting substrings, and pattern matching. When indexing a string in Lua, the first character is at position 1 (not at 0, as in C). Indices are allowed to be negative and are interpreted as indexing backwards, from the end of the string. Thus, the last character is at position -1, and so on.
 --- @class stringlib

--- a/misc/package/Data Files/MWSE/core/meta/lib/table.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/table.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- This library provides generic functions for table manipulation. It provides all its functions inside the table table.
 --- @class tablelib

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The tes3 library provides the majority of the functions for interacting with the game system.
 --- @class tes3lib

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The tes3ui library provides access to manipulating the game's GUI.
 --- @class tes3uilib

--- a/misc/package/Data Files/MWSE/core/meta/lib/timer.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/timer.lua
@@ -1,4 +1,5 @@
 --- @meta
+--- @diagnostic disable:undefined-doc-name
 
 --- The timer library provides helper functions for creating delayed executors.
 --- @class timerlib

--- a/misc/package/Data Files/MWSE/core/mwse_init.lua
+++ b/misc/package/Data Files/MWSE/core/mwse_init.lua
@@ -69,7 +69,7 @@ function require(name)
 end
 
 --- A dictionary keeping track of what files have already tried to be included.
---- @type <string, boolean>
+--- @type table<string, boolean>
 package.noinclude = {}
 
 --- A tweaked version of pygy/require.lua (https://github.com/pygy/require.lua)
@@ -189,6 +189,7 @@ local function convertUTF8Table(t, language)
 	for k, v in pairs(t) do
 		local vType = type(v)
 		if (vType == "string") then
+			--- @diagnostic disable-next-line:undefined-field
 			t[k] = mwse.iconv(language, v)
 		elseif (vType == "table") then
 			convertUTF8Table(v, language)
@@ -540,6 +541,7 @@ function string.multifind(s, patterns, index, plain)
 	for _, pattern in ipairs(patterns) do
 		local r = { string.find(s, pattern, index, plain) }
 		if (#r > 0) then
+			---@diagnostic disable-next-line:deprecated
 			return pattern, unpack(r)
 		end
 	end
@@ -781,16 +783,19 @@ end
 -- Helper function: Sets a config value while obfuscating the userdata binding.
 function mwse.setConfig(key, value)
 	return pcall(function()
+		--- @diagnostic disable-next-line:undefined-global
 		mwseConfig[key] = value
 	end)
 end
 
 -- Helper function: Gets a config value while obfuscating the userdata binding.
 function mwse.getConfig(key)
+	--- @diagnostic disable-next-line:undefined-global
 	return mwseConfig[key]
 end
 
 -- Load user config values.
+--- @diagnostic disable-next-line:undefined-global
 local userConfig = mwse.loadConfig("MWSE", mwseConfig.getDefaults())
 for k, v in pairs(userConfig) do
 	if (not mwse.setConfig(k, v)) then


### PR DESCRIPTION
Fix a warning in mwse_init.lua and disable warnings for the others. The goal is to reduce the number of warnings generated by MWSE files users get when they open MWSE folder as a workspace.