### PR TITLE
Fix config load gotchas

### DIFF
--- a/misc/package/Data Files/MWSE/core/mwse_init.lua
+++ b/misc/package/Data Files/MWSE/core/mwse_init.lua
@@ -368,6 +368,18 @@ function table.copymissing(to, from)
 	end
 end
 
+function table.copymissingflat(to, from)
+	if (type(to) ~= "table" or type(from) ~= "table") then
+		error("Arguments for table.copymissing must be tables.")
+	end
+
+	for k, v in pairs(from) do
+		if (to[k] == nil) then
+			to[k] = v
+		end
+	end
+end
+
 function table.traverse(t, k)
 	k = k or "children"
 	local function iter(nodes)
@@ -792,7 +804,7 @@ function mwse.loadConfig(fileName, defaults)
 
 	if (result) then
 		if (type(defaults) == "table") then
-			table.copymissing(result, defaults)
+			table.copymissingflat(result, defaults)
 		end
 	else
 		result = defaults


### PR DESCRIPTION
- Added a new shallow version of `table.copymissing`
- This will be used instead of recursive one when loading config

This change is warranted by the fact that copying stuff recursively borks loading configs that include tables. This is particularly glaring when using MCM's `exclusionsPage`, where any removal of a k-v pair that otherwise exists in the default config table is treated as an error. It shouldn't be so.