### PR TITLE
Support table types docs

### DIFF
--- a/autocomplete/builders/mkdocs.lua
+++ b/autocomplete/builders/mkdocs.lua
@@ -55,11 +55,29 @@ end
 
 local function breakoutTypeLinks(type)
 	local types = {}
-	for _, t in ipairs(string.split(type, "|")) do
-		if (classes[t]) then
-			table.insert(types, string.format("[%s](../../types/%s)", t, t))
+
+	---@param type string
+	local function getTypeLink(type)
+		if classes[type] then
+			return string.format("[%s](../../types/%s)", type, type)
 		else
-			table.insert(types, t)
+			return type
+		end
+	end
+	-- Support "table<x, y>" as type, by converting it to "table (x, y)"
+	if string.find(type, 'table<') then
+		type = string.gsub(type, " ", "")
+		type = string.gsub(type, "table<", "")
+		type = string.gsub(type, ">", "")
+		type = string.split(type, ",")
+
+		local keyType = getTypeLink(type[1])
+		local valueType = getTypeLink(type[2])
+
+		table.insert(types, string.format("table (%s, %s)", keyType, valueType))
+	else
+		for _, t in ipairs(string.split(type, "|")) do
+			table.insert(types, getTypeLink(t))
 		end
 	end
 	return table.concat(types, ", ")

--- a/docs/source/types/tes3weatherController.md
+++ b/docs/source/types/tes3weatherController.md
@@ -550,7 +550,7 @@ The underwater sunset fog value.
 
 **Returns**:
 
-* `result` (table<number, tes3weather>)
+* `result` (table (number, [tes3weather](../../types/tes3weather)))
 
 ***
 


### PR DESCRIPTION
This PR adds support for "table<x, y>" types. I changed `breakoutTypeLinks()` to first check if the type has "table<" phrase. If so, it will convert "table<x,y>" or "table<x, y>" to "table (x, y)". It will also add links to types that exist in the classes global table. Let me know if you find this solution too hacky.