### PR TITLE
Add event.isRegistered

### DIFF
--- a/autocomplete/definitions/global/event/isRegistered.lua
+++ b/autocomplete/definitions/global/event/isRegistered.lua
@@ -1,0 +1,10 @@
+return {
+	type = "function",
+	description = [[Returns true for a function previously registered to an event with `event.register()`.]],
+	arguments = {
+		{ name = "eventId", type = "string" },
+		{ name = "callback", type = "function" },
+		{ name = "options", type = "table", optional = true },
+	},
+	valuetype = "boolean"
+}

--- a/docs/source/apis/event.md
+++ b/docs/source/apis/event.md
@@ -19,6 +19,26 @@ event.clear(eventId, options)
 
 ***
 
+### `event.isRegistered`
+
+Returns true for a function previously registered to an event with `event.register()`.
+
+```lua
+local result = event.isRegistered(eventId, callback, options)
+```
+
+**Parameters**:
+
+* `eventId` (string)
+* `callback` (function)
+* `options` (table): *Optional*.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `event.register`
 
 Registers a function to be called when an event is raised.

--- a/misc/package/Data Files/MWSE/core/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/lib/event.lua
@@ -122,6 +122,25 @@ function this.unregister(eventType, callback, options)
 	end
 end
 
+function this.isRegistered(eventType, callback, options)
+	-- Validate event type.
+	if (type(eventType) ~= "string" or eventType == "") then
+		return error("event.unregister: Event type must be a valid string.")
+	end
+
+	-- Validate callback.
+	if (type(callback) ~= "function") then
+		return error("event.unregister: Event callback must be a valid function.")
+	end
+
+	-- Make sure options is an empty table if nothing else.
+	local options = options or {}
+
+	local callbacks = getEventTable(eventType, options.filter)
+	local found = table.find(callbacks, callback)
+	return found ~= nil
+end
+
 function this.clear(eventType, filter)
 	if (filter == nil) then
 		-- Clear out general events of this type.

--- a/misc/package/Data Files/MWSE/core/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/lib/event.lua
@@ -125,12 +125,12 @@ end
 function this.isRegistered(eventType, callback, options)
 	-- Validate event type.
 	if (type(eventType) ~= "string" or eventType == "") then
-		return error("event.unregister: Event type must be a valid string.")
+		return error("event.isRegistered: Event type must be a valid string.")
 	end
 
 	-- Validate callback.
 	if (type(callback) ~= "function") then
-		return error("event.unregister: Event callback must be a valid function.")
+		return error("event.isRegistered: Event callback must be a valid function.")
 	end
 
 	-- Make sure options is an empty table if nothing else.

--- a/misc/package/Data Files/MWSE/core/meta/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/event.lua
@@ -156,6 +156,13 @@ event = {}
 --- @param options table *Optional*. No description yet available.
 function event.clear(eventId, options) end
 
+--- Returns true for a function previously registered to an event with `event.register()`.
+--- @param eventId string No description yet available.
+--- @param callback function No description yet available.
+--- @param options table *Optional*. No description yet available.
+--- @return boolean result No description yet available.
+function event.isRegistered(eventId, callback, options) end
+
 --- Registers a function to be called when an event is raised.
 --- @param eventId string No description yet available.
 --- @param callback function No description yet available.


### PR DESCRIPTION
This adds an isRegistered function to event.lua. There currently is no way to check for that besides storing that state in your own script. You might want to register an event at multiple locations and need to check if it already exists. Is this fine to merge?