### PR TITLE
Fix VS Code lua extension warnings in MCM api

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
@@ -76,7 +76,7 @@ function Component:getComponent(componentData)
 		end
 	end
 	if component then
-		data = self:prepareData(componentData)
+		self:prepareData(componentData)
 		return component:new(componentData)
 	else
 		mwse.log("Error: class %s not found", componentData.class)
@@ -150,7 +150,7 @@ function Component:createLabel(parentBlock)
 end
 
 --[[
-	Wraps up the entire component 
+	Wraps up the entire component
 ]]
 function Component:createOuterContainer(parentBlock)
 	local outerContainer

--- a/misc/package/Data Files/MWSE/core/mcm/components/categories/Category.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/categories/Category.lua
@@ -68,7 +68,7 @@ function Category:checkDisabled()
 				isDisabled = false
 			end
 		elseif component.componentType == "Category" then
-			componentDisabled = component:checkDisabled()
+			local componentDisabled = component:checkDisabled()
 			isDisabled = component:checkDisabled()
 			if componentDisabled then
 				hasSettings = true
@@ -78,7 +78,7 @@ function Category:checkDisabled()
 	return (hasSettings and not tes3.player and isDisabled)
 end
 
--- UI METHODS 
+-- UI METHODS
 
 function Category:createSubcomponentsContainer(parentBlock)
 	local subcomponentsContainer = parentBlock:createBlock({ id = tes3ui.registerID("Category_ContentsContainer") })

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
@@ -237,8 +237,8 @@ function ExclusionsPage:createSearchBar(parentBlock, listName)
 	-- Set up the events to control text input control.
 	input:register("keyPress", function(e)
 		local inputController = tes3.worldController.inputController
-		pressedTab = (inputController:isKeyDown(tes3.scanCode.tab))
-		backspacedNothing = ((inputController:isKeyDown(tes3.scanCode.delete) or
+		local pressedTab = (inputController:isKeyDown(tes3.scanCode.tab))
+		local backspacedNothing = ((inputController:isKeyDown(tes3.scanCode.delete) or
 		                    inputController:isKeyDown(tes3.scanCode.backspace)) and input.text == placeholderText)
 
 		if pressedTab then
@@ -368,7 +368,7 @@ function ExclusionsPage:createList(parentBlock, listId)
 	self:createSearchBar(block, listId)
 
 	-- Create actual list
-	list = block:createVerticalScrollPane{}
+	local list = block:createVerticalScrollPane{}
 	list.widthProportional = 1.0
 	list.heightProportional = 1.0
 	list.paddingLeft = 8

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/FilterPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/FilterPage.lua
@@ -59,8 +59,8 @@ function FilterPage:createSearchBar(parentBlock)
 	input:register("keyPress", function(e)
 		-- Prevent tabs/backspacing into nothing
 		local inputController = tes3.worldController.inputController
-		pressedTab = (inputController:isKeyDown(tes3.scanCode.tab))
-		backspacedNothing = ((inputController:isKeyDown(tes3.scanCode.delete) or
+		local pressedTab = (inputController:isKeyDown(tes3.scanCode.tab))
+		local backspacedNothing = ((inputController:isKeyDown(tes3.scanCode.delete) or
 		                    inputController:isKeyDown(tes3.scanCode.backspace)) and input.text == self.placeholderSearchText)
 
 		if pressedTab then

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
@@ -8,7 +8,7 @@ Dropdown.pressedColor = tes3ui.getPalette("normal_pressed_color")
 function Dropdown:enable()
 	Parent.enable(self)
 	local currentValue = self.variable.value
-	local skillLabel
+	local label
 	for _, option in ipairs(self.options) do
 		if option.value == currentValue then
 			label = option.label


### PR DESCRIPTION
1. I marked variables as local where appropriate.
2. I changed `skillLabel` to `label` in `Dropdown.lua` since it was unused, while `label` was a global because it didn't have `local`, and this raised a warning
3. I removed `data = ` in `Component.lua`. It was unused global variable. Shouldn't change functionality.

I'd like Merlord to have a look over this before merging.