### PR TITLE
Fix/silence warnings in dependencies

### DIFF
--- a/misc/package/Data Files/MWSE/core/lib/ssl/https.lua
+++ b/misc/package/Data Files/MWSE/core/lib/ssl/https.lua
@@ -73,7 +73,7 @@ end
 local function tcp(params)
    params = params or {}
    -- Default settings
-   for k, v in pairs(cfg) do 
+   for k, v in pairs(cfg) do
       params[k] = params[k] or v
    end
    -- Force client mode
@@ -93,7 +93,7 @@ local function tcp(params)
          self.sock:sni(host)
          self.sock:settimeout(_M.TIMEOUT)
          try(self.sock:dohandshake())
-         reg(self, getmetatable(self.sock))
+         reg(self)
          return 1
       end
       return conn

--- a/misc/package/Data Files/MWSE/core/lib/vscode-debuggee.lua
+++ b/misc/package/Data Files/MWSE/core/lib/vscode-debuggee.lua
@@ -1,3 +1,5 @@
+---@diagnostic disable
+
 local debuggee = {}
 
 local socket = require 'socket.core'
@@ -1028,7 +1030,7 @@ function handlers.evaluate(req)
 	-- 환경 준비.
 	-- 뭘 요구할지 모르니까 로컬, 업밸류, 글로벌을 죄다 복사해둔다.
 	-- 우선순위는 글로벌-업밸류-로컬 순서니까
-	-- 그 반대로 갖다놓아서 나중 것이 앞의 것을 덮어쓰게 한다. 
+	-- 그 반대로 갖다놓아서 나중 것이 앞의 것을 덮어쓰게 한다.
 	local depth = req.arguments.frameId
 	local tempG = {}
 	local declared = {}


### PR DESCRIPTION
This fixes the warnings we get inside https.lua, and disables all the warnings in the vscode-debugee.lua. This means that we are diverging from our dependencies. I guess if we could update luasec then this change wouldn't be needed since the offending line [is fixed ](https://github.com/brunoos/luasec/blob/df27c62f4cea33cb3525fed2a4b280997ed11aad/src/https.lua#L96)upstream. As for the vscode-debugee.lua I don't have a better solution.

The goal is to remove all the warnings Sumneko's lua plugin produces from the files that come with the MWSE, so the only warnings that can be received are from mods.