### PR TITLE
Add debug.printNodeTree

### DIFF
--- a/autocomplete/definitions/global/debug/printNodeTree.lua
+++ b/autocomplete/definitions/global/debug/printNodeTree.lua
@@ -1,0 +1,7 @@
+return {
+	type = "function",
+	description = [[Prints node name tree structure of passed niNode object.]],
+	arguments = {
+		{ name = "root", type = "niNode", description = "The root node to traverse and print the tree for." },
+	}
+}

--- a/docs/source/apis/debug.md
+++ b/docs/source/apis/debug.md
@@ -36,3 +36,54 @@ local value = debug.log(value)
 
 ***
 
+### `debug.printNodeTree`
+
+Prints node name tree structure of passed `niNode` object.
+
+```lua
+debug.printNodeTree(root)
+```
+
+**Parameters**:
+
+* `root` (niNode): The root node to traverse and print the tree for.
+
+## Examples
+
+!!! example "Example: Print tree structure of `worldRoot`"
+
+	```lua
+	-- Print tree structure of worldRoot
+	debug.printNodeTree(tes3.game.worldRoot)
+	```
+
+Output:
+
+```log
+[...]
+
+- WorldObjectRoot
+		- activation ambientLight
+		- CLONE PlayerSaveGame
+			- MRT
+			- Bip01
+				- Bip01 Pelvis
+					- Bip01 Spine
+						- Bip01 Spine1
+							- Bip01 Spine2
+								- Bip01 Neck
+									- Bip01 Head
+										- Head
+											- nil
+											- nil
+									- ab01node
+										- Tri Amulet_Extravagant_1 0
+										- Tri Amulet_Extravagant_1 1
+										- Tri Amulet_Extravagant_1 2
+										- Tri Amulet_Extravagant_1 3
+
+[...]
+```
+
+
+***

--- a/misc/package/Data Files/MWSE/core/meta/lib/debug.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/debug.lua
@@ -14,3 +14,7 @@ function debug.clearLogCacheForFile(file) end
 --- @return string value No description yet available.
 function debug.log(value) end
 
+--- Prints node name tree structure of passed `niNode` object.
+--- @param root niNode The root node to traverse and print the tree for.
+function debug.printNodeTree(root)
+

--- a/misc/package/Data Files/MWSE/core/mwse_init.lua
+++ b/misc/package/Data Files/MWSE/core/mwse_init.lua
@@ -674,6 +674,22 @@ function debug.log(value)
 	return value
 end
 
+function debug.printNodeTree(root)
+	local function walk(node, level)
+		if node then
+			print(string.format("%s- %s", string.rep("\t", level), node.name))
+			if node.children then
+				for _, child in ipairs(node.children) do
+					if child then
+						walk(child, level + 1)
+					end
+				end
+			end
+		end
+	end
+	walk(root, 0)
+end
+
 
 -------------------------------------------------
 -- Extend 3rd API: lfs


### PR DESCRIPTION
A small helper function to print node structure for a `niNode` objects for testing. Super useful for working with root nodes. 