### PR TITLE
Fix optional table arguments in autocomplete

### DIFF
--- a/autocomplete/builders/emmy.lua
+++ b/autocomplete/builders/emmy.lua
@@ -132,13 +132,22 @@ local function writeFunction(package, file, namespaceOverride)
 		if (argument.tableParams) then
 			local types = type:split("|")
 			table.removevalue(types, "table")
-			table.insert(types, package.namespace .. ".params")
 
-			type = table.concat(types, "|")
+			-- Check if a function can be called without any arguments. If all the
+			-- fields in the table are optional, mark the whole table as optional.
+			local optionalCount = 0
 			description = "This table accepts the following values:"
 			for _, tableArgument in ipairs(argument.tableParams) do
 				description = description .. string.format("\n\n`%s`: %s — %s", tableArgument.name or "unknown", getAllPossibleVariationsOfType(tableArgument.type, tableArgument) or "any", formatLineBreaks(common.getDescriptionString(tableArgument)))
+				if tableArgument.optional then
+					optionalCount = optionalCount + 1
+				end
 			end
+			if optionalCount == #argument.tableParams then
+				argument.optional = true
+			end
+			table.insert(types, package.namespace .. ".params")
+			type = table.concat(types, "|")
 		end
 		if (argument.type == "variadic") then
 			file:write(string.format("--- @param ... %s %s\n", getAllPossibleVariationsOfType(argument.variadicType, argument) or "any?", formatLineBreaks(description)))

--- a/misc/package/Data Files/MWSE/core/meta/class/mgeCameraConfig.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mgeCameraConfig.lua
@@ -19,7 +19,7 @@ mgeCameraConfig = {}
 function mgeCameraConfig.stopZoom() end
 
 --- Sets up continuous camera zoom. The zoom speed starts at `rate`. The speed will approach `targetRate` over time, if provided.
---- @param params mgeCameraConfig.zoomContinuous.params This table accepts the following values:
+--- @param params mgeCameraConfig.zoomContinuous.params? This table accepts the following values:
 --- 
 --- `rate`: number? — *Optional*. No description yet available.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3dataHandler.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3dataHandler.lua
@@ -30,7 +30,7 @@
 tes3dataHandler = {}
 
 --- No description yet available.
---- @param params tes3dataHandler.updateCollisionGroupsForActiveCells.params This table accepts the following values:
+--- @param params tes3dataHandler.updateCollisionGroupsForActiveCells.params? This table accepts the following values:
 --- 
 --- `force`: boolean? — *Default*: `true`. No description yet available.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3mobileActor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3mobileActor.lua
@@ -190,7 +190,7 @@ function tes3mobileActor:calcEffectiveDamage(params) end
 --- @field resistAttribute number? *Optional*. The resistance attribute that is applied to the damage. It can reduce damage or exploit weakness. Uses values from [`tes3.effectAttribute`](https://mwse.github.io/MWSE/references/effect-attributes/) namespace.
 
 --- Calculates the starting velocity of a jump.
---- @param params tes3mobileActor.calculateJumpVelocity.params This table accepts the following values:
+--- @param params tes3mobileActor.calculateJumpVelocity.params? This table accepts the following values:
 --- 
 --- `direction`: tes3vector2? — *Optional*. The ground direction vector used to calculate the velocity. If not specified, a zero-length direction vector for a regular jump without movement will be used.
 --- @return tes3vector3 result No description yet available.
@@ -201,7 +201,7 @@ function tes3mobileActor:calculateJumpVelocity(params) end
 --- @field direction tes3vector2? *Optional*. The ground direction vector used to calculate the velocity. If not specified, a zero-length direction vector for a regular jump without movement will be used.
 
 --- Forces the actor to jump. If `velocity` or other parameters with non-default values are specified it will be treated as a non-default jump during the [`jump`](https://mwse.github.io/MWSE/events/jump) event. Returns `false` if the actor is currently unable to jump or the jump has been cancelled, otherwise returns `true`.
---- @param params tes3mobileActor.doJump.params This table accepts the following values:
+--- @param params tes3mobileActor.doJump.params? This table accepts the following values:
 --- 
 --- `velocity`: tes3vector3? — *Optional*. The initial velocity of the jump. If not specified, the velocity of a regular jump without movement will be used.
 --- 
@@ -358,7 +358,7 @@ function tes3mobileActor:startDialogue() end
 function tes3mobileActor:stopCombat(force) end
 
 --- Unequips one or more items from the actor.
---- @param params tes3mobileActor.unequip.params This table accepts the following values:
+--- @param params tes3mobileActor.unequip.params? This table accepts the following values:
 --- 
 --- `item`: tes3alchemy|tes3apparatus|tes3armor|tes3book|tes3clothing|tes3ingredient|tes3light|tes3lockpick|tes3misc|tes3probe|tes3repairTool|tes3weapon|string|nil — *Optional*. The item to unequip.
 --- 
@@ -378,7 +378,7 @@ function tes3mobileActor:unequip(params) end
 --- @field clothingSlot number? *Optional*. The clothing slot to unequip. Maps to values in [`tes3.clothingSlot`](https://mwse.github.io/MWSE/references/clothing-slots/) namespace
 
 --- Unequips the currently equipped magic, optionally unequipping the enchanted item if needed.
---- @param params tes3mobileActor.unequipMagic.params This table accepts the following values:
+--- @param params tes3mobileActor.unequipMagic.params? This table accepts the following values:
 --- 
 --- `unequipItem`: boolean? — *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/lib/mwscript.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mwscript.lua
@@ -10,7 +10,7 @@ mwscript = {}
 
 --- Use [`tes3reference:activate()`](https://mwse.github.io/MWSE/types/tes3reference/#activate) or [`tes3.setAIActivate()`](https://mwse.github.io/MWSE/apis/tes3/#tes3setaiactivate) instead. Wrapper for the `Activate` mwscript function.
 --- @deprecated
---- @param params mwscript.activate.params This table accepts the following values:
+--- @param params mwscript.activate.params? This table accepts the following values:
 --- 
 --- `reference`: tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string|nil — *Optional*. The target reference for this command to be executed on. Defaults to the normal script execution reference.
 function mwscript.activate(params) end
@@ -239,7 +239,7 @@ function mwscript.getDetected(params) end
 
 --- Use [`object.disabled`](https://mwse.github.io/MWSE/types/tes3baseObject/#disabled) on any object inheriting from `tes3baseObject`. Wrapper for the `GetDisabled` mwscript function.
 --- @deprecated
---- @param params mwscript.getDisabled.params This table accepts the following values:
+--- @param params mwscript.getDisabled.params? This table accepts the following values:
 --- 
 --- `reference`: tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string|nil — *Optional*. The target reference for this command to be executed on. Defaults to the normal script execution reference.
 --- @return boolean result No description yet available.
@@ -474,7 +474,7 @@ function mwscript.scriptRunning(params) end
 
 --- Marks the `reference` as deleted, and modified. Deleted reference isn't rendered nor is its local mwscript run.
 --- @deprecated
---- @param params mwscript.setDelete.params This table accepts the following values:
+--- @param params mwscript.setDelete.params? This table accepts the following values:
 --- 
 --- `reference`: tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string|nil — *Optional*. The target reference for this command to be executed on. Defaults to the normal script execution reference.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -871,7 +871,7 @@ function tes3.findClosestExteriorReferenceOfObject(params) end
 --- Locates a root dialogue topic that can then be filtered down for a specific actor to return a specific dialogue info. Specify either `topic`, or both `type` and `page` for other types of dialogue.
 --- 
 --- For example, `tes3.findDialogue({type = tes3.dialogueType.greeting, page = tes3.dialoguePage.greeting.greeting0})` will return the "Greeting 0" topic, which is not available using a topic ID.
---- @param params tes3.findDialogue.params This table accepts the following values:
+--- @param params tes3.findDialogue.params? This table accepts the following values:
 --- 
 --- `topic`: string? — *Optional*. The dialogue topic to look for.
 --- 
@@ -1142,7 +1142,7 @@ function tes3.getJournalIndex(params) end
 --- @field id tes3dialogue|string No description yet available.
 
 --- Returns how many times the player killed an actor. If no actor is specified, total number of kills player commited will be returned.
---- @param params tes3.getKillCount.params This table accepts the following values:
+--- @param params tes3.getKillCount.params? This table accepts the following values:
 --- 
 --- `actor`: tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3npc|tes3npcInstance|string|nil — *Optional*. The actor (or their ID) for whom to retrieve player's kill count.
 --- @return number count No description yet available.
@@ -1949,7 +1949,7 @@ function tes3.removeSpell(params) end
 --- @field updateGUI boolean? *Default*: `true`. If true, the GUI will be updated respecting the removal of the spell. This can be useful to disable when batch-removing many spells. The batch should be ended with [`tes3.updateMagicGUI`](https://mwse.github.io/MWSE/apis/tes3/#tes3updatemagicgui) to reflect the changes.
 
 --- Removes one or more visual effects created either through magical effects or `tes3.createVisualEffect()`.
---- @param params tes3.removeVisualEffect.params This table accepts the following values:
+--- @param params tes3.removeVisualEffect.params? This table accepts the following values:
 --- 
 --- `vfx`: tes3vfx? — *Optional*. If provided, the specific VFX handle will be deleted.
 --- 
@@ -2308,7 +2308,7 @@ function tes3.setOwner(params) end
 --- @field requiredRank number? *Default*: `0`. If `owner` is set to faction, `requitedRank` variable controls minimal rank in faction the player has to have to be able to freely take the reference.
 
 --- Enables or disables player's controls state.
---- @param params tes3.setPlayerControlState.params This table accepts the following values:
+--- @param params tes3.setPlayerControlState.params? This table accepts the following values:
 --- 
 --- `enabled`: boolean? — *Default*: `false`. Setting this to false will disable any kind of control.
 --- 
@@ -2386,7 +2386,7 @@ function tes3.setTrap(params) end
 --- Toggles the camera into vanity mode. In vanity mode the camera is in third person and it is orbiting slowly around the player character. Returns true if changed to vanity mode.
 --- 
 --- Note that unlike the vanity mode caused by not doing anything for a while, this vanity mode must be toggled to go off.
---- @param params tes3.setVanityMode.params This table accepts the following values:
+--- @param params tes3.setVanityMode.params? This table accepts the following values:
 --- 
 --- `enabled`: boolean? — *Default*: `true`. This flag sets the vanity mode as enabled or disabled.
 --- 
@@ -2444,7 +2444,7 @@ function tes3.showDialogueMenu(params) end
 --- @field checkAllowWerewolfForceGreeting boolean? *Default*: `true`. If true, the `AllowWerewolfForceGreeting` variable must exist on the reference's script to allow opening a dialogue while the player is a werewolf. This can be set to false to override the vanilla behavior.
 
 --- This function opens the repair service menu.
---- @param params tes3.showRepairServiceMenu.params This table accepts the following values:
+--- @param params tes3.showRepairServiceMenu.params? This table accepts the following values:
 --- 
 --- `serviceActor`: tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3reference|string|nil — *Optional*. The actor to use for calculating the service price.
 function tes3.showRepairServiceMenu(params) end
@@ -2456,7 +2456,7 @@ function tes3.showRepairServiceMenu(params) end
 --- This function opens the resting menu and returns true on success. If the player can't rest currently, it returns false.
 --- 
 --- Various parameters can be used to allow resting in situations not normally possible.
---- @param params tes3.showRestMenu.params This table accepts the following values:
+--- @param params tes3.showRestMenu.params? This table accepts the following values:
 --- 
 --- `checkForEnemies`: boolean? — *Default*: `true`. Perform a check whether there are enemies nearby before opening rest menu. If there are, false is returned.
 --- 
@@ -2603,7 +2603,7 @@ function tes3.transferItem(params) end
 --- @field updateGUI boolean? *Default*: `true`. If false, the function won't manually resync the player's GUI state. This can result in some optimizations, though [`tes3ui.forcePlayerInventoryUpdate()`](https://mwse.github.io/MWSE/apis/tes3ui/#tes3uiforceplayerinventoryupdate) must manually be called after all inventory updates are finished.
 
 --- Emulates the player committing a crime. Returns `true` if the crime was witnessed by an actor.
---- @param params tes3.triggerCrime.params This table accepts the following values:
+--- @param params tes3.triggerCrime.params? This table accepts the following values:
 --- 
 --- `type`: number? — *Default*: `tes3.crimeType.theft`. The type of crime to be committed. Maps to values in the [`tes3.crimeType`](https://mwse.github.io/MWSE/references/crime-types/) table.
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
@@ -215,7 +215,7 @@ function tes3ui.setConsoleReference(reference) end
 function tes3ui.showBookMenu(text) end
 
 --- This function creates a dialogue message. The message can have three styles. The style `2` makes a selectable text. That way by calling this function multiple time you can create a selection of responses.
---- @param params tes3ui.showDialogueMessage.params This table accepts the following values:
+--- @param params tes3ui.showDialogueMessage.params? This table accepts the following values:
 --- 
 --- `text`: string? — *Default*: ``. The text of the shown message.
 --- 


### PR DESCRIPTION
Made to fix errors like these:
![image](https://user-images.githubusercontent.com/41503714/180605004-12e88a08-99d6-4307-b318-1d1c53f7f0ae.png)

The tes3.fadeOut function can be called without any arguments, but we get warnings for using it that way, marking the argument table as optional fixes this.

To fix the issue with tes3.fadeOut, we need to add `optional = true` in the `duration` argument definition to fix the error on the image above. I added a way to more easily discover which definitions have a default value set but no optional in #376.