### PR TITLE
Fix messageBox warning

### DIFF
--- a/autocomplete/builders/common.lua
+++ b/autocomplete/builders/common.lua
@@ -148,6 +148,18 @@ function table.deepcopy(t)
 	return copy
 end
 
+---@param t table
+---@param value any
+---@return boolean
+function table.removevalue(t, value)
+	local i = table.find(t, value)
+	if (i ~= nil) then
+		table.remove(t, i)
+		return true
+	end
+	return false
+end
+
 
 --
 -- json library extensions

--- a/autocomplete/builders/emmy.lua
+++ b/autocomplete/builders/emmy.lua
@@ -130,14 +130,18 @@ local function writeFunction(package, file, namespaceOverride)
 		local type = argument.type
 		local description = common.getDescriptionString(argument)
 		if (argument.tableParams) then
-			type = package.namespace .. ".params"
+			local types = type:split("|")
+			table.removevalue(types, "table")
+			table.insert(types, package.namespace .. ".params")
+
+			type = table.concat(types, "|")
 			description = "This table accepts the following values:"
 			for _, tableArgument in ipairs(argument.tableParams) do
 				description = description .. string.format("\n\n`%s`: %s — %s", tableArgument.name or "unknown", getAllPossibleVariationsOfType(tableArgument.type, tableArgument) or "any", formatLineBreaks(common.getDescriptionString(tableArgument)))
 			end
 		end
 		if (argument.type == "variadic") then
-			file:write(string.format("--- @vararg %s %s\n", getAllPossibleVariationsOfType(argument.variadicType, argument) or "any", formatLineBreaks(description)))
+			file:write(string.format("--- @param ... %s %s\n", getAllPossibleVariationsOfType(argument.variadicType, argument) or "any?", formatLineBreaks(description)))
 		else
 			file:write(string.format("--- @param %s %s %s\n", argument.name or "unknown", getAllPossibleVariationsOfType(type, argument), formatLineBreaks(description)))
 		end

--- a/autocomplete/definitions/events/standard/enchantedItemCreateFailed.lua
+++ b/autocomplete/definitions/events/standard/enchantedItemCreateFailed.lua
@@ -16,7 +16,7 @@ return {
 			description = "The soul gem used for the failed creation of the item.",
 		},
 		["enchanter"] = {
-			type = "tes3mobile",
+			type = "tes3mobileActor",
 			description = "The mobile actor responsible for failing to create the enchantment.",
 		},
 		["enchanterReference"] = {

--- a/autocomplete/definitions/events/standard/enchantedItemCreated.lua
+++ b/autocomplete/definitions/events/standard/enchantedItemCreated.lua
@@ -21,7 +21,7 @@ return {
 			description = "The soul gem used for the creation of the item.",
 		},
 		["enchanter"] = {
-			type = "tes3mobile",
+			type = "tes3mobileActor",
 			description = "The mobile actor responsible for creating the enchantment.",
 		},
 		["enchanterReference"] = {

--- a/autocomplete/definitions/events/standard/jump.lua
+++ b/autocomplete/definitions/events/standard/jump.lua
@@ -17,11 +17,11 @@ return {
 			description = "The velocity of the jump.",
 		},
 		["applyFatigueCost"] = {
-			type = "bool",
+			type = "boolean",
 			description = "If `false`, this jump will not reduce fatigue.",
 		},
 		["isDefaultJump"] = {
-			type = "bool",
+			type = "boolean",
 			readOnly = true,
 			description = "If `true`, the jump has been initiated from the ground and without custom velocity or fatigue cost. This does not change if other event callbacks change any of these parameters.",
 		},

--- a/autocomplete/definitions/global/mge/getWeatherScattering.lua
+++ b/autocomplete/definitions/global/mge/getWeatherScattering.lua
@@ -2,5 +2,5 @@ return {
 	type = "function",
 	deprecated = true,
 	description = [[Gets the in- and out-scatter values from MGE. These are returned in a table with the `inscatter` and `outscatter` keys. The result table can be modified, then sent back to `setScattering`.]],
-	returns = "table<string, float>",
+	returns = "table<string, number>",
 }

--- a/autocomplete/definitions/global/mge/setWeatherScattering.lua
+++ b/autocomplete/definitions/global/mge/setWeatherScattering.lua
@@ -2,5 +2,5 @@ return {
 	type = "function",
 	deprecated = true,
 	description = [[Use `mge.weather.getScattering()` instead.]],
-	returns = "table<string, float>",
+	returns = "table<string, number>",
 }

--- a/autocomplete/definitions/namedTypes/tes3weatherControllerParticle/weatherController.lua
+++ b/autocomplete/definitions/namedTypes/tes3weatherControllerParticle/weatherController.lua
@@ -2,5 +2,5 @@ return {
 	type = "value",
 	description = [[A shortcut to the weather controller.]],
 	readOnly = true,
-	valuetype = "tes3vector3",
+	valuetype = "tes3weatherController",
 }

--- a/docs/source/events/enchantedItemCreateFailed.md
+++ b/docs/source/events/enchantedItemCreateFailed.md
@@ -20,7 +20,7 @@ event.register(tes3.event.enchantedItemCreateFailed, enchantedItemCreateFailedCa
 ## Event Data
 
 * `baseObject` ([tes3item](../../types/tes3item)): *Read-only*. The item originally enchanted.
-* `enchanter` (tes3mobile): The mobile actor responsible for failing to create the enchantment.
+* `enchanter` ([tes3mobileActor](../../types/tes3mobileActor)): The mobile actor responsible for failing to create the enchantment.
 * `enchanterReference` ([tes3reference](../../types/tes3reference)): The reference responsible for failing to create the enchantment.
 * `soul` ([tes3actor](../../types/tes3actor)): The actor used to enchant the item.
 * `soulGem` ([tes3misc](../../types/tes3misc)): The soul gem used for the failed creation of the item.

--- a/docs/source/events/enchantedItemCreated.md
+++ b/docs/source/events/enchantedItemCreated.md
@@ -20,7 +20,7 @@ event.register(tes3.event.enchantedItemCreated, enchantedItemCreatedCallback)
 ## Event Data
 
 * `baseObject` ([tes3item](../../types/tes3item)): *Read-only*. The item originally enchanted.
-* `enchanter` (tes3mobile): The mobile actor responsible for creating the enchantment.
+* `enchanter` ([tes3mobileActor](../../types/tes3mobileActor)): The mobile actor responsible for creating the enchantment.
 * `enchanterReference` ([tes3reference](../../types/tes3reference)): The reference responsible for creating the enchantment.
 * `object` ([tes3item](../../types/tes3item)): *Read-only*. The newly created and enchanted item.
 * `soul` ([tes3actor](../../types/tes3actor)): The actor used to enchant the item.

--- a/docs/source/events/jump.md
+++ b/docs/source/events/jump.md
@@ -25,8 +25,8 @@ event.register(tes3.event.jump, jumpCallback)
 
 ## Event Data
 
-* `applyFatigueCost` (bool): If `false`, this jump will not reduce fatigue.
-* `isDefaultJump` (bool): *Read-only*. If `true`, the jump has been initiated from the ground and without custom velocity or fatigue cost. This does not change if other event callbacks change any of these parameters.
+* `applyFatigueCost` (boolean): If `false`, this jump will not reduce fatigue.
+* `isDefaultJump` (boolean): *Read-only*. If `true`, the jump has been initiated from the ground and without custom velocity or fatigue cost. This does not change if other event callbacks change any of these parameters.
 * `mobile` ([tes3mobileActor](../../types/tes3mobileActor)): *Read-only*. The mobile actor that is trying to jump.
 * `reference` ([tes3reference](../../types/tes3reference)): *Read-only*. Mobile's related reference.
 * `velocity` ([tes3vector3](../../types/tes3vector3)): The velocity of the jump.

--- a/docs/source/types/tes3weatherControllerParticle.md
+++ b/docs/source/types/tes3weatherControllerParticle.md
@@ -65,7 +65,7 @@ The velocity of the particle.
 
 **Returns**:
 
-* `result` ([tes3vector3](../../types/tes3vector3))
+* `result` ([tes3weatherController](../../types/tes3weatherController))
 
 ***
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3weatherControllerParticle.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3weatherControllerParticle.lua
@@ -11,6 +11,6 @@
 --- @field rainRoot niBillboardNode|niCollisionSwitch|niNode|niSwitchNode *Read-only*. A shortcut to the root rain node.
 --- @field remainingLifetime number The remaining time before the particle becomes inactive.
 --- @field velocity tes3vector3 The velocity of the particle.
---- @field weatherController tes3vector3 *Read-only*. A shortcut to the weather controller.
+--- @field weatherController tes3weatherController *Read-only*. A shortcut to the weather controller.
 tes3weatherControllerParticle = {}
 

--- a/misc/package/Data Files/MWSE/core/meta/event/enchantedItemCreateFailed.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/enchantedItemCreateFailed.lua
@@ -8,7 +8,7 @@
 --- @class enchantedItemCreateFailedEventData
 --- @field claim boolean If set to `true`, any lower-priority event callbacks will be skipped. Returning `false` will set this to `true`.
 --- @field baseObject tes3alchemy|tes3apparatus|tes3armor|tes3book|tes3clothing|tes3ingredient|tes3light|tes3lockpick|tes3misc|tes3probe|tes3repairTool|tes3weapon *Read-only*. The item originally enchanted.
---- @field enchanter tes3mobile The mobile actor responsible for failing to create the enchantment.
+--- @field enchanter tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer The mobile actor responsible for failing to create the enchantment.
 --- @field enchanterReference tes3reference The reference responsible for failing to create the enchantment.
 --- @field soul tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3npc|tes3npcInstance The actor used to enchant the item.
 --- @field soulGem tes3misc The soul gem used for the failed creation of the item.

--- a/misc/package/Data Files/MWSE/core/meta/event/enchantedItemCreated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/enchantedItemCreated.lua
@@ -8,7 +8,7 @@
 --- @class enchantedItemCreatedEventData
 --- @field claim boolean If set to `true`, any lower-priority event callbacks will be skipped. Returning `false` will set this to `true`.
 --- @field baseObject tes3alchemy|tes3apparatus|tes3armor|tes3book|tes3clothing|tes3ingredient|tes3light|tes3lockpick|tes3misc|tes3probe|tes3repairTool|tes3weapon *Read-only*. The item originally enchanted.
---- @field enchanter tes3mobile The mobile actor responsible for creating the enchantment.
+--- @field enchanter tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer The mobile actor responsible for creating the enchantment.
 --- @field enchanterReference tes3reference The reference responsible for creating the enchantment.
 --- @field object tes3alchemy|tes3apparatus|tes3armor|tes3book|tes3clothing|tes3ingredient|tes3light|tes3lockpick|tes3misc|tes3probe|tes3repairTool|tes3weapon *Read-only*. The newly created and enchanted item.
 --- @field soul tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3npc|tes3npcInstance The actor used to enchant the item.

--- a/misc/package/Data Files/MWSE/core/meta/event/jump.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/jump.lua
@@ -10,8 +10,8 @@
 --- @class jumpEventData
 --- @field block boolean If set to `true`, vanilla logic will be suppressed. Returning `false` will set this to `true`.
 --- @field claim boolean If set to `true`, any lower-priority event callbacks will be skipped. Returning `false` will set this to `true`.
---- @field applyFatigueCost bool If `false`, this jump will not reduce fatigue.
---- @field isDefaultJump bool *Read-only*. If `true`, the jump has been initiated from the ground and without custom velocity or fatigue cost. This does not change if other event callbacks change any of these parameters.
+--- @field applyFatigueCost boolean If `false`, this jump will not reduce fatigue.
+--- @field isDefaultJump boolean *Read-only*. If `true`, the jump has been initiated from the ground and without custom velocity or fatigue cost. This does not change if other event callbacks change any of these parameters.
 --- @field mobile tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer *Read-only*. The mobile actor that is trying to jump.
 --- @field reference tes3reference *Read-only*. Mobile's related reference.
 --- @field velocity tes3vector3 The velocity of the jump.

--- a/misc/package/Data Files/MWSE/core/meta/lib/mge.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mge.lua
@@ -85,7 +85,7 @@ function mge.getWeatherPPLLight(weather) end
 
 --- Gets the in- and out-scatter values from MGE. These are returned in a table with the `inscatter` and `outscatter` keys. The result table can be modified, then sent back to `setScattering`.
 --- @deprecated
---- @return table<string, float> result No description yet available.
+--- @return table<string, number> result No description yet available.
 function mge.getWeatherScattering() end
 
 --- Gets the camera zoom. Use `mge.camera.zoom` instead.
@@ -160,7 +160,7 @@ function mge.setWeatherPPLLight(weather, mult, offset) end
 
 --- Use `mge.weather.getScattering()` instead.
 --- @deprecated
---- @return table<string, float> result No description yet available.
+--- @return table<string, number> result No description yet available.
 function mge.setWeatherScattering() end
 
 --- Sets the zoom to a specified amount. Use `mge.camera.zoom = amount` instead.

--- a/misc/package/Data Files/MWSE/core/meta/lib/mwse.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mwse.lua
@@ -49,7 +49,7 @@ function mwse.loadTranslations(mod) end
 --- 
 --- The message accepts formatting and additional parameters matching string.format's usage.
 --- @param message string No description yet available.
---- @vararg any *Optional*. No description yet available.
+--- @param ... any? *Optional*. No description yet available.
 function mwse.log(message, ...) end
 
 --- Converts a TES3 object type (e.g. from tes3.objectType) into an uppercase, 4-character string.

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -1498,7 +1498,7 @@ function tes3.makeSafeObjectHandle(object) end
 function tes3.menuMode() end
 
 --- Displays a message box. This may be a simple toast-style message, or a box with choice buttons.
---- @param messageOrParams tes3.messageBox.params This table accepts the following values:
+--- @param messageOrParams string|tes3.messageBox.params This table accepts the following values:
 --- 
 --- `message`: string — No description yet available.
 --- 
@@ -1509,7 +1509,7 @@ function tes3.menuMode() end
 --- `showInDialog`: boolean? — *Default*: `true`. Specifying showInDialog = false forces the toast-style message, which is not shown in the dialog menu.
 --- 
 --- `duration`: number? — *Optional*. Overrides how long the toast-style message remains visible.
---- @vararg any *Optional*. Only used if messageOrParams is a string.
+--- @param ... any? *Optional*. Only used if messageOrParams is a string.
 --- @return tes3uiElement|nil element The UI menu created for the notification, if any.
 function tes3.messageBox(messageOrParams, ...) end
 

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
@@ -166,7 +166,7 @@ function tes3ui.leaveMenuMode() end
 ---
 --- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3ui/#tes3uilog).
 --- @param message string No description yet available.
---- @vararg any *Optional*. No description yet available.
+--- @param ... any? *Optional*. No description yet available.
 function tes3ui.log(message, ...) end
 
 --- Logs a message to the console. Consider using `tes3ui.log` instead of this function if you do not need to make use of the `isCommand` parameter.
@@ -314,7 +314,7 @@ function tes3ui.showJournal() end
 
 --- Creates a new notify menu with a formatted string. A notify menu is a toast-style display that shows at the bottom of the screen. It will expire after an amount of time, determined by the length of the message and the `fMessageTimePerChar` GMST.
 --- @param string string The message to display. If it supports formatting, additional arguments are used.
---- @vararg any Optional values to feed to formatting found in the first parameter.
+--- @param ... any? Optional values to feed to formatting found in the first parameter.
 --- @return tes3uiElement menu The notify menu created.
 function tes3ui.showNotifyMenu(string, ...) end
 


### PR DESCRIPTION
Summary of changes:
- arguments in overloaded functions that can be a table or a simple type will be marked so, with types split with `|`. Currently, tes3.messageBox is the only definition affected. This fixes the mentioned warning.
- Use `---@param ...` in favor of `---@vararg`, since Sumneko's Lua plugin now supports `...` as a valid argument name for a variadic number of arguments, both in parameter and return [annotations](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#vararg).

The first commit ended up in this PR by a mistake. 😅