### PR TITLE
Docs: Make *Optional* always show up in the argument descriptions

### DIFF
--- a/autocomplete/builders/common.lua
+++ b/autocomplete/builders/common.lua
@@ -317,12 +317,12 @@ function common.getDescriptionString(package, useDefault)
 		table.insert(descriptionBits, "*Read-only*.")
 	end
 
-	if (package.default ~= nil) then
-		table.insert(descriptionBits, string.format("*Default*: `%s`.", tostring(package.default)))
-	elseif (package.optional) then
+	if (package.optional) then
 		table.insert(descriptionBits, "*Optional*.")
 	end
-
+	if (package.default ~= nil) then
+		table.insert(descriptionBits, string.format("*Default*: `%s`.", tostring(package.default)))
+	end
 	if (package.description) then
 		table.insert(descriptionBits, package.description)
 	elseif (useDefault) then

--- a/docs/source/apis/mwscript.md
+++ b/docs/source/apis/mwscript.md
@@ -639,7 +639,7 @@ local executed = mwscript.setDelete({ reference = ..., delete = ... })
 
 * `params` (table): *Optional*.
 	* `reference` ([tes3reference](../../types/tes3reference), [tes3mobileActor](../../types/tes3mobileActor), string): *Optional*. The target reference for this command to be executed on. Defaults to the normal script execution reference.
-	* `delete` (boolean): *Default*: `true`. Setting this to true deletes the reference and triggers `referenceDeactivated` event. Setting this to false effectively undeletes/activates the reference and triggers `referenceActivated` event.
+	* `delete` (boolean): *Optional*. *Default*: `true`. Setting this to true deletes the reference and triggers `referenceDeactivated` event. Setting this to false effectively undeletes/activates the reference and triggers `referenceActivated` event.
 
 **Returns**:
 

--- a/docs/source/apis/table.md
+++ b/docs/source/apis/table.md
@@ -330,7 +330,7 @@ local result = table.traverse(t, k)
 **Parameters**:
 
 * `t` (table): A table to transverse.
-* `k` (unknown): *Default*: `children`. The key of a table inside t object.
+* `k` (unknown): *Optional*. *Default*: `children`. The key of a table inside t object.
 
 **Returns**:
 

--- a/docs/source/apis/tes3.md
+++ b/docs/source/apis/tes3.md
@@ -217,7 +217,7 @@ tes3.addJournalEntry({ text = ..., showMessage = ... })
 
 * `params` (table)
 	* `text` (string): The text of the new Journal entry.
-	* `showMessage` (boolean): *Default*: `true`. If this parameter is true, a "Your journal has been updated" message will be displayed.
+	* `showMessage` (boolean): *Optional*. *Default*: `true`. If this parameter is true, a "Your journal has been updated" message will be displayed.
 
 ***
 
@@ -233,13 +233,13 @@ local effect = tes3.addMagicEffect({ id = ..., name = ..., baseCost = ..., schoo
 
 * `params` (table)
 	* `id` (number): Id of the new effect. Maps to newly claimed `tes3.effect` constants with `tes3.claimSpellEffectId()`. If the effect of this id already exists, an error will be thrown.
-	* `name` (string): *Default*: `Unnamed Effect`. Name of the effect.
-	* `baseCost` (number): *Default*: `1`. Base magicka cost for the effect.
-	* `school` (integer): *Default*: `tes3.magicSchool.alteration`. The magic school the new effect will be assigned to. Maps to [`tes3.magicSchool`](https://mwse.github.io/MWSE/references/magic-schools/) constants.
-	* `size` (number): *Default*: `1`. Controls how much the visual effect scales with its magnitude.
-	* `sizeCap` (number): *Default*: `1`. The maximum possible size of the projectile.
-	* `speed` (number): *Default*: `1`.
-	* `description` (string): *Default*: `No description available.`. Description for the effect.
+	* `name` (string): *Optional*. *Default*: `Unnamed Effect`. Name of the effect.
+	* `baseCost` (number): *Optional*. *Default*: `1`. Base magicka cost for the effect.
+	* `school` (integer): *Optional*. *Default*: `tes3.magicSchool.alteration`. The magic school the new effect will be assigned to. Maps to [`tes3.magicSchool`](https://mwse.github.io/MWSE/references/magic-schools/) constants.
+	* `size` (number): *Optional*. *Default*: `1`. Controls how much the visual effect scales with its magnitude.
+	* `sizeCap` (number): *Optional*. *Default*: `1`. The maximum possible size of the projectile.
+	* `speed` (number): *Optional*. *Default*: `1`.
+	* `description` (string): *Optional*. *Default*: `No description available.`. Description for the effect.
 	* `lighting` (table): *Optional*.
 		* `x` (number): *Default*: `1`. Value of red color channel. In range of 0 - 1.
 		* `y` (number): *Default*: `1`. Value of green color channel. In range of 0 - 1.
@@ -254,25 +254,25 @@ local effect = tes3.addMagicEffect({ id = ..., name = ..., baseCost = ..., schoo
 	* `boltVFX` ([tes3physicalObject](../../types/tes3physicalObject), string): *Optional*. The visual played when a spell with this effect is in flight.
 	* `hitVFX` ([tes3physicalObject](../../types/tes3physicalObject), string): *Optional*. The visual played when a spell with this effect hits something.
 	* `areaVFX` ([tes3physicalObject](../../types/tes3physicalObject), string): *Optional*. The visual played when a spell with this effect, with area of effect hits something.
-	* `allowEnchanting` (boolean): *Default*: `true`. A flag which controls whether this effect can be used in a custom enchantment.
-	* `allowSpellmaking` (boolean): *Default*: `true`. A flag which controls whether this effect can be used in a custom spell.
-	* `appliesOnce` (boolean): *Default*: `true`. A flag which controls whether this effect applies once or is a ticking effect.
-	* `canCastSelf` (boolean): *Default*: `true`. A flag which controls whether this effect can be used with cast on self range.
-	* `canCastTarget` (boolean): *Default*: `true`. A flag which controls whether this effect can be used with cast on target range.
-	* `canCastTouch` (boolean): *Default*: `true`. A flag which controls whether this effect can be used with cast on touch range.
-	* `casterLinked` (boolean): *Default*: `true`. Access to the base flag that determines if this effect must end if caster is dead, or not an NPC/creature. Not allowed in container or door trap spells.
+	* `allowEnchanting` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect can be used in a custom enchantment.
+	* `allowSpellmaking` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect can be used in a custom spell.
+	* `appliesOnce` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect applies once or is a ticking effect.
+	* `canCastSelf` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect can be used with cast on self range.
+	* `canCastTarget` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect can be used with cast on target range.
+	* `canCastTouch` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect can be used with cast on touch range.
+	* `casterLinked` (boolean): *Optional*. *Default*: `true`. Access to the base flag that determines if this effect must end if caster is dead, or not an NPC/creature. Not allowed in container or door trap spells.
 
 Note that this property is hidden in the Construction Set.
-	* `hasContinuousVFX` (boolean): *Default*: `true`. A flag which controls whether the effect's visual is continuously played during the whole duration of the effect.
-	* `hasNoDuration` (boolean): *Default*: `true`. A flag which controls whether this effect doesn't have duration.
-	* `hasNoMagnitude` (boolean): *Default*: `true`. A flag which controls whether this effect doesn't have magnitude.
-	* `illegalDaedra` (boolean): *Default*: `true`. A flag which controls whether this effect is illegal to use in public, because it summons Daedra. Note: this mechanic is not implemented in the game. Some mods might rely on this parameter.
-	* `isHarmful` (boolean): *Default*: `true`. A flag which controls whether this effect is considered harmful and casting it can be considered as an attack.
-	* `nonRecastable` (boolean): *Default*: `true`. A flag which controls whether this effect can be recast while it already is in duration.
-	* `targetsAttributes` (boolean): *Default*: `true`. A flag which controls whether this effect targets a certain attribute or attributes.
-	* `targetsSkills` (boolean): *Default*: `true`. A flag which controls whether this effect targets a certain skill or skills.
-	* `unreflectable` (boolean): *Default*: `true`. A flag which controls whether this effect can be reflected.
-	* `usesNegativeLighting` (boolean): *Default*: `true`. A flag which controls whether this effect uses negative lighting.
+	* `hasContinuousVFX` (boolean): *Optional*. *Default*: `true`. A flag which controls whether the effect's visual is continuously played during the whole duration of the effect.
+	* `hasNoDuration` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect doesn't have duration.
+	* `hasNoMagnitude` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect doesn't have magnitude.
+	* `illegalDaedra` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect is illegal to use in public, because it summons Daedra. Note: this mechanic is not implemented in the game. Some mods might rely on this parameter.
+	* `isHarmful` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect is considered harmful and casting it can be considered as an attack.
+	* `nonRecastable` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect can be recast while it already is in duration.
+	* `targetsAttributes` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect targets a certain attribute or attributes.
+	* `targetsSkills` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect targets a certain skill or skills.
+	* `unreflectable` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect can be reflected.
+	* `usesNegativeLighting` (boolean): *Optional*. *Default*: `true`. A flag which controls whether this effect uses negative lighting.
 	* `onTick` (function): *Optional*. A function which will be called on each tick of a spell containing this effect. A table `tickParams` will be passed to the callback function. Note: `dt`(frame time) scaling is handled automatically.
 		- `tickParams` (table)
 			- `effectId` (number)
@@ -559,8 +559,8 @@ local hoursPassed = tes3.advanceTime({ hours = ..., resting = ..., updateEnviron
 
 * `params` (table)
 	* `hours` (number): How many hours to progress.
-	* `resting` (boolean): *Default*: `false`. Should advancing time count as resting? If set to true invokes usual sleeping mechanics: health, fatigue and magicka restoration, and possible rest interruption. The length of the rest will be equal to hours parameter, rounded down to nearest natural number.
-	* `updateEnvironment` (boolean): *Default*: `true`. Controls if the weather system is updated for each hour passed.
+	* `resting` (boolean): *Optional*. *Default*: `false`. Should advancing time count as resting? If set to true invokes usual sleeping mechanics: health, fatigue and magicka restoration, and possible rest interruption. The length of the rest will be equal to hours parameter, rounded down to nearest natural number.
+	* `updateEnvironment` (boolean): *Optional*. *Default*: `true`. Controls if the weather system is updated for each hour passed.
 
 **Returns**:
 
@@ -583,19 +583,19 @@ local instance = tes3.applyMagicSource({ reference = ..., source = ..., name = .
 	* `source` ([tes3object](../../types/tes3object)): *Optional*. A magic source to apply.
 	* `name` (string): *Optional*. While optional for other uses, if applying alchemy as a source, you must specify a name for the magic source.
 	* `effects` (table): *Optional*. A table of custom effects to apply as a potion. Maximal number of effects is 8.
-		* `id` (boolean): *Default*: `-1`. ID of the effect.
-		* `skill` (number): *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Skill, a skill should be provided. This also applies to any custom spell effect which operates on a certain skill. This value maps to [`tes3.skill`](https://mwse.github.io/MWSE/references/skills/) constants.
-		* `attribute` (number): *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Attribute, an attribute should be provided. This also applies to any custom spell effect which operates on a certain attribute. This value maps to [`tes3.attribute`](https://mwse.github.io/MWSE/references/attributes/) constants.
-		* `rangeType` (number): *Default*: `tes3.effectRange.self`. The range of the effect. This maps to [`tes3.effectRange`](https://mwse.github.io/MWSE/references/effect-ranges/) constants.
-		* `radius` (number): *Default*: `0`. The radius of the effect.
-		* `duration` (number): *Default*: `0`. Number of seconds the effect is going to be active.
-		* `min` (number): *Default*: `0`. The minimal magintude of the effect per tick.
-		* `max` (number): *Default*: `0`. The maximal magnitude of the effect per tick.
-	* `createCopy` (boolean): *Default*: `true`. This parameter controls whether the function will return the original magic source or a copy of the magic source. This parameter is only used if source is alchemy.
+		* `id` (boolean): *Optional*. *Default*: `-1`. ID of the effect.
+		* `skill` (number): *Optional*. *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Skill, a skill should be provided. This also applies to any custom spell effect which operates on a certain skill. This value maps to [`tes3.skill`](https://mwse.github.io/MWSE/references/skills/) constants.
+		* `attribute` (number): *Optional*. *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Attribute, an attribute should be provided. This also applies to any custom spell effect which operates on a certain attribute. This value maps to [`tes3.attribute`](https://mwse.github.io/MWSE/references/attributes/) constants.
+		* `rangeType` (number): *Optional*. *Default*: `tes3.effectRange.self`. The range of the effect. This maps to [`tes3.effectRange`](https://mwse.github.io/MWSE/references/effect-ranges/) constants.
+		* `radius` (number): *Optional*. *Default*: `0`. The radius of the effect.
+		* `duration` (number): *Optional*. *Default*: `0`. Number of seconds the effect is going to be active.
+		* `min` (number): *Optional*. *Default*: `0`. The minimal magintude of the effect per tick.
+		* `max` (number): *Optional*. *Default*: `0`. The maximal magnitude of the effect per tick.
+	* `createCopy` (boolean): *Optional*. *Default*: `true`. This parameter controls whether the function will return the original magic source or a copy of the magic source. This parameter is only used if source is alchemy.
 	* `fromStack` ([tes3equipmentStack](../../types/tes3equipmentStack)): *Optional*. The piece of equipment this magic source is coming from. The fromStack has to be an already equipped item from tes3actor.equipment. This will probably change in the future.
 	* `castChance` (number): *Optional*. This parameter allows overriding the casting chance of the magic source.
 	* `target` ([tes3reference](../../types/tes3reference), [tes3mobileActor](../../types/tes3mobileActor), string): *Optional*. The target of the magic.
-	* `bypassResistances` (boolean): *Default*: `false`. Is this effect going to bypass magic resistance?
+	* `bypassResistances` (boolean): *Optional*. *Default*: `false`. Is this effect going to bypass magic resistance?
 
 **Returns**:
 
@@ -1753,8 +1753,8 @@ local effectiveMagnitude, magnitude = tes3.getEffectMagnitude({ reference = ...,
 * `params` (table)
 	* `reference` ([tes3reference](../../types/tes3reference), [tes3mobileActor](../../types/tes3mobileActor), string): An associated mobile should exist for this function to be able to work.
 	* `effect` (number): Effect ID. Can be any of the predefined spell effects, or one added by `tes3.claimSpellEffectId()`. Maps to values of [`tes3.effect`](https://mwse.github.io/MWSE/references/magic-effects/) constants
-	* `skill` (number): *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Skill, a skill should be provided. This also applies to any custom spell effect which operates on a certain skill. This value maps to [`tes3.skill`](https://mwse.github.io/MWSE/references/skills/) constants.
-	* `attribute` (number): *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Attribute, an attribute should be provided. This also applies to any custom spell effect which operates on a certain attribute. This value maps to [`tes3.attribute`](https://mwse.github.io/MWSE/references/attributes/) constants.
+	* `skill` (number): *Optional*. *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Skill, a skill should be provided. This also applies to any custom spell effect which operates on a certain skill. This value maps to [`tes3.skill`](https://mwse.github.io/MWSE/references/skills/) constants.
+	* `attribute` (number): *Optional*. *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Attribute, an attribute should be provided. This also applies to any custom spell effect which operates on a certain attribute. This value maps to [`tes3.attribute`](https://mwse.github.io/MWSE/references/attributes/) constants.
 
 **Returns**:
 
@@ -2336,7 +2336,7 @@ local region = tes3.getRegion(useDoors)
 
 **Parameters**:
 
-* `useDoors` (boolean): *Default*: `false`.
+* `useDoors` (boolean): *Optional*. *Default*: `false`.
 
 **Returns**:
 
@@ -2499,10 +2499,10 @@ local result = tes3.getSpells({ target = ..., spellType = ..., getActorSpells = 
 
 * `params` (table)
 	* `target` ([tes3reference](../../types/tes3reference), [tes3mobileActor](../../types/tes3mobileActor), [tes3actor](../../types/tes3actor)): The actor to get the spells of. Must be able to cast spells.
-	* `spellType` (number): *Default*: `-1`. The spell type to filter for. Only spells with this spell type will be returned. A value of `-1` will return spells of all types. Maps to values in the [`tes3.spellType`](https://mwse.github.io/MWSE/references/spell-types/) table.
-	* `getActorSpells` (boolean): *Default*: `true`. If `true`, the spells of the actor itself will be included in the result. This includes every spell except racial and birthsign spells.
-	* `getRaceSpells` (boolean): *Default*: `true`. If `true`, the spells of the actor's race will be included in the result.
-	* `getBirthsignSpells` (boolean): *Default*: `true`. If `true`, the spells of the actor's birthsign will be included in the result.
+	* `spellType` (number): *Optional*. *Default*: `-1`. The spell type to filter for. Only spells with this spell type will be returned. A value of `-1` will return spells of all types. Maps to values in the [`tes3.spellType`](https://mwse.github.io/MWSE/references/spell-types/) table.
+	* `getActorSpells` (boolean): *Optional*. *Default*: `true`. If `true`, the spells of the actor itself will be included in the result. This includes every spell except racial and birthsign spells.
+	* `getRaceSpells` (boolean): *Optional*. *Default*: `true`. If `true`, the spells of the actor's race will be included in the result.
+	* `getBirthsignSpells` (boolean): *Optional*. *Default*: `true`. If `true`, the spells of the actor's birthsign will be included in the result.
 
 **Returns**:
 
@@ -2885,7 +2885,7 @@ local model = tes3.loadMesh(path, useCache)
 **Parameters**:
 
 * `path` (string): Path, relative to Data Files/Meshes.
-* `useCache` (boolean): *Default*: `true`. If false, a new object will be created even if it had been previously loaded.
+* `useCache` (boolean): *Optional*. *Default*: `true`. If false, a new object will be created even if it had been previously loaded.
 
 **Returns**:
 
@@ -2996,7 +2996,7 @@ local element = tes3.messageBox({ message = ..., buttons = ..., callback = ..., 
 	* `message` (string)
 	* `buttons` (string[]): *Optional*. An array of strings to use for buttons.
 	* `callback` (function)
-	* `showInDialog` (boolean): *Default*: `true`. Specifying showInDialog = false forces the toast-style message, which is not shown in the dialog menu.
+	* `showInDialog` (boolean): *Optional*. *Default*: `true`. Specifying showInDialog = false forces the toast-style message, which is not shown in the dialog menu.
 	* `duration` (number): *Optional*. Overrides how long the toast-style message remains visible.
 * `formatAdditions` (variadic): *Optional*. Only used if messageOrParams is a string.
 
@@ -3210,9 +3210,9 @@ local executed = tes3.positionCell({ reference = ..., cell = ..., position = ...
 	* `cell` ([tes3cell](../../types/tes3cell)): *Optional*. The cell to move the reference to. If not provided, the reference will be moved to a cell in the exterior worldspace at the position provided.
 	* `position` ([tes3vector3](../../types/tes3vector3), table): The position to move the reference to.
 	* `orientation` ([tes3vector3](../../types/tes3vector3), table): *Optional*. The new orientation of the reference.
-	* `forceCellChange` (boolean): *Default*: `false`. When true, forces the game to update a reference that has moved within a single cell, as if it was moved into a new cell.
-	* `suppressFader` (boolean): *Default*: `false`. When moving the player, can be used to prevent the fade in and out visual effect.
-	* `teleportCompanions` (boolean): *Default*: `true`. If used on the player, determines if companions should also be teleported.
+	* `forceCellChange` (boolean): *Optional*. *Default*: `false`. When true, forces the game to update a reference that has moved within a single cell, as if it was moved into a new cell.
+	* `suppressFader` (boolean): *Optional*. *Default*: `false`. When moving the player, can be used to prevent the fade in and out visual effect.
+	* `teleportCompanions` (boolean): *Optional*. *Default*: `true`. If used on the player, determines if companions should also be teleported.
 
 **Returns**:
 
@@ -3648,7 +3648,7 @@ tes3.setAIEscort({ reference = ..., target = ..., destination = ..., duration = 
 	* `reference` ([tes3mobileActor](../../types/tes3mobileActor), [tes3reference](../../types/tes3reference)): The escorting actor.
 	* `target` ([tes3reference](../../types/tes3reference), [tes3mobileActor](../../types/tes3mobileActor)): The actor being escorted.
 	* `destination` ([tes3vector3](../../types/tes3vector3), table)
-	* `duration` (number): *Default*: `0`. How long the escorter will do the escorting, in hours.
+	* `duration` (number): *Optional*. *Default*: `0`. How long the escorter will do the escorting, in hours.
 	* `cell` ([tes3cell](../../types/tes3cell), string): *Optional*.
 	* `reset` (boolean): *Default*: `true`.
 
@@ -3668,7 +3668,7 @@ tes3.setAIFollow({ reference = ..., target = ..., destination = ..., duration = 
 	* `reference` ([tes3mobileActor](../../types/tes3mobileActor), [tes3reference](../../types/tes3reference)): This is the actor that will follow another one.
 	* `target` ([tes3reference](../../types/tes3reference), [tes3mobileActor](../../types/tes3mobileActor)): The actor to follow.
 	* `destination` ([tes3vector3](../../types/tes3vector3), table): *Optional*.
-	* `duration` (number): *Default*: `0`. How long the follower will follow, in hours.
+	* `duration` (number): *Optional*. *Default*: `0`. How long the follower will follow, in hours.
 	* `cell` ([tes3cell](../../types/tes3cell), string): *Optional*.
 	* `reset` (boolean): *Default*: `true`.
 
@@ -3704,9 +3704,9 @@ tes3.setAIWander({ reference = ..., idles = ..., range = ..., duration = ..., ti
 * `params` (table)
 	* `reference` ([tes3mobileActor](../../types/tes3mobileActor), [tes3reference](../../types/tes3reference)): This actor will wander around.
 	* `idles` (number[]): An array with 8 values that corresponds to the chance of playing each idle animation. For more info see [tes3aiPackageWander.idles](https://mwse.github.io/MWSE/types/tes3aiPackageWander/#idles).
-	* `range` (number): *Default*: `0`.
-	* `duration` (number): *Default*: `0`. How long the actor will be wandering around, in hours.
-	* `time` (number): *Default*: `0`.
+	* `range` (number): *Optional*. *Default*: `0`.
+	* `duration` (number): *Optional*. *Default*: `0`. How long the actor will be wandering around, in hours.
+	* `time` (number): *Optional*. *Default*: `0`.
 	* `reset` (boolean): *Default*: `true`.
 
 ***
@@ -3872,7 +3872,7 @@ tes3.setMarkLocation({ position = ..., rotation = ..., cell = ... })
 
 * `params` (table)
 	* `position` ([tes3vector3](../../types/tes3vector3)): Coordinates of the mark's position.
-	* `rotation` (number): *Default*: `Player's current rotation.`. This argument controls which direction the player's mark location will be facing.
+	* `rotation` (number): *Optional*. *Default*: `Player's current rotation.`. This argument controls which direction the player's mark location will be facing.
 	* `cell` ([tes3cell](../../types/tes3cell)): *Optional*. A cell in which the mark should be placed.
 
 ***
@@ -3889,10 +3889,10 @@ tes3.setOwner({ reference = ..., remove = ..., owner = ..., requiredGlobal = ...
 
 * `params` (table)
 	* `reference` ([tes3reference](../../types/tes3reference), [tes3mobileActor](../../types/tes3mobileActor), string): A reference whose owner to set.
-	* `remove` (boolean): *Default*: `false`. If this parameter is set to true, reference's owner field will be removed.
+	* `remove` (boolean): *Optional*. *Default*: `false`. If this parameter is set to true, reference's owner field will be removed.
 	* `owner` ([tes3npc](../../types/tes3npc), [tes3faction](../../types/tes3faction), string): Assigns this NPC or a faction as the owner of the reference.
 	* `requiredGlobal` ([tes3globalVariable](../../types/tes3globalVariable)): *Optional*. If `owner` is set to NPC, `requiredGlobal` variable can be set.
-	* `requiredRank` (number): *Default*: `0`. If `owner` is set to faction, `requitedRank` variable controls minimal rank in faction the player has to have to be able to freely take the reference.
+	* `requiredRank` (number): *Optional*. *Default*: `0`. If `owner` is set to faction, `requitedRank` variable controls minimal rank in faction the player has to have to be able to freely take the reference.
 
 ***
 
@@ -3907,12 +3907,12 @@ local changedControlState = tes3.setPlayerControlState({ enabled = ..., attack =
 **Parameters**:
 
 * `params` (table): *Optional*.
-	* `enabled` (boolean): *Default*: `false`. Setting this to false will disable any kind of control.
-	* `attack` (boolean): *Default*: `false`. If this is false, it will block player from attacking.
-	* `jumping` (boolean): *Default*: `false`. If this is false, it will block player from jumping.
-	* `magic` (boolean): *Default*: `false`. If this is false, it will block player from using magic.
-	* `vanity` (boolean): *Default*: `false`. If this is false, it will block player from going to vanity mode.
-	* `viewSwitch` (boolean): *Default*: `false`. If this is false, it will block player changing view mod from 1st to 3rd person camera and vice versa.
+	* `enabled` (boolean): *Optional*. *Default*: `false`. Setting this to false will disable any kind of control.
+	* `attack` (boolean): *Optional*. *Default*: `false`. If this is false, it will block player from attacking.
+	* `jumping` (boolean): *Optional*. *Default*: `false`. If this is false, it will block player from jumping.
+	* `magic` (boolean): *Optional*. *Default*: `false`. If this is false, it will block player from using magic.
+	* `vanity` (boolean): *Optional*. *Default*: `false`. If this is false, it will block player from going to vanity mode.
+	* `viewSwitch` (boolean): *Optional*. *Default*: `false`. If this is false, it will block player changing view mod from 1st to 3rd person camera and vice versa.
 
 **Returns**:
 
@@ -3931,7 +3931,7 @@ tes3.setSourceless(object, sourceless)
 **Parameters**:
 
 * `object` ([tes3baseObject](../../types/tes3baseObject)): The object whose sourceless flag to modify.
-* `sourceless` (boolean): *Default*: `true`. Allows flagging an object as sourceless or undoing that action.
+* `sourceless` (boolean): *Optional*. *Default*: `true`. Allows flagging an object as sourceless or undoing that action.
 
 ***
 
@@ -3990,9 +3990,9 @@ local changedVanityMode = tes3.setVanityMode({ enabled = ..., checkVanityDisable
 **Parameters**:
 
 * `params` (table): *Optional*.
-	* `enabled` (boolean): *Default*: `true`. This flag sets the vanity mode as enabled or disabled.
-	* `checkVanityDisabled` (boolean): *Default*: `true`. This will prevent changing vanity mode according to vanityDisabled flag on tes3.mobilePlayer.
-	* `toggle` (boolean): *Default*: `false`. When this flag is set to true. The vanity mode will be toggled. If the player was in vanity mode, this will make the player leave vanity mode. Conversly, if the player wasn't in the vanity mode, this will turn on the vanity mode.
+	* `enabled` (boolean): *Optional*. *Default*: `true`. This flag sets the vanity mode as enabled or disabled.
+	* `checkVanityDisabled` (boolean): *Optional*. *Default*: `true`. This will prevent changing vanity mode according to vanityDisabled flag on tes3.mobilePlayer.
+	* `toggle` (boolean): *Optional*. *Default*: `false`. When this flag is set to true. The vanity mode will be toggled. If the player was in vanity mode, this will make the player leave vanity mode. Conversly, if the player wasn't in the vanity mode, this will turn on the vanity mode.
 
 **Returns**:
 
@@ -4076,7 +4076,7 @@ tes3.showRepairServiceMenu({ serviceActor = ... })
 **Parameters**:
 
 * `params` (table): *Optional*.
-	* `serviceActor` ([tes3mobileActor](../../types/tes3mobileActor), [tes3reference](../../types/tes3reference), string): *Default*: `tes3mobilePlayer`. The actor to use for calculating the service price.
+	* `serviceActor` ([tes3mobileActor](../../types/tes3mobileActor), [tes3reference](../../types/tes3reference), string): *Optional*. *Default*: `tes3mobilePlayer`. The actor to use for calculating the service price.
 
 ***
 
@@ -4093,13 +4093,13 @@ local success = tes3.showRestMenu({ checkForEnemies = ..., checkForSolidGround =
 **Parameters**:
 
 * `params` (table): *Optional*.
-	* `checkForEnemies` (boolean): *Default*: `true`. Perform a check whether there are enemies nearby before opening rest menu. If there are, false is returned.
-	* `checkForSolidGround` (boolean): *Default*: `true`. Perform a check if the player is underwater. If underwater, false is returned.
-	* `checkSleepingIllegal` (boolean): *Default*: `true`. Perform a check if the sleeping in the current cell is illegal. If illegal, then the player will be prompted to wait instead of rest.
-	* `checkIsWerewolf` (boolean): *Default*: `true`. Perform a check if the player is Werewolf. If they are, then the player will be prompted to wait instead of rest.
-	* `showMessage` (boolean): *Default*: `true`. Should a messagebox be shown if the player can't open resting menu because some condition isn't met.
-	* `resting` (boolean): *Default*: `true`. Should this be a rest?
-	* `waiting` (boolean): *Default*: `false`. Or, is this a wait?
+	* `checkForEnemies` (boolean): *Optional*. *Default*: `true`. Perform a check whether there are enemies nearby before opening rest menu. If there are, false is returned.
+	* `checkForSolidGround` (boolean): *Optional*. *Default*: `true`. Perform a check if the player is underwater. If underwater, false is returned.
+	* `checkSleepingIllegal` (boolean): *Optional*. *Default*: `true`. Perform a check if the sleeping in the current cell is illegal. If illegal, then the player will be prompted to wait instead of rest.
+	* `checkIsWerewolf` (boolean): *Optional*. *Default*: `true`. Perform a check if the player is Werewolf. If they are, then the player will be prompted to wait instead of rest.
+	* `showMessage` (boolean): *Optional*. *Default*: `true`. Should a messagebox be shown if the player can't open resting menu because some condition isn't met.
+	* `resting` (boolean): *Optional*. *Default*: `true`. Should this be a rest?
+	* `waiting` (boolean): *Optional*. *Default*: `false`. Or, is this a wait?
 
 **Returns**:
 
@@ -4259,10 +4259,10 @@ local result = tes3.triggerCrime({ type = ..., victim = ..., value = ..., forceD
 **Parameters**:
 
 * `params` (table)
-	* `type` (number): *Default*: `tes3.crimeType.theft`. The type of crime to be committed. Maps to values in the [`tes3.crimeType`](https://mwse.github.io/MWSE/references/crime-types/) table.
-	* `victim` ([tes3mobileNPC](../../types/tes3mobileNPC), [tes3actor](../../types/tes3actor), [tes3faction](../../types/tes3faction)): *Default*: `tes3.mobilePlayer`. The victim of the crime. This can be an individual actor or a entire faction. Has no effect on crimes with a `type` of `tes3.crimeType.trespass` or `tes3.crimeType.werewolf`.
-	* `value` (number): *Default*: `0`. Only valid if `type` is `tes3.crimeType.theft`. The value of the stolen objects.
-	* `forceDetection` (boolean): *Default*: `false`. If `true`, bypasses regular detection logic and forces all nearby actors to detect the crime.
+	* `type` (number): *Optional*. *Default*: `tes3.crimeType.theft`. The type of crime to be committed. Maps to values in the [`tes3.crimeType`](https://mwse.github.io/MWSE/references/crime-types/) table.
+	* `victim` ([tes3mobileNPC](../../types/tes3mobileNPC), [tes3actor](../../types/tes3actor), [tes3faction](../../types/tes3faction)): *Optional*. *Default*: `tes3.mobilePlayer`. The victim of the crime. This can be an individual actor or a entire faction. Has no effect on crimes with a `type` of `tes3.crimeType.trespass` or `tes3.crimeType.werewolf`.
+	* `value` (number): *Optional*. *Default*: `0`. Only valid if `type` is `tes3.crimeType.theft`. The value of the stolen objects.
+	* `forceDetection` (boolean): *Optional*. *Default*: `false`. If `true`, bypasses regular detection logic and forces all nearby actors to detect the crime.
 
 **Returns**:
 

--- a/docs/source/apis/tes3ui.md
+++ b/docs/source/apis/tes3ui.md
@@ -599,9 +599,9 @@ tes3ui.showDialogueMessage({ text = ..., style = ..., answerIndex = ... })
 **Parameters**:
 
 * `params` (table)
-	* `text` (string): *Default*: ``. The text of the shown message.
-	* `style` (number): *Default*: `0`. This argument controls the text color of the message. Value `0` makes the message text the same color as the text in the dialogue window. Value `1` makes the text white, and also print a newline after the message. Value `2` turns the message into a selectable text inside the dialogue window. Value `3` looks the same as `1` but there isn't a newline after each message. Value `4` is the same as value `1`. All the other values work as `0`.
-	* `answerIndex` (number): *Default*: `0`. This number can be used later to identify which response was selected.
+	* `text` (string): *Optional*. *Default*: ``. The text of the shown message.
+	* `style` (number): *Optional*. *Default*: `0`. This argument controls the text color of the message. Value `0` makes the message text the same color as the text in the dialogue window. Value `1` makes the text white, and also print a newline after the message. Value `2` turns the message into a selectable text inside the dialogue window. Value `3` looks the same as `1` but there isn't a newline after each message. Value `4` is the same as value `1`. All the other values work as `0`.
+	* `answerIndex` (number): *Optional*. *Default*: `0`. This number can be used later to identify which response was selected.
 
 ***
 
@@ -616,7 +616,7 @@ tes3ui.showInventorySelectMenu({ reference = ..., title = ..., leaveMenuMode = .
 **Parameters**:
 
 * `params` (table)
-	* `reference` ([tes3reference](../../types/tes3reference)): *Default*: `tes3player`. The reference of a `tes3actor` whose inventory will be used.
+	* `reference` ([tes3reference](../../types/tes3reference)): *Optional*. *Default*: `tes3player`. The reference of a `tes3actor` whose inventory will be used.
 	* `title` (string): The text used for the title of the inventory select menu.
 	* `leaveMenuMode` (boolean): *Optional*. Determines if menu mode should be exited after closing the inventory select menu. By default, it will be in the state it was in before this function was called.
 	* `noResultsText` (string): *Optional*. The text used for the message that gets shown to the player if no items have been found in the inventory. The default text is equivalent to the `sInventorySelectNoItems` GMST value, unless `"ingredients"` or `"soulgemFilled"` has been assigned to `filter`, in which case the default text is equivalent to either the `sInventorySelectNoIngredients` or `sInventorySelectNoSoul` GMST value respectively.

--- a/docs/source/apis/timer.md
+++ b/docs/source/apis/timer.md
@@ -58,7 +58,7 @@ local timer = timer.delayOneFrame(callback, type)
 **Parameters**:
 
 * `callback` (function): The callback function that will execute when the timer expires.
-* `type` (number): *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.
+* `type` (number): *Optional*. *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.
 
 **Returns**:
 
@@ -114,11 +114,11 @@ local timer = timer.start({ type = ..., duration = ..., callback = ..., iteratio
 **Parameters**:
 
 * `params` (table)
-	* `type` (number): *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.
+	* `type` (number): *Optional*. *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.
 	* `duration` (number): Duration of the timer. The method of time passing depends on the timer type.
 	* `callback` (function): The callback function that will execute when the timer expires.
-	* `iterations` (number): *Default*: `1`. The number of iterations to run. Use `-1` for infinite looping.
-	* `persist` (boolean): *Default*: `true`. Registering a timer with persist flag set to `true` will serialize the callback string in the save to persist between sessions. Only a registered timer will persist between sessions. See `timer.register()`.
+	* `iterations` (number): *Optional*. *Default*: `1`. The number of iterations to run. Use `-1` for infinite looping.
+	* `persist` (boolean): *Optional*. *Default*: `true`. Registering a timer with persist flag set to `true` will serialize the callback string in the save to persist between sessions. Only a registered timer will persist between sessions. See `timer.register()`.
 	* `data` (table): *Optional*. Data to be attached to the timer. If this is a persistent timer, the data must be json-serializable, matching the same limitations as data stored on references.
 
 **Returns**:

--- a/docs/source/types/niAVObject.md
+++ b/docs/source/types/niAVObject.md
@@ -350,7 +350,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -532,9 +532,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -635,9 +635,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niAlphaProperty.md
+++ b/docs/source/types/niAlphaProperty.md
@@ -140,7 +140,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/niAmbientLight.md
+++ b/docs/source/types/niAmbientLight.md
@@ -450,7 +450,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -632,9 +632,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -735,9 +735,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niBillboardNode.md
+++ b/docs/source/types/niBillboardNode.md
@@ -311,7 +311,7 @@ myObject:attachChild(child, useFirstAvailable)
 **Parameters**:
 
 * `child` ([niAVObject](../../types/niAVObject))
-* `useFirstAvailable` (boolean): *Default*: `false`. Use the first available space in the list. If `false` appends the child at the end of the list.
+* `useFirstAvailable` (boolean): *Optional*. *Default*: `false`. Use the first available space in the list. If `false` appends the child at the end of the list.
 
 ***
 
@@ -495,7 +495,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -677,9 +677,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -794,9 +794,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niCamera.md
+++ b/docs/source/types/niCamera.md
@@ -400,7 +400,7 @@ myObject:click(something)
 
 **Parameters**:
 
-* `something` (boolean): *Default*: `false`.
+* `something` (boolean): *Optional*. *Default*: `false`.
 
 ***
 
@@ -464,7 +464,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -646,9 +646,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -749,9 +749,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niCollisionSwitch.md
+++ b/docs/source/types/niCollisionSwitch.md
@@ -307,7 +307,7 @@ myObject:attachChild(child, useFirstAvailable)
 **Parameters**:
 
 * `child` ([niAVObject](../../types/niAVObject))
-* `useFirstAvailable` (boolean): *Default*: `false`. Use the first available space in the list. If `false` appends the child at the end of the list.
+* `useFirstAvailable` (boolean): *Optional*. *Default*: `false`. Use the first available space in the list. If `false` appends the child at the end of the list.
 
 ***
 
@@ -491,7 +491,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -673,9 +673,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -776,9 +776,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niColor.md
+++ b/docs/source/types/niColor.md
@@ -140,9 +140,9 @@ local color = niColor.new(r, g, b)
 
 **Parameters**:
 
-* `r` (number): *Default*: `0`. The red value for the color.
-* `g` (number): *Default*: `0`. The green value for the color.
-* `b` (number): *Default*: `0`. The blue value for the color.
+* `r` (number): *Optional*. *Default*: `0`. The red value for the color.
+* `g` (number): *Optional*. *Default*: `0`. The green value for the color.
+* `b` (number): *Optional*. *Default*: `0`. The blue value for the color.
 
 **Returns**:
 

--- a/docs/source/types/niColorA.md
+++ b/docs/source/types/niColorA.md
@@ -136,10 +136,10 @@ local color = niColorA.new(r, g, b, a)
 
 **Parameters**:
 
-* `r` (number): *Default*: `0`. The red value for the color.
-* `g` (number): *Default*: `0`. The green value for the color.
-* `b` (number): *Default*: `0`. The blue value for the color.
-* `a` (number): *Default*: `0`. The alpha value for the color.
+* `r` (number): *Optional*. *Default*: `0`. The red value for the color.
+* `g` (number): *Optional*. *Default*: `0`. The green value for the color.
+* `b` (number): *Optional*. *Default*: `0`. The blue value for the color.
+* `a` (number): *Optional*. *Default*: `0`. The alpha value for the color.
 
 **Returns**:
 

--- a/docs/source/types/niDirectionalLight.md
+++ b/docs/source/types/niDirectionalLight.md
@@ -460,7 +460,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -642,9 +642,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -745,9 +745,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niDynamicEffect.md
+++ b/docs/source/types/niDynamicEffect.md
@@ -408,7 +408,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -590,9 +590,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -693,9 +693,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niFogProperty.md
+++ b/docs/source/types/niFogProperty.md
@@ -150,7 +150,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/niGeometry.md
+++ b/docs/source/types/niGeometry.md
@@ -351,7 +351,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -533,9 +533,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -636,9 +636,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niLight.md
+++ b/docs/source/types/niLight.md
@@ -450,7 +450,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -632,9 +632,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -735,9 +735,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niMaterialProperty.md
+++ b/docs/source/types/niMaterialProperty.md
@@ -190,7 +190,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/niNode.md
+++ b/docs/source/types/niNode.md
@@ -297,7 +297,7 @@ myObject:attachChild(child, useFirstAvailable)
 **Parameters**:
 
 * `child` ([niAVObject](../../types/niAVObject))
-* `useFirstAvailable` (boolean): *Default*: `false`. Use the first available space in the list. If `false` appends the child at the end of the list.
+* `useFirstAvailable` (boolean): *Optional*. *Default*: `false`. Use the first available space in the list. If `false` appends the child at the end of the list.
 
 ***
 
@@ -481,7 +481,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -663,9 +663,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -766,9 +766,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niObjectNET.md
+++ b/docs/source/types/niObjectNET.md
@@ -110,7 +110,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/niPackedColor.md
+++ b/docs/source/types/niPackedColor.md
@@ -101,10 +101,10 @@ local color = niPackedColor.new(r, g, b, a)
 
 **Parameters**:
 
-* `r` (number): *Default*: `0`. The red value for the color.
-* `g` (number): *Default*: `0`. The green value for the color.
-* `b` (number): *Default*: `0`. The blue value for the color.
-* `a` (number): *Default*: `0`. The alpha value for the color.
+* `r` (number): *Optional*. *Default*: `0`. The red value for the color.
+* `g` (number): *Optional*. *Default*: `0`. The green value for the color.
+* `b` (number): *Optional*. *Default*: `0`. The blue value for the color.
+* `a` (number): *Optional*. *Default*: `0`. The alpha value for the color.
 
 **Returns**:
 

--- a/docs/source/types/niParticles.md
+++ b/docs/source/types/niParticles.md
@@ -360,7 +360,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -542,9 +542,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -645,9 +645,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niPixelData.md
+++ b/docs/source/types/niPixelData.md
@@ -101,7 +101,7 @@ myObject:fill(data, mipMapLevel)
 **Parameters**:
 
 * `data` (number[]): The color data to be set (1-indexed). The values should be in range [0.0, 1.0]. The first three values are RGB color channels, while the last one is alpha channel. The array length must be equal to the `bytesPerPixel` property of this niPixelData object, because alpha can be assigned only to the niPixelData object that has an alpha channel.
-* `mipMapLevel` (number): *Default*: `0`. The mipmap level to fill with the provided color. The finest (largest) mipmap level is level 0.
+* `mipMapLevel` (number): *Optional*. *Default*: `0`. The mipmap level to fill with the provided color. The finest (largest) mipmap level is level 0.
 
 ***
 
@@ -115,7 +115,7 @@ local result = myObject:getHeight(mipMapLevel)
 
 **Parameters**:
 
-* `mipMapLevel` (number): *Default*: `0`.
+* `mipMapLevel` (number): *Optional*. *Default*: `0`.
 
 **Returns**:
 
@@ -133,7 +133,7 @@ local result = myObject:getWidth(mipMapLevel)
 
 **Parameters**:
 
-* `mipMapLevel` (number): *Default*: `0`.
+* `mipMapLevel` (number): *Optional*. *Default*: `0`.
 
 **Returns**:
 
@@ -206,7 +206,7 @@ myObject:setPixelsByte(data, mipMapLevel)
 **Parameters**:
 
 * `data` (number[]): The byte data to be set to (1-indexed).
-* `mipMapLevel` (number): *Default*: `0`. The mipmap level whose data to modify. The finest (largest) mipmap level is level 0.
+* `mipMapLevel` (number): *Optional*. *Default*: `0`. The mipmap level whose data to modify. The finest (largest) mipmap level is level 0.
 
 ***
 
@@ -221,7 +221,7 @@ myObject:setPixelsFloat(data, mipMapLevel)
 **Parameters**:
 
 * `data` (number[]): The float data to be set to (1-indexed). The values should be in range [0.0, 1.0].
-* `mipMapLevel` (number): *Default*: `0`. The mipmap level whose data to modify. The finest (largest) mipmap level is level 0.
+* `mipMapLevel` (number): *Optional*. *Default*: `0`. The mipmap level whose data to modify. The finest (largest) mipmap level is level 0.
 
 ***
 
@@ -239,7 +239,7 @@ local pixelData = niPixelData.new(width, height, mipMapLevels)
 
 * `width` (number)
 * `height` (number)
-* `mipMapLevels` (number): *Default*: `1`.
+* `mipMapLevels` (number): *Optional*. *Default*: `1`.
 
 **Returns**:
 

--- a/docs/source/types/niPointLight.md
+++ b/docs/source/types/niPointLight.md
@@ -480,7 +480,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -662,9 +662,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -793,9 +793,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niProperty.md
+++ b/docs/source/types/niProperty.md
@@ -130,7 +130,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/niQuaternion.md
+++ b/docs/source/types/niQuaternion.md
@@ -168,10 +168,10 @@ local quaternion = niQuaternion.new(w, x, y, z)
 
 **Parameters**:
 
-* `w` (number): *Default*: `0`.
-* `x` (number): *Default*: `0`.
-* `y` (number): *Default*: `0`.
-* `z` (number): *Default*: `0`.
+* `w` (number): *Optional*. *Default*: `0`.
+* `x` (number): *Optional*. *Default*: `0`.
+* `y` (number): *Optional*. *Default*: `0`.
+* `z` (number): *Optional*. *Default*: `0`.
 
 **Returns**:
 

--- a/docs/source/types/niRotatingParticles.md
+++ b/docs/source/types/niRotatingParticles.md
@@ -360,7 +360,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -542,9 +542,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -645,9 +645,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niSourceTexture.md
+++ b/docs/source/types/niSourceTexture.md
@@ -190,7 +190,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/niSpotLight.md
+++ b/docs/source/types/niSpotLight.md
@@ -510,7 +510,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -692,9 +692,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -823,9 +823,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niStencilProperty.md
+++ b/docs/source/types/niStencilProperty.md
@@ -240,7 +240,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/niSwitchNode.md
+++ b/docs/source/types/niSwitchNode.md
@@ -307,7 +307,7 @@ myObject:attachChild(child, useFirstAvailable)
 **Parameters**:
 
 * `child` ([niAVObject](../../types/niAVObject))
-* `useFirstAvailable` (boolean): *Default*: `false`. Use the first available space in the list. If `false` appends the child at the end of the list.
+* `useFirstAvailable` (boolean): *Optional*. *Default*: `false`. Use the first available space in the list. If `false` appends the child at the end of the list.
 
 ***
 
@@ -505,7 +505,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -687,9 +687,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -790,9 +790,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niTexture.md
+++ b/docs/source/types/niTexture.md
@@ -140,7 +140,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/niTextureEffect.md
+++ b/docs/source/types/niTextureEffect.md
@@ -420,7 +420,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -602,9 +602,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -705,9 +705,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niTexturingProperty.md
+++ b/docs/source/types/niTexturingProperty.md
@@ -249,7 +249,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/niTriBasedGeometry.md
+++ b/docs/source/types/niTriBasedGeometry.md
@@ -350,7 +350,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -532,9 +532,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -635,9 +635,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niTriShape.md
+++ b/docs/source/types/niTriShape.md
@@ -404,7 +404,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 
@@ -586,9 +586,9 @@ myObject:propagatePositionChange({ time = ..., controllers = ..., bounds = ... }
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 
@@ -689,9 +689,9 @@ myObject:update({ time = ..., controllers = ..., bounds = ... })
 **Parameters**:
 
 * `args` (table): *Optional*.
-	* `time` (number): *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
-	* `controllers` (boolean): *Default*: `false`. Update object's controllers?
-	* `bounds` (boolean): *Default*: `true`. Update object's bounds?
+	* `time` (number): *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+	* `controllers` (boolean): *Optional*. *Default*: `false`. Update object's controllers?
+	* `bounds` (boolean): *Optional*. *Default*: `true`. Update object's bounds?
 
 ***
 

--- a/docs/source/types/niTriShapeData.md
+++ b/docs/source/types/niTriShapeData.md
@@ -187,9 +187,9 @@ local copiedData = myObject:copy({ normals = ..., colors = ..., texCoords = ... 
 **Parameters**:
 
 * `filters` (table): *Optional*.
-	* `normals` (boolean): *Default*: `true`. If false, the geometry data's normals will be absent from the copy.
-	* `colors` (boolean): *Default*: `true`. If false, the geometry data's colors will be absent from the copy.
-	* `texCoords` (boolean): *Default*: `true`. If false, the geometry data's texture coordinates will be absent from the copy.
+	* `normals` (boolean): *Optional*. *Default*: `true`. If false, the geometry data's normals will be absent from the copy.
+	* `colors` (boolean): *Optional*. *Default*: `true`. If false, the geometry data's colors will be absent from the copy.
+	* `texCoords` (boolean): *Optional*. *Default*: `true`. If false, the geometry data's texture coordinates will be absent from the copy.
 
 **Returns**:
 

--- a/docs/source/types/niVertexColorProperty.md
+++ b/docs/source/types/niVertexColorProperty.md
@@ -161,7 +161,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/niZBufferProperty.md
+++ b/docs/source/types/niZBufferProperty.md
@@ -152,7 +152,7 @@ local reference = myObject:getGameReference(searchParents)
 
 **Parameters**:
 
-* `searchParents` (boolean): *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+* `searchParents` (boolean): *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 
 **Returns**:
 

--- a/docs/source/types/tes3audioController.md
+++ b/docs/source/types/tes3audioController.md
@@ -183,8 +183,8 @@ myObject:changeMusicTrack({ filename = ..., crossfade = ..., volume = ... })
 
 * `params` (table)
 	* `filename` (string): File name of the new music track.
-	* `crossfade` (number): *Default*: `1000`. Duration of the crossfading between music tracks. Measured in miliseconds.
-	* `volume` (number): *Default*: `1`. Allows changing the volume of the music track.
+	* `crossfade` (number): *Optional*. *Default*: `1000`. Duration of the crossfading between music tracks. Measured in miliseconds.
+	* `volume` (number): *Optional*. *Default*: `1`. Allows changing the volume of the music track.
 
 ***
 

--- a/docs/source/types/tes3bodyPartManager.md
+++ b/docs/source/types/tes3bodyPartManager.md
@@ -129,8 +129,8 @@ myObject:setActivePartData(layer, index, overwriteData, node)
 
 * `layer` (number): A value from [`tes3.activeBodyPartLayer`](https://mwse.github.io/MWSE/references/active-body-part-layers/) namespace.
 * `index` (number): A value from [`tes3.activeBodyPart`](https://mwse.github.io/MWSE/references/active-body-parts/) namespace.
-* `overwriteData` (boolean): *Default*: `true`. A flag which controls whether the current data should be overwritten.
-* `node` ([niNode](../../types/niNode)): *Default*: `nil`. 
+* `overwriteData` (boolean): *Optional*. *Default*: `true`. A flag which controls whether the current data should be overwritten.
+* `node` ([niNode](../../types/niNode)): *Optional*. *Default*: `nil`. 
 
 ***
 
@@ -147,7 +147,7 @@ myObject:setBodyPartByIdForObject(object, index, bodyPartId, isFirstPerson)
 * `object` ([tes3physicalObject](../../types/tes3physicalObject)): An object whose body part to set.
 * `index` (number): A value from [`tes3.activeBodyPart`](https://mwse.github.io/MWSE/references/active-body-parts/) namespace.
 * `bodyPartId` (string): The unique ID of the `tes3bodyPart` object to set as a new body part for given object.
-* `isFirstPerson` (boolean): *Default*: `false`. A flag which controls whether the body part is used in first person.
+* `isFirstPerson` (boolean): *Optional*. *Default*: `false`. A flag which controls whether the body part is used in first person.
 
 ***
 
@@ -164,7 +164,7 @@ myObject:setBodyPartForObject(object, index, bodyPart, isFirstPerson)
 * `object` ([tes3physicalObject](../../types/tes3physicalObject)): An object whose body part to set.
 * `index` (number): A value from [`tes3.activeBodyPart`](https://mwse.github.io/MWSE/references/active-body-parts/) namespace.
 * `bodyPart` ([tes3bodyPart](../../types/tes3bodyPart)): The `tes3bodyPart` object to set as a new body part for given object.
-* `isFirstPerson` (boolean): *Default*: `false`. A flag which controls whether the body part is used in first person.
+* `isFirstPerson` (boolean): *Optional*. *Default*: `false`. A flag which controls whether the body part is used in first person.
 
 ***
 

--- a/docs/source/types/tes3dataHandler.md
+++ b/docs/source/types/tes3dataHandler.md
@@ -232,9 +232,9 @@ myObject:updateCollisionGroupsForActiveCells({ force = ..., isResettingData = ..
 **Parameters**:
 
 * `params` (table)
-	* `force` (boolean): *Default*: `true`.
-	* `isResettingData` (boolean): *Default*: `false`.
-	* `resetCollisionGroups` (boolean): *Default*: `true`.
+	* `force` (boolean): *Optional*. *Default*: `true`.
+	* `isResettingData` (boolean): *Optional*. *Default*: `false`.
+	* `resetCollisionGroups` (boolean): *Optional*. *Default*: `true`.
 
 ***
 

--- a/docs/source/types/tes3fader.md
+++ b/docs/source/types/tes3fader.md
@@ -99,7 +99,7 @@ local result = myObject:setColor({ color = ..., flag = ... })
 
 * `params` (table)
 	* `color` ([tes3vector3](../../types/tes3vector3), table): The RGB values to set in [0.0, 1.0] range.
-	* `flag` (boolean): *Default*: `false`.
+	* `flag` (boolean): *Optional*. *Default*: `false`.
 
 **Returns**:
 
@@ -158,7 +158,7 @@ local fader = tes3fader.new(distance, unknownBool)
 **Parameters**:
 
 * `distance` (number): *Optional*. If no distance is provided, a distance will be calculated based on current amount of faders, `tes3.worldController.projectionDistance` and crosshair node's `translation.y`.
-* `unknownBool` (boolean): *Default*: `true`.
+* `unknownBool` (boolean): *Optional*. *Default*: `true`.
 
 **Returns**:
 

--- a/docs/source/types/tes3magicSourceInstance.md
+++ b/docs/source/types/tes3magicSourceInstance.md
@@ -337,7 +337,7 @@ myObject:playVisualEffect({ effectIndex = ..., position = ..., visual = ..., sca
 	* `effectIndex` (number): The index in the effect whose visual will be played, a number in range [0, 7].
 	* `position` ([tes3vector3](../../types/tes3vector3), table): A table or a `tes3vector3` holding `x`, `y` and `z` coordinates at which the visual effect will be played.
 	* `visual` ([tes3physicalObject](../../types/tes3physicalObject), string): The visual effect to be played.
-	* `scale` (number): *Default*: `1`. The scale of the effect. Only applies to effects that are designed to be scaled.
+	* `scale` (number): *Optional*. *Default*: `1`. The scale of the effect. Only applies to effects that are designed to be scaled.
 	* `reference` ([tes3reference](../../types/tes3reference), string): A reference on which the visual effect will be played.
 
 ??? example "Example: Plays the soul trap effect if the player kills a target that is affected by vampirism."

--- a/docs/source/types/tes3matrix33.md
+++ b/docs/source/types/tes3matrix33.md
@@ -279,15 +279,15 @@ local matrix = tes3matrix33.new(x0, y0, z0, x1, y1, z1, x2, y2, z2, x, y, z)
 
 **Parameters**:
 
-* `x0` (number): *Default*: `0`.
-* `y0` (number): *Default*: `0`.
-* `z0` (number): *Default*: `0`.
-* `x1` (number): *Default*: `0`.
-* `y1` (number): *Default*: `0`.
-* `z1` (number): *Default*: `0`.
-* `x2` (number): *Default*: `0`.
-* `y2` (number): *Default*: `0`.
-* `z2` (number): *Default*: `0`.
+* `x0` (number): *Optional*. *Default*: `0`.
+* `y0` (number): *Optional*. *Default*: `0`.
+* `z0` (number): *Optional*. *Default*: `0`.
+* `x1` (number): *Optional*. *Default*: `0`.
+* `y1` (number): *Optional*. *Default*: `0`.
+* `z1` (number): *Optional*. *Default*: `0`.
+* `x2` (number): *Optional*. *Default*: `0`.
+* `y2` (number): *Optional*. *Default*: `0`.
+* `z2` (number): *Optional*. *Default*: `0`.
 * `x` ([tes3vector3](../../types/tes3vector3)): *Optional*.
 * `y` ([tes3vector3](../../types/tes3vector3)): *Optional*.
 * `z` ([tes3vector3](../../types/tes3vector3)): *Optional*.

--- a/docs/source/types/tes3matrix44.md
+++ b/docs/source/types/tes3matrix44.md
@@ -87,22 +87,22 @@ local matrix = tes3matrix44.new(w0, x0, y0, z0, w1, x1, y1, z1, w2, x2, y2, z2, 
 
 **Parameters**:
 
-* `w0` (number): *Default*: `0`.
-* `x0` (number): *Default*: `0`.
-* `y0` (number): *Default*: `0`.
-* `z0` (number): *Default*: `0`.
-* `w1` (number): *Default*: `0`.
-* `x1` (number): *Default*: `0`.
-* `y1` (number): *Default*: `0`.
-* `z1` (number): *Default*: `0`.
-* `w2` (number): *Default*: `0`.
-* `x2` (number): *Default*: `0`.
-* `y2` (number): *Default*: `0`.
-* `z2` (number): *Default*: `0`.
-* `w3` (number): *Default*: `0`.
-* `x3` (number): *Default*: `0`.
-* `y3` (number): *Default*: `0`.
-* `z3` (number): *Default*: `0`.
+* `w0` (number): *Optional*. *Default*: `0`.
+* `x0` (number): *Optional*. *Default*: `0`.
+* `y0` (number): *Optional*. *Default*: `0`.
+* `z0` (number): *Optional*. *Default*: `0`.
+* `w1` (number): *Optional*. *Default*: `0`.
+* `x1` (number): *Optional*. *Default*: `0`.
+* `y1` (number): *Optional*. *Default*: `0`.
+* `z1` (number): *Optional*. *Default*: `0`.
+* `w2` (number): *Optional*. *Default*: `0`.
+* `x2` (number): *Optional*. *Default*: `0`.
+* `y2` (number): *Optional*. *Default*: `0`.
+* `z2` (number): *Optional*. *Default*: `0`.
+* `w3` (number): *Optional*. *Default*: `0`.
+* `x3` (number): *Optional*. *Default*: `0`.
+* `y3` (number): *Optional*. *Default*: `0`.
+* `z3` (number): *Optional*. *Default*: `0`.
 * `w` ([tes3vector4](../../types/tes3vector4)): *Optional*.
 * `x` ([tes3vector4](../../types/tes3vector4)): *Optional*.
 * `y` ([tes3vector4](../../types/tes3vector4)): *Optional*.

--- a/docs/source/types/tes3mobileActor.md
+++ b/docs/source/types/tes3mobileActor.md
@@ -1428,8 +1428,8 @@ local result = myObject:doJump({ velocity = ..., applyFatigueCost = ..., allowMi
 
 * `params` (table): *Optional*.
 	* `velocity` ([tes3vector3](../../types/tes3vector3)): *Optional*. The initial velocity of the jump. If not specified, the velocity of a regular jump without movement will be used.
-	* `applyFatigueCost` (boolean): *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
-	* `allowMidairJumping` (boolean): *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
+	* `applyFatigueCost` (boolean): *Optional*. *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
+	* `allowMidairJumping` (boolean): *Optional*. *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
 
 **Returns**:
 
@@ -1478,8 +1478,8 @@ local result = myObject:equipMagic({ source = ..., itemData = ..., equipItem = .
 		Items must have a castable enchantment. Castable enchantments have a `castType` of `tes3.enchantmentType.onUse` or `tes3.enchantmentType.castOnce`. The actor is not required to have this item in their inventory, unless `equipItem` is `true`.
 
 	* `itemData` ([tes3itemData](../../types/tes3itemData)): *Optional*. Only valid if an item has been assigned to `source`. The item data of the specific item to equip.
-	* `equipItem` (boolean): *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
-	* `updateGUI` (boolean): *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+	* `equipItem` (boolean): *Optional*. *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
+	* `updateGUI` (boolean): *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 
 **Returns**:
 
@@ -1795,8 +1795,8 @@ myObject:unequipMagic({ unequipItem = ..., updateGUI = ... })
 **Parameters**:
 
 * `params` (table): *Optional*.
-	* `unequipItem` (boolean): *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
-	* `updateGUI` (boolean): *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+	* `unequipItem` (boolean): *Optional*. *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
+	* `updateGUI` (boolean): *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 
 ***
 

--- a/docs/source/types/tes3mobileCreature.md
+++ b/docs/source/types/tes3mobileCreature.md
@@ -1538,8 +1538,8 @@ local result = myObject:doJump({ velocity = ..., applyFatigueCost = ..., allowMi
 
 * `params` (table): *Optional*.
 	* `velocity` ([tes3vector3](../../types/tes3vector3)): *Optional*. The initial velocity of the jump. If not specified, the velocity of a regular jump without movement will be used.
-	* `applyFatigueCost` (boolean): *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
-	* `allowMidairJumping` (boolean): *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
+	* `applyFatigueCost` (boolean): *Optional*. *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
+	* `allowMidairJumping` (boolean): *Optional*. *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
 
 **Returns**:
 
@@ -1588,8 +1588,8 @@ local result = myObject:equipMagic({ source = ..., itemData = ..., equipItem = .
 		Items must have a castable enchantment. Castable enchantments have a `castType` of `tes3.enchantmentType.onUse` or `tes3.enchantmentType.castOnce`. The actor is not required to have this item in their inventory, unless `equipItem` is `true`.
 
 	* `itemData` ([tes3itemData](../../types/tes3itemData)): *Optional*. Only valid if an item has been assigned to `source`. The item data of the specific item to equip.
-	* `equipItem` (boolean): *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
-	* `updateGUI` (boolean): *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+	* `equipItem` (boolean): *Optional*. *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
+	* `updateGUI` (boolean): *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 
 **Returns**:
 
@@ -1905,8 +1905,8 @@ myObject:unequipMagic({ unequipItem = ..., updateGUI = ... })
 **Parameters**:
 
 * `params` (table): *Optional*.
-	* `unequipItem` (boolean): *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
-	* `updateGUI` (boolean): *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+	* `unequipItem` (boolean): *Optional*. *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
+	* `updateGUI` (boolean): *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 
 ***
 

--- a/docs/source/types/tes3mobileNPC.md
+++ b/docs/source/types/tes3mobileNPC.md
@@ -1818,8 +1818,8 @@ local result = myObject:doJump({ velocity = ..., applyFatigueCost = ..., allowMi
 
 * `params` (table): *Optional*.
 	* `velocity` ([tes3vector3](../../types/tes3vector3)): *Optional*. The initial velocity of the jump. If not specified, the velocity of a regular jump without movement will be used.
-	* `applyFatigueCost` (boolean): *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
-	* `allowMidairJumping` (boolean): *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
+	* `applyFatigueCost` (boolean): *Optional*. *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
+	* `allowMidairJumping` (boolean): *Optional*. *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
 
 **Returns**:
 
@@ -1868,8 +1868,8 @@ local result = myObject:equipMagic({ source = ..., itemData = ..., equipItem = .
 		Items must have a castable enchantment. Castable enchantments have a `castType` of `tes3.enchantmentType.onUse` or `tes3.enchantmentType.castOnce`. The actor is not required to have this item in their inventory, unless `equipItem` is `true`.
 
 	* `itemData` ([tes3itemData](../../types/tes3itemData)): *Optional*. Only valid if an item has been assigned to `source`. The item data of the specific item to equip.
-	* `equipItem` (boolean): *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
-	* `updateGUI` (boolean): *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+	* `equipItem` (boolean): *Optional*. *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
+	* `updateGUI` (boolean): *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 
 **Returns**:
 
@@ -2185,8 +2185,8 @@ myObject:unequipMagic({ unequipItem = ..., updateGUI = ... })
 **Parameters**:
 
 * `params` (table): *Optional*.
-	* `unequipItem` (boolean): *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
-	* `updateGUI` (boolean): *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+	* `unequipItem` (boolean): *Optional*. *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
+	* `updateGUI` (boolean): *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 
 ***
 

--- a/docs/source/types/tes3mobilePlayer.md
+++ b/docs/source/types/tes3mobilePlayer.md
@@ -2207,8 +2207,8 @@ local result = myObject:doJump({ velocity = ..., applyFatigueCost = ..., allowMi
 
 * `params` (table): *Optional*.
 	* `velocity` ([tes3vector3](../../types/tes3vector3)): *Optional*. The initial velocity of the jump. If not specified, the velocity of a regular jump without movement will be used.
-	* `applyFatigueCost` (boolean): *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
-	* `allowMidairJumping` (boolean): *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
+	* `applyFatigueCost` (boolean): *Optional*. *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
+	* `allowMidairJumping` (boolean): *Optional*. *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
 
 **Returns**:
 
@@ -2257,8 +2257,8 @@ local result = myObject:equipMagic({ source = ..., itemData = ..., equipItem = .
 		Items must have a castable enchantment. Castable enchantments have a `castType` of `tes3.enchantmentType.onUse` or `tes3.enchantmentType.castOnce`. The actor is not required to have this item in their inventory, unless `equipItem` is `true`.
 
 	* `itemData` ([tes3itemData](../../types/tes3itemData)): *Optional*. Only valid if an item has been assigned to `source`. The item data of the specific item to equip.
-	* `equipItem` (boolean): *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
-	* `updateGUI` (boolean): *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+	* `equipItem` (boolean): *Optional*. *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
+	* `updateGUI` (boolean): *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 
 **Returns**:
 
@@ -2639,8 +2639,8 @@ myObject:unequipMagic({ unequipItem = ..., updateGUI = ... })
 **Parameters**:
 
 * `params` (table): *Optional*.
-	* `unequipItem` (boolean): *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
-	* `updateGUI` (boolean): *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+	* `unequipItem` (boolean): *Optional*. *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
+	* `updateGUI` (boolean): *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 
 ***
 

--- a/docs/source/types/tes3uiElement.md
+++ b/docs/source/types/tes3uiElement.md
@@ -602,8 +602,8 @@ local copy = myObject:copy({ to = ..., copyChildren = ..., copyProperties = ... 
 
 * `params` (table)
 	* `to` ([tes3uiElement](../../types/tes3uiElement)): The element to create the copy in. Will be the parent of the newly created element.
-	* `copyChildren` (boolean): *Default*: `true`. If `true`, all children will also be copied to the newly created element.
-	* `copyProperties` (boolean): *Default*: `true`. If `true`, all properties will be copied to the newly created element.
+	* `copyChildren` (boolean): *Optional*. *Default*: `true`. If `true`, all children will also be copied to the newly created element.
+	* `copyProperties` (boolean): *Optional*. *Default*: `true`. If `true`, all properties will be copied to the newly created element.
 
 **Returns**:
 
@@ -921,8 +921,8 @@ local result = myObject:createSlider({ id = ..., current = ..., max = ..., step 
 	* `id` (string, number): *Optional*. An identifier to help find this element later.
 	* `current` (number): The current value of the slider.
 	* `max` (number): The maximum value of the slider.
-	* `step` (number): *Default*: `1`. The change in value when clicking the left and right arrow buttons.
-	* `jump` (number): *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
+	* `step` (number): *Optional*. *Default*: `1`. The change in value when clicking the left and right arrow buttons.
+	* `jump` (number): *Optional*. *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
 
 **Returns**:
 
@@ -946,8 +946,8 @@ local result = myObject:createSliderVertical({ id = ..., current = ..., max = ..
 	* `id` (string, number): *Optional*. An identifier to help find this element later.
 	* `current` (number): The current value of the slider.
 	* `max` (number): The maximum value of the slider.
-	* `step` (number): *Default*: `1`. The change in value when clicking the left and right arrow buttons.
-	* `jump` (number): *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
+	* `step` (number): *Optional*. *Default*: `1`. The change in value when clicking the left and right arrow buttons.
+	* `jump` (number): *Optional*. *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
 
 **Returns**:
 
@@ -995,7 +995,7 @@ local result = myObject:createTextSelect({ id = ..., text = ..., state = ... })
 * `params` (table): *Optional*.
 	* `id` (string, number): *Optional*. An identifier to help find this element later.
 	* `text` (string): *Optional*. The text to display.
-	* `state` (number): *Default*: `tes3.uiState.normal`. The initial interaction state.
+	* `state` (number): *Optional*. *Default*: `tes3.uiState.normal`. The initial interaction state.
 
 **Returns**:
 

--- a/docs/source/types/tes3vector2.md
+++ b/docs/source/types/tes3vector2.md
@@ -99,8 +99,8 @@ local vector = tes3vector2.new(x, y)
 
 **Parameters**:
 
-* `x` (number): *Default*: `0`.
-* `y` (number): *Default*: `0`.
+* `x` (number): *Optional*. *Default*: `0`.
+* `y` (number): *Optional*. *Default*: `0`.
 
 **Returns**:
 

--- a/docs/source/types/tes3vector3.md
+++ b/docs/source/types/tes3vector3.md
@@ -301,9 +301,9 @@ local vector = tes3vector3.new(x, y, z)
 
 **Parameters**:
 
-* `x` (number): *Default*: `0`.
-* `y` (number): *Default*: `0`.
-* `z` (number): *Default*: `0`.
+* `x` (number): *Optional*. *Default*: `0`.
+* `y` (number): *Optional*. *Default*: `0`.
+* `z` (number): *Optional*. *Default*: `0`.
 
 **Returns**:
 

--- a/docs/source/types/tes3vector4.md
+++ b/docs/source/types/tes3vector4.md
@@ -91,10 +91,10 @@ local vector = tes3vector4.new(x, y, z, w)
 
 **Parameters**:
 
-* `x` (number): *Default*: `0`.
-* `y` (number): *Default*: `0`.
-* `z` (number): *Default*: `0`.
-* `w` (number): *Default*: `0`.
+* `x` (number): *Optional*. *Default*: `0`.
+* `y` (number): *Optional*. *Default*: `0`.
+* `z` (number): *Optional*. *Default*: `0`.
+* `w` (number): *Optional*. *Default*: `0`.
 
 **Returns**:
 

--- a/misc/package/Data Files/MWSE/core/meta/class/niAVObject.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niAVObject.lua
@@ -61,18 +61,18 @@ function niAVObject:getProperty(type) end
 --- 
 --- @param args niAVObject.propagatePositionChange.params? This table accepts the following values:
 --- 
---- `time`: number? — *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+--- `time`: number? — *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
 --- 
---- `controllers`: boolean? — *Default*: `false`. Update object's controllers?
+--- `controllers`: boolean? — *Optional*. *Default*: `false`. Update object's controllers?
 --- 
---- `bounds`: boolean? — *Default*: `true`. Update object's bounds?
+--- `bounds`: boolean? — *Optional*. *Default*: `true`. Update object's bounds?
 function niAVObject:propagatePositionChange(args) end
 
 ---Table parameter definitions for `niAVObject.propagatePositionChange`.
 --- @class niAVObject.propagatePositionChange.params
---- @field time number? *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
---- @field controllers boolean? *Default*: `false`. Update object's controllers?
---- @field bounds boolean? *Default*: `true`. Update object's bounds?
+--- @field time number? *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+--- @field controllers boolean? *Optional*. *Default*: `false`. Update object's controllers?
+--- @field bounds boolean? *Optional*. *Default*: `true`. Update object's bounds?
 
 --- Updates the world transforms of this node and its children, which makes changes visible for rendering. Use after changing any local rotation, translation, scale, bounds or after attaching and detaching nodes.
 --- 
@@ -82,18 +82,18 @@ function niAVObject:propagatePositionChange(args) end
 --- 
 --- @param args niAVObject.update.params? This table accepts the following values:
 --- 
---- `time`: number? — *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+--- `time`: number? — *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
 --- 
---- `controllers`: boolean? — *Default*: `false`. Update object's controllers?
+--- `controllers`: boolean? — *Optional*. *Default*: `false`. Update object's controllers?
 --- 
---- `bounds`: boolean? — *Default*: `true`. Update object's bounds?
+--- `bounds`: boolean? — *Optional*. *Default*: `true`. Update object's bounds?
 function niAVObject:update(args) end
 
 ---Table parameter definitions for `niAVObject.update`.
 --- @class niAVObject.update.params
---- @field time number? *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
---- @field controllers boolean? *Default*: `false`. Update object's controllers?
---- @field bounds boolean? *Default*: `true`. Update object's bounds?
+--- @field time number? *Optional*. *Default*: `0`. This parameter is the time-slice for transformation and bounds updates
+--- @field controllers boolean? *Optional*. *Default*: `false`. Update object's controllers?
+--- @field bounds boolean? *Optional*. *Default*: `true`. Update object's bounds?
 
 --- Update all attached effects. This method must be called at or above any object when dynamic effects are attached or detached from it
 function niAVObject:updateEffects() end

--- a/misc/package/Data Files/MWSE/core/meta/class/niCamera.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niCamera.lua
@@ -19,7 +19,7 @@
 niCamera = {}
 
 --- This method renders the currently-attached scene graph to the active renderer.
---- @param something boolean? *Default*: `false`. No description yet available.
+--- @param something boolean? *Optional*. *Default*: `false`. No description yet available.
 function niCamera:click(something) end
 
 --- Given a screen space position, calculates the world position and outlook direction. This can be useful when trying to find a reference under a UI element, such as the cusor.

--- a/misc/package/Data Files/MWSE/core/meta/class/niColor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niColor.lua
@@ -15,9 +15,9 @@
 niColor = {}
 
 --- Creates a new niColor.
---- @param r number? *Default*: `0`. The red value for the color.
---- @param g number? *Default*: `0`. The green value for the color.
---- @param b number? *Default*: `0`. The blue value for the color.
+--- @param r number? *Optional*. *Default*: `0`. The red value for the color.
+--- @param g number? *Optional*. *Default*: `0`. The green value for the color.
+--- @param b number? *Optional*. *Default*: `0`. The blue value for the color.
 --- @return niColor color No description yet available.
 function niColor.new(r, g, b) end
 

--- a/misc/package/Data Files/MWSE/core/meta/class/niColorA.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niColorA.lua
@@ -17,10 +17,10 @@
 niColorA = {}
 
 --- Creates a new niColorA.
---- @param r number? *Default*: `0`. The red value for the color.
---- @param g number? *Default*: `0`. The green value for the color.
---- @param b number? *Default*: `0`. The blue value for the color.
---- @param a number? *Default*: `0`. The alpha value for the color.
+--- @param r number? *Optional*. *Default*: `0`. The red value for the color.
+--- @param g number? *Optional*. *Default*: `0`. The green value for the color.
+--- @param b number? *Optional*. *Default*: `0`. The blue value for the color.
+--- @param a number? *Optional*. *Default*: `0`. The alpha value for the color.
 --- @return niColorA color No description yet available.
 function niColorA.new(r, g, b, a) end
 

--- a/misc/package/Data Files/MWSE/core/meta/class/niNode.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niNode.lua
@@ -16,7 +16,7 @@ function niNode.new() end
 
 --- Attaches the child to the children list of the node. Doesn't check to see if the object is already in the child list.
 --- @param child niAmbientLight|niBillboardNode|niCamera|niCollisionSwitch|niDirectionalLight|niNode|niParticles|niPointLight|niRotatingParticles|niSpotLight|niSwitchNode|niTextureEffect|niTriShape No description yet available.
---- @param useFirstAvailable boolean? *Default*: `false`. Use the first available space in the list. If `false` appends the child at the end of the list.
+--- @param useFirstAvailable boolean? *Optional*. *Default*: `false`. Use the first available space in the list. If `false` appends the child at the end of the list.
 function niNode:attachChild(child, useFirstAvailable) end
 
 --- Attaches a dynamic effect to the node. It will not attach the same effect twice.

--- a/misc/package/Data Files/MWSE/core/meta/class/niObjectNET.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niObjectNET.lua
@@ -16,7 +16,7 @@ niObjectNET = {}
 function niObjectNET:addExtraData(extraData) end
 
 --- Searches for an niExtraData on this object to see if it has one that holds a related reference.
---- @param searchParents boolean? *Default*: `false`. If true, all parent objects (if applicable) are also searched.
+--- @param searchParents boolean? *Optional*. *Default*: `false`. If true, all parent objects (if applicable) are also searched.
 --- @return tes3reference? reference No description yet available.
 function niObjectNET:getGameReference(searchParents) end
 

--- a/misc/package/Data Files/MWSE/core/meta/class/niPackedColor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niPackedColor.lua
@@ -17,10 +17,10 @@
 niPackedColor = {}
 
 --- Creates a new niPackedColor object.
---- @param r number? *Default*: `0`. The red value for the color.
---- @param g number? *Default*: `0`. The green value for the color.
---- @param b number? *Default*: `0`. The blue value for the color.
---- @param a number? *Default*: `0`. The alpha value for the color.
+--- @param r number? *Optional*. *Default*: `0`. The red value for the color.
+--- @param g number? *Optional*. *Default*: `0`. The green value for the color.
+--- @param b number? *Optional*. *Default*: `0`. The blue value for the color.
+--- @param a number? *Optional*. *Default*: `0`. The alpha value for the color.
 --- @return niPackedColor color No description yet available.
 function niPackedColor.new(r, g, b, a) end
 

--- a/misc/package/Data Files/MWSE/core/meta/class/niPixelData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niPixelData.lua
@@ -13,7 +13,7 @@ niPixelData = {}
 --- Creates a new NiPixelData object.
 --- @param width number No description yet available.
 --- @param height number No description yet available.
---- @param mipMapLevels number? *Default*: `1`. No description yet available.
+--- @param mipMapLevels number? *Optional*. *Default*: `1`. No description yet available.
 --- @return niPixelData pixelData No description yet available.
 function niPixelData.new(width, height, mipMapLevels) end
 
@@ -23,26 +23,26 @@ function niPixelData:createSourceTexture() end
 
 --- Fills this pixel data with the provided color.
 --- @param data number[] The color data to be set (1-indexed). The values should be in range [0.0, 1.0]. The first three values are RGB color channels, while the last one is alpha channel. The array length must be equal to the `bytesPerPixel` property of this niPixelData object, because alpha can be assigned only to the niPixelData object that has an alpha channel.
---- @param mipMapLevel number? *Default*: `0`. The mipmap level to fill with the provided color. The finest (largest) mipmap level is level 0.
+--- @param mipMapLevel number? *Optional*. *Default*: `0`. The mipmap level to fill with the provided color. The finest (largest) mipmap level is level 0.
 function niPixelData:fill(data, mipMapLevel) end
 
 --- Returns the height of the mipmap level at the given index, where level 0 is the finest (largest) mipmap level, and level `mipMapLevels - 1` is the coarsest (smallest) mipmap level.
---- @param mipMapLevel number? *Default*: `0`. No description yet available.
+--- @param mipMapLevel number? *Optional*. *Default*: `0`. No description yet available.
 --- @return number result No description yet available.
 function niPixelData:getHeight(mipMapLevel) end
 
 --- Returns the width of the mipmap level at the given index, where level 0 is the finest (largest) mipmap level, and level `mipMapLevels - 1` is the coarsest (smallest) mipmap level.
---- @param mipMapLevel number? *Default*: `0`. No description yet available.
+--- @param mipMapLevel number? *Optional*. *Default*: `0`. No description yet available.
 --- @return number result No description yet available.
 function niPixelData:getWidth(mipMapLevel) end
 
 --- Sets the pixel data from byte data.
 --- @param data number[] The byte data to be set to (1-indexed).
---- @param mipMapLevel number? *Default*: `0`. The mipmap level whose data to modify. The finest (largest) mipmap level is level 0.
+--- @param mipMapLevel number? *Optional*. *Default*: `0`. The mipmap level whose data to modify. The finest (largest) mipmap level is level 0.
 function niPixelData:setPixelsByte(data, mipMapLevel) end
 
 --- Sets the pixel data from float data.
 --- @param data number[] The float data to be set to (1-indexed). The values should be in range [0.0, 1.0].
---- @param mipMapLevel number? *Default*: `0`. The mipmap level whose data to modify. The finest (largest) mipmap level is level 0.
+--- @param mipMapLevel number? *Optional*. *Default*: `0`. The mipmap level whose data to modify. The finest (largest) mipmap level is level 0.
 function niPixelData:setPixelsFloat(data, mipMapLevel) end
 

--- a/misc/package/Data Files/MWSE/core/meta/class/niQuaternion.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niQuaternion.lua
@@ -13,10 +13,10 @@
 niQuaternion = {}
 
 --- Creates a new niQuaternion object.
---- @param w number? *Default*: `0`. No description yet available.
---- @param x number? *Default*: `0`. No description yet available.
---- @param y number? *Default*: `0`. No description yet available.
---- @param z number? *Default*: `0`. No description yet available.
+--- @param w number? *Optional*. *Default*: `0`. No description yet available.
+--- @param x number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y number? *Optional*. *Default*: `0`. No description yet available.
+--- @param z number? *Optional*. *Default*: `0`. No description yet available.
 --- @return niQuaternion quaternion No description yet available.
 function niQuaternion.new(w, x, y, z) end
 

--- a/misc/package/Data Files/MWSE/core/meta/class/niTriShapeData.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niTriShapeData.lua
@@ -12,17 +12,17 @@ niTriShapeData = {}
 --- Creates a copy of the data. An optional table of filters can be passed to remove information from the copy.
 --- @param filters niTriShapeData.copy.params? This table accepts the following values:
 --- 
---- `normals`: boolean? — *Default*: `true`. If false, the geometry data's normals will be absent from the copy.
+--- `normals`: boolean? — *Optional*. *Default*: `true`. If false, the geometry data's normals will be absent from the copy.
 --- 
---- `colors`: boolean? — *Default*: `true`. If false, the geometry data's colors will be absent from the copy.
+--- `colors`: boolean? — *Optional*. *Default*: `true`. If false, the geometry data's colors will be absent from the copy.
 --- 
---- `texCoords`: boolean? — *Default*: `true`. If false, the geometry data's texture coordinates will be absent from the copy.
+--- `texCoords`: boolean? — *Optional*. *Default*: `true`. If false, the geometry data's texture coordinates will be absent from the copy.
 --- @return niTriShapeData copiedData The duplicated data.
 function niTriShapeData:copy(filters) end
 
 ---Table parameter definitions for `niTriShapeData.copy`.
 --- @class niTriShapeData.copy.params
---- @field normals boolean? *Default*: `true`. If false, the geometry data's normals will be absent from the copy.
---- @field colors boolean? *Default*: `true`. If false, the geometry data's colors will be absent from the copy.
---- @field texCoords boolean? *Default*: `true`. If false, the geometry data's texture coordinates will be absent from the copy.
+--- @field normals boolean? *Optional*. *Default*: `true`. If false, the geometry data's normals will be absent from the copy.
+--- @field colors boolean? *Optional*. *Default*: `true`. If false, the geometry data's colors will be absent from the copy.
+--- @field texCoords boolean? *Optional*. *Default*: `true`. If false, the geometry data's texture coordinates will be absent from the copy.
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3audioController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3audioController.lua
@@ -29,16 +29,16 @@ tes3audioController = {}
 --- 
 --- `filename`: string — File name of the new music track.
 --- 
---- `crossfade`: number? — *Default*: `1000`. Duration of the crossfading between music tracks. Measured in miliseconds.
+--- `crossfade`: number? — *Optional*. *Default*: `1000`. Duration of the crossfading between music tracks. Measured in miliseconds.
 --- 
---- `volume`: number? — *Default*: `1`. Allows changing the volume of the music track.
+--- `volume`: number? — *Optional*. *Default*: `1`. Allows changing the volume of the music track.
 function tes3audioController:changeMusicTrack(params) end
 
 ---Table parameter definitions for `tes3audioController.changeMusicTrack`.
 --- @class tes3audioController.changeMusicTrack.params
 --- @field filename string File name of the new music track.
---- @field crossfade number? *Default*: `1000`. Duration of the crossfading between music tracks. Measured in miliseconds.
---- @field volume number? *Default*: `1`. Allows changing the volume of the music track.
+--- @field crossfade number? *Optional*. *Default*: `1000`. Duration of the crossfading between music tracks. Measured in miliseconds.
+--- @field volume number? *Optional*. *Default*: `1`. Allows changing the volume of the music track.
 
 --- Final volume of a provided type of audio, after master volume and its own volume adjustments. Music volume is an exception since it isn't affected by master volume.
 --- @param mix number The type of sound mix to perform a check for. Accepts values from [`tes3.soundMix`](https://mwse.github.io/MWSE/references/sound-mix-types/) namespace.

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPartManager.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPartManager.lua
@@ -35,22 +35,22 @@ function tes3bodyPartManager:removeEquippedLayers() end
 --- The method sets a niNode derived object as active body part at a given layer and position.
 --- @param layer number A value from [`tes3.activeBodyPartLayer`](https://mwse.github.io/MWSE/references/active-body-part-layers/) namespace.
 --- @param index number A value from [`tes3.activeBodyPart`](https://mwse.github.io/MWSE/references/active-body-parts/) namespace.
---- @param overwriteData boolean? *Default*: `true`. A flag which controls whether the current data should be overwritten.
---- @param node niBillboardNode|niCollisionSwitch|niNode|niSwitchNode|nil *Default*: `nil`. 
+--- @param overwriteData boolean? *Optional*. *Default*: `true`. A flag which controls whether the current data should be overwritten.
+--- @param node niBillboardNode|niCollisionSwitch|niNode|niSwitchNode|nil *Optional*. *Default*: `nil`. 
 function tes3bodyPartManager:setActivePartData(layer, index, overwriteData, node) end
 
 --- The method sets a new body part for a given object.
 --- @param object tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3bodyPart|tes3book|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3door|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3repairTool|tes3static|tes3weapon An object whose body part to set.
 --- @param index number A value from [`tes3.activeBodyPart`](https://mwse.github.io/MWSE/references/active-body-parts/) namespace.
 --- @param bodyPartId string The unique ID of the `tes3bodyPart` object to set as a new body part for given object.
---- @param isFirstPerson boolean? *Default*: `false`. A flag which controls whether the body part is used in first person.
+--- @param isFirstPerson boolean? *Optional*. *Default*: `false`. A flag which controls whether the body part is used in first person.
 function tes3bodyPartManager:setBodyPartByIdForObject(object, index, bodyPartId, isFirstPerson) end
 
 --- The method sets a new body part for a given object.
 --- @param object tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3bodyPart|tes3book|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3door|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3repairTool|tes3static|tes3weapon An object whose body part to set.
 --- @param index number A value from [`tes3.activeBodyPart`](https://mwse.github.io/MWSE/references/active-body-parts/) namespace.
 --- @param bodyPart tes3bodyPart The `tes3bodyPart` object to set as a new body part for given object.
---- @param isFirstPerson boolean? *Default*: `false`. A flag which controls whether the body part is used in first person.
+--- @param isFirstPerson boolean? *Optional*. *Default*: `false`. A flag which controls whether the body part is used in first person.
 function tes3bodyPartManager:setBodyPartForObject(object, index, bodyPart, isFirstPerson) end
 
 --- The method updates all body parts for a given reference.

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3dataHandler.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3dataHandler.lua
@@ -32,16 +32,16 @@ tes3dataHandler = {}
 --- No description yet available.
 --- @param params tes3dataHandler.updateCollisionGroupsForActiveCells.params This table accepts the following values:
 --- 
---- `force`: boolean? — *Default*: `true`. No description yet available.
+--- `force`: boolean? — *Optional*. *Default*: `true`. No description yet available.
 --- 
---- `isResettingData`: boolean? — *Default*: `false`. No description yet available.
+--- `isResettingData`: boolean? — *Optional*. *Default*: `false`. No description yet available.
 --- 
---- `resetCollisionGroups`: boolean? — *Default*: `true`. No description yet available.
+--- `resetCollisionGroups`: boolean? — *Optional*. *Default*: `true`. No description yet available.
 function tes3dataHandler:updateCollisionGroupsForActiveCells(params) end
 
 ---Table parameter definitions for `tes3dataHandler.updateCollisionGroupsForActiveCells`.
 --- @class tes3dataHandler.updateCollisionGroupsForActiveCells.params
---- @field force boolean? *Default*: `true`. No description yet available.
---- @field isResettingData boolean? *Default*: `false`. No description yet available.
---- @field resetCollisionGroups boolean? *Default*: `true`. No description yet available.
+--- @field force boolean? *Optional*. *Default*: `true`. No description yet available.
+--- @field isResettingData boolean? *Optional*. *Default*: `false`. No description yet available.
+--- @field resetCollisionGroups boolean? *Optional*. *Default*: `true`. No description yet available.
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3fader.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3fader.lua
@@ -11,7 +11,7 @@ tes3fader = {}
 
 --- Creates a new fader, and adds it to the fader system.
 --- @param distance number? *Optional*. If no distance is provided, a distance will be calculated based on current amount of faders, `tes3.worldController.projectionDistance` and crosshair node's `translation.y`.
---- @param unknownBool boolean? *Default*: `true`. No description yet available.
+--- @param unknownBool boolean? *Optional*. *Default*: `true`. No description yet available.
 --- @return tes3fader fader No description yet available.
 function tes3fader.new(distance, unknownBool) end
 
@@ -59,14 +59,14 @@ function tes3fader:fadeTo(params) end
 --- 
 --- `color`: tes3vector3|table — The RGB values to set in [0.0, 1.0] range.
 --- 
---- `flag`: boolean? — *Default*: `false`. No description yet available.
+--- `flag`: boolean? — *Optional*. *Default*: `false`. No description yet available.
 --- @return boolean result No description yet available.
 function tes3fader:setColor(params) end
 
 ---Table parameter definitions for `tes3fader.setColor`.
 --- @class tes3fader.setColor.params
 --- @field color tes3vector3|table The RGB values to set in [0.0, 1.0] range.
---- @field flag boolean? *Default*: `false`. No description yet available.
+--- @field flag boolean? *Optional*. *Default*: `false`. No description yet available.
 
 --- This method allows changing the texture of the fader.
 --- @param path string A path for the texture that will be displayed on screen.

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3magicSourceInstance.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3magicSourceInstance.lua
@@ -45,7 +45,7 @@ function tes3magicSourceInstance:getMagnitudeForIndex(index) end
 --- 
 --- `visual`: tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3bodyPart|tes3book|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3door|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3repairTool|tes3static|tes3weapon|string — The visual effect to be played.
 --- 
---- `scale`: number? — *Default*: `1`. The scale of the effect. Only applies to effects that are designed to be scaled.
+--- `scale`: number? — *Optional*. *Default*: `1`. The scale of the effect. Only applies to effects that are designed to be scaled.
 --- 
 --- `reference`: tes3reference|string — A reference on which the visual effect will be played.
 function tes3magicSourceInstance:playVisualEffect(params) end
@@ -55,6 +55,6 @@ function tes3magicSourceInstance:playVisualEffect(params) end
 --- @field effectIndex number The index in the effect whose visual will be played, a number in range [0, 7].
 --- @field position tes3vector3|table A table or a `tes3vector3` holding `x`, `y` and `z` coordinates at which the visual effect will be played.
 --- @field visual tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3bodyPart|tes3book|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3door|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3repairTool|tes3static|tes3weapon|string The visual effect to be played.
---- @field scale number? *Default*: `1`. The scale of the effect. Only applies to effects that are designed to be scaled.
+--- @field scale number? *Optional*. *Default*: `1`. The scale of the effect. Only applies to effects that are designed to be scaled.
 --- @field reference tes3reference|string A reference on which the visual effect will be played.
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3matrix33.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3matrix33.lua
@@ -12,15 +12,15 @@
 tes3matrix33 = {}
 
 --- Creates a new 3 by 3 matrix from 3 provided vectors or 9 numbers. Creates an empty matrix if nothing is provided.
---- @param x0 number? *Default*: `0`. No description yet available.
---- @param y0 number? *Default*: `0`. No description yet available.
---- @param z0 number? *Default*: `0`. No description yet available.
---- @param x1 number? *Default*: `0`. No description yet available.
---- @param y1 number? *Default*: `0`. No description yet available.
---- @param z1 number? *Default*: `0`. No description yet available.
---- @param x2 number? *Default*: `0`. No description yet available.
---- @param y2 number? *Default*: `0`. No description yet available.
---- @param z2 number? *Default*: `0`. No description yet available.
+--- @param x0 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y0 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param z0 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param x1 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y1 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param z1 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param x2 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y2 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param z2 number? *Optional*. *Default*: `0`. No description yet available.
 --- @param x tes3vector3? *Optional*. No description yet available.
 --- @param y tes3vector3? *Optional*. No description yet available.
 --- @param z tes3vector3? *Optional*. No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3matrix44.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3matrix44.lua
@@ -13,22 +13,22 @@
 tes3matrix44 = {}
 
 --- Creates a new 4 by 4 matrix from 4 provided vectors or 16 numbers. Creates an empty matrix if nothing is provided.
---- @param w0 number? *Default*: `0`. No description yet available.
---- @param x0 number? *Default*: `0`. No description yet available.
---- @param y0 number? *Default*: `0`. No description yet available.
---- @param z0 number? *Default*: `0`. No description yet available.
---- @param w1 number? *Default*: `0`. No description yet available.
---- @param x1 number? *Default*: `0`. No description yet available.
---- @param y1 number? *Default*: `0`. No description yet available.
---- @param z1 number? *Default*: `0`. No description yet available.
---- @param w2 number? *Default*: `0`. No description yet available.
---- @param x2 number? *Default*: `0`. No description yet available.
---- @param y2 number? *Default*: `0`. No description yet available.
---- @param z2 number? *Default*: `0`. No description yet available.
---- @param w3 number? *Default*: `0`. No description yet available.
---- @param x3 number? *Default*: `0`. No description yet available.
---- @param y3 number? *Default*: `0`. No description yet available.
---- @param z3 number? *Default*: `0`. No description yet available.
+--- @param w0 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param x0 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y0 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param z0 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param w1 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param x1 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y1 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param z1 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param w2 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param x2 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y2 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param z2 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param w3 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param x3 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y3 number? *Optional*. *Default*: `0`. No description yet available.
+--- @param z3 number? *Optional*. *Default*: `0`. No description yet available.
 --- @param w tes3vector4? *Optional*. No description yet available.
 --- @param x tes3vector4? *Optional*. No description yet available.
 --- @param y tes3vector4? *Optional*. No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3mobileActor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3mobileActor.lua
@@ -205,17 +205,17 @@ function tes3mobileActor:calculateJumpVelocity(params) end
 --- 
 --- `velocity`: tes3vector3? — *Optional*. The initial velocity of the jump. If not specified, the velocity of a regular jump without movement will be used.
 --- 
---- `applyFatigueCost`: boolean? — *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
+--- `applyFatigueCost`: boolean? — *Optional*. *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
 --- 
---- `allowMidairJumping`: boolean? — *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
+--- `allowMidairJumping`: boolean? — *Optional*. *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
 --- @return boolean result No description yet available.
 function tes3mobileActor:doJump(params) end
 
 ---Table parameter definitions for `tes3mobileActor.doJump`.
 --- @class tes3mobileActor.doJump.params
 --- @field velocity tes3vector3? *Optional*. The initial velocity of the jump. If not specified, the velocity of a regular jump without movement will be used.
---- @field applyFatigueCost boolean? *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
---- @field allowMidairJumping boolean? *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
+--- @field applyFatigueCost boolean? *Optional*. *Default*: `true`. If `true`, reduces the actor's current fatigue by the amount a regular jump would currently cost. Will not reduce fatigue if `false`.
+--- @field allowMidairJumping boolean? *Optional*. *Default*: `false`. If `true`, enables the jump to be performed while already jumping or falling. Does not work during levitation or other methods of flying.
 
 --- Equips an item, optionally adding the item if needed. If the best match is already equipped, it does not perform an unequip-equip cycle, but does return `true`.
 --- @param params tes3mobileActor.equip.params This table accepts the following values:
@@ -252,9 +252,9 @@ function tes3mobileActor:equip(params) end
 --- 
 --- `itemData`: tes3itemData? — *Optional*. Only valid if an item has been assigned to `source`. The item data of the specific item to equip.
 --- 
---- `equipItem`: boolean? — *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
+--- `equipItem`: boolean? — *Optional*. *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
 --- 
---- `updateGUI`: boolean? — *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+--- `updateGUI`: boolean? — *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 --- @return boolean result No description yet available.
 function tes3mobileActor:equipMagic(params) end
 
@@ -267,8 +267,8 @@ function tes3mobileActor:equipMagic(params) end
 --- 		Items must have a castable enchantment. Castable enchantments have a `castType` of `tes3.enchantmentType.onUse` or `tes3.enchantmentType.castOnce`. The actor is not required to have this item in their inventory, unless `equipItem` is `true`.
 --- 
 --- @field itemData tes3itemData? *Optional*. Only valid if an item has been assigned to `source`. The item data of the specific item to equip.
---- @field equipItem boolean? *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
---- @field updateGUI boolean? *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+--- @field equipItem boolean? *Optional*. *Default*: `false`. Only valid if an item has been assigned to `source`. If `true`, the item assigned to `source` will be equipped. Requires the actor to have the item in their inventory. If `false`, `itemData` must not be nil.
+--- @field updateGUI boolean? *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 
 --- Fetches a filtered list of the active magic effects on the actor. Returns a table with [`tes3activeMagicEffect`](https://mwse.github.io/MWSE/types/tes3activeMagicEffect/) items.
 --- @param params tes3mobileActor.getActiveMagicEffects.params? This table accepts the following values:
@@ -380,15 +380,15 @@ function tes3mobileActor:unequip(params) end
 --- Unequips the currently equipped magic, optionally unequipping the enchanted item if needed.
 --- @param params tes3mobileActor.unequipMagic.params? This table accepts the following values:
 --- 
---- `unequipItem`: boolean? — *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
+--- `unequipItem`: boolean? — *Optional*. *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
 --- 
---- `updateGUI`: boolean? — *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+--- `updateGUI`: boolean? — *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 function tes3mobileActor:unequipMagic(params) end
 
 ---Table parameter definitions for `tes3mobileActor.unequipMagic`.
 --- @class tes3mobileActor.unequipMagic.params
---- @field unequipItem boolean? *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
---- @field updateGUI boolean? *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
+--- @field unequipItem boolean? *Optional*. *Default*: `false`. Only valid if the currently equipped magic is from an equippable item enchantment. If `true`, the item containing the enchantment will be unequipped.
+--- @field updateGUI boolean? *Optional*. *Default*: `true`. Only valid if this actor is the player. If `false`, the player GUI will not be updated to reflect the change to equipped magic.
 
 --- Updates statistics derived from attributes, which are magicka, fatigue, and encumbrance. Will also update the UI if used on the player. Normally handled automatically when you use `tes3.modStatistic()`.
 --- @param attribute tes3statistic|tes3statisticSkill|nil *Optional*. Limits the update to statistics derived from this attribute.  e.g. `mobile:updateDerivedStatistics(mobile.strength)`. If not present, all derived statistics will be updated.

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiElement.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiElement.lua
@@ -97,17 +97,17 @@ tes3uiElement = {}
 --- 
 --- `to`: tes3uiElement — The element to create the copy in. Will be the parent of the newly created element.
 --- 
---- `copyChildren`: boolean? — *Default*: `true`. If `true`, all children will also be copied to the newly created element.
+--- `copyChildren`: boolean? — *Optional*. *Default*: `true`. If `true`, all children will also be copied to the newly created element.
 --- 
---- `copyProperties`: boolean? — *Default*: `true`. If `true`, all properties will be copied to the newly created element.
+--- `copyProperties`: boolean? — *Optional*. *Default*: `true`. If `true`, all properties will be copied to the newly created element.
 --- @return tes3uiElement copy The created copy.
 function tes3uiElement:copy(params) end
 
 ---Table parameter definitions for `tes3uiElement.copy`.
 --- @class tes3uiElement.copy.params
 --- @field to tes3uiElement The element to create the copy in. Will be the parent of the newly created element.
---- @field copyChildren boolean? *Default*: `true`. If `true`, all children will also be copied to the newly created element.
---- @field copyProperties boolean? *Default*: `true`. If `true`, all properties will be copied to the newly created element.
+--- @field copyChildren boolean? *Optional*. *Default*: `true`. If `true`, all children will also be copied to the newly created element.
+--- @field copyProperties boolean? *Optional*. *Default*: `true`. If `true`, all properties will be copied to the newly created element.
 
 --- Creates an empty block container inside the element. Used to group and layout elements.
 --- @param params tes3uiElement.createBlock.params? This table accepts the following values:
@@ -334,9 +334,9 @@ function tes3uiElement:createRect(params) end
 --- 
 --- `max`: number — The maximum value of the slider.
 --- 
---- `step`: number? — *Default*: `1`. The change in value when clicking the left and right arrow buttons.
+--- `step`: number? — *Optional*. *Default*: `1`. The change in value when clicking the left and right arrow buttons.
 --- 
---- `jump`: number? — *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
+--- `jump`: number? — *Optional*. *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
 --- @return tes3uiElement result No description yet available.
 function tes3uiElement:createSlider(params) end
 
@@ -345,8 +345,8 @@ function tes3uiElement:createSlider(params) end
 --- @field id string|number|nil *Optional*. An identifier to help find this element later.
 --- @field current number The current value of the slider.
 --- @field max number The maximum value of the slider.
---- @field step number? *Default*: `1`. The change in value when clicking the left and right arrow buttons.
---- @field jump number? *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
+--- @field step number? *Optional*. *Default*: `1`. The change in value when clicking the left and right arrow buttons.
+--- @field jump number? *Optional*. *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
 
 --- Creates a vertical slider.
 --- 
@@ -359,9 +359,9 @@ function tes3uiElement:createSlider(params) end
 --- 
 --- `max`: number — The maximum value of the slider.
 --- 
---- `step`: number? — *Default*: `1`. The change in value when clicking the left and right arrow buttons.
+--- `step`: number? — *Optional*. *Default*: `1`. The change in value when clicking the left and right arrow buttons.
 --- 
---- `jump`: number? — *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
+--- `jump`: number? — *Optional*. *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
 --- @return tes3uiElement result No description yet available.
 function tes3uiElement:createSliderVertical(params) end
 
@@ -370,8 +370,8 @@ function tes3uiElement:createSliderVertical(params) end
 --- @field id string|number|nil *Optional*. An identifier to help find this element later.
 --- @field current number The current value of the slider.
 --- @field max number The maximum value of the slider.
---- @field step number? *Default*: `1`. The change in value when clicking the left and right arrow buttons.
---- @field jump number? *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
+--- @field step number? *Optional*. *Default*: `1`. The change in value when clicking the left and right arrow buttons.
+--- @field jump number? *Optional*. *Default*: `5`. The change in value when clicking into the empty areas next to the slider handle.
 
 --- Creates a single line text input element. To receive input the keyboard must be captured with `tes3ui.acquireTextInput(element)`. Read the input with the `text` property. Write an initial value to display by setting the `text` property; that value will be cleared on the first keypress.
 --- 
@@ -407,7 +407,7 @@ function tes3uiElement:createTextInput(params) end
 --- 
 --- `text`: string? — *Optional*. The text to display.
 --- 
---- `state`: number? — *Default*: `tes3.uiState.normal`. The initial interaction state.
+--- `state`: number? — *Optional*. *Default*: `tes3.uiState.normal`. The initial interaction state.
 --- @return tes3uiElement result No description yet available.
 function tes3uiElement:createTextSelect(params) end
 
@@ -415,7 +415,7 @@ function tes3uiElement:createTextSelect(params) end
 --- @class tes3uiElement.createTextSelect.params
 --- @field id string|number|nil *Optional*. An identifier to help find this element later.
 --- @field text string? *Optional*. The text to display.
---- @field state number? *Default*: `tes3.uiState.normal`. The initial interaction state.
+--- @field state number? *Optional*. *Default*: `tes3.uiState.normal`. The initial interaction state.
 
 --- Creates a styled thin border element. Any content should be created as children of this border.
 --- @param params tes3uiElement.createThinBorder.params? This table accepts the following values:

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3vector2.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3vector2.lua
@@ -11,8 +11,8 @@
 tes3vector2 = {}
 
 --- Creates a new vector. If no parameters are provided, an empty set will be constructed.
---- @param x number? *Default*: `0`. No description yet available.
---- @param y number? *Default*: `0`. No description yet available.
+--- @param x number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y number? *Optional*. *Default*: `0`. No description yet available.
 --- @return tes3vector2 vector No description yet available.
 function tes3vector2.new(x, y) end
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3vector3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3vector3.lua
@@ -16,9 +16,9 @@
 tes3vector3 = {}
 
 --- Creates a new vector. If no parameters are provided, an empty set will be constructed.
---- @param x number? *Default*: `0`. No description yet available.
---- @param y number? *Default*: `0`. No description yet available.
---- @param z number? *Default*: `0`. No description yet available.
+--- @param x number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y number? *Optional*. *Default*: `0`. No description yet available.
+--- @param z number? *Optional*. *Default*: `0`. No description yet available.
 --- @return tes3vector3 vector No description yet available.
 function tes3vector3.new(x, y, z) end
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3vector4.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3vector4.lua
@@ -13,10 +13,10 @@
 tes3vector4 = {}
 
 --- Creates a new vector. If no parameters are provided, an empty set will be constructed.
---- @param x number? *Default*: `0`. No description yet available.
---- @param y number? *Default*: `0`. No description yet available.
---- @param z number? *Default*: `0`. No description yet available.
---- @param w number? *Default*: `0`. No description yet available.
+--- @param x number? *Optional*. *Default*: `0`. No description yet available.
+--- @param y number? *Optional*. *Default*: `0`. No description yet available.
+--- @param z number? *Optional*. *Default*: `0`. No description yet available.
+--- @param w number? *Optional*. *Default*: `0`. No description yet available.
 --- @return tes3vector4 vector No description yet available.
 function tes3vector4.new(x, y, z, w) end
 

--- a/misc/package/Data Files/MWSE/core/meta/lib/mwscript.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mwscript.lua
@@ -478,14 +478,14 @@ function mwscript.scriptRunning(params) end
 --- 
 --- `reference`: tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string|nil — *Optional*. The target reference for this command to be executed on. Defaults to the normal script execution reference.
 --- 
---- `delete`: boolean? — *Default*: `true`. Setting this to true deletes the reference and triggers `referenceDeactivated` event. Setting this to false effectively undeletes/activates the reference and triggers `referenceActivated` event.
+--- `delete`: boolean? — *Optional*. *Default*: `true`. Setting this to true deletes the reference and triggers `referenceDeactivated` event. Setting this to false effectively undeletes/activates the reference and triggers `referenceActivated` event.
 --- @return boolean executed No description yet available.
 function mwscript.setDelete(params) end
 
 ---Table parameter definitions for `mwscript.setDelete`.
 --- @class mwscript.setDelete.params
 --- @field reference tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string|nil *Optional*. The target reference for this command to be executed on. Defaults to the normal script execution reference.
---- @field delete boolean? *Default*: `true`. Setting this to true deletes the reference and triggers `referenceDeactivated` event. Setting this to false effectively undeletes/activates the reference and triggers `referenceActivated` event.
+--- @field delete boolean? *Optional*. *Default*: `true`. Setting this to true deletes the reference and triggers `referenceDeactivated` event. Setting this to false effectively undeletes/activates the reference and triggers `referenceActivated` event.
 
 --- Use [`tes3npc.level`](https://mwse.github.io/MWSE/types/tes3npc/#level) instead. Wrapper for the `SetLevel` mwscript function.
 --- @deprecated

--- a/misc/package/Data Files/MWSE/core/meta/lib/table.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/table.lua
@@ -120,7 +120,7 @@ function table.size(t) end
 ---
 --- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/table/#tabletraverse).
 --- @param t table A table to transverse.
---- @param k unknown? *Default*: `children`. The key of a table inside t object.
+--- @param k unknown? *Optional*. *Default*: `children`. The key of a table inside t object.
 --- @return iterator result No description yet available.
 function table.traverse(t, k) end
 

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -113,13 +113,13 @@ function tes3.addItemData(params) end
 --- 
 --- `text`: string — The text of the new Journal entry.
 --- 
---- `showMessage`: boolean? — *Default*: `true`. If this parameter is true, a "Your journal has been updated" message will be displayed.
+--- `showMessage`: boolean? — *Optional*. *Default*: `true`. If this parameter is true, a "Your journal has been updated" message will be displayed.
 function tes3.addJournalEntry(params) end
 
 ---Table parameter definitions for `tes3.addJournalEntry`.
 --- @class tes3.addJournalEntry.params
 --- @field text string The text of the new Journal entry.
---- @field showMessage boolean? *Default*: `true`. If this parameter is true, a "Your journal has been updated" message will be displayed.
+--- @field showMessage boolean? *Optional*. *Default*: `true`. If this parameter is true, a "Your journal has been updated" message will be displayed.
 
 --- This function creates a new custom magic effect. The effect can be scripted through lua. This function should be used inside [`magicEffectsResolved`](https://mwse.github.io/MWSE/events/magicEffectsResolved/) event callback.
 ---
@@ -128,19 +128,19 @@ function tes3.addJournalEntry(params) end
 --- 
 --- `id`: number — Id of the new effect. Maps to newly claimed `tes3.effect` constants with `tes3.claimSpellEffectId()`. If the effect of this id already exists, an error will be thrown.
 --- 
---- `name`: string? — *Default*: `Unnamed Effect`. Name of the effect.
+--- `name`: string? — *Optional*. *Default*: `Unnamed Effect`. Name of the effect.
 --- 
---- `baseCost`: number? — *Default*: `1`. Base magicka cost for the effect.
+--- `baseCost`: number? — *Optional*. *Default*: `1`. Base magicka cost for the effect.
 --- 
---- `school`: integer? — *Default*: `tes3.magicSchool.alteration`. The magic school the new effect will be assigned to. Maps to [`tes3.magicSchool`](https://mwse.github.io/MWSE/references/magic-schools/) constants.
+--- `school`: integer? — *Optional*. *Default*: `tes3.magicSchool.alteration`. The magic school the new effect will be assigned to. Maps to [`tes3.magicSchool`](https://mwse.github.io/MWSE/references/magic-schools/) constants.
 --- 
---- `size`: number? — *Default*: `1`. Controls how much the visual effect scales with its magnitude.
+--- `size`: number? — *Optional*. *Default*: `1`. Controls how much the visual effect scales with its magnitude.
 --- 
---- `sizeCap`: number? — *Default*: `1`. The maximum possible size of the projectile.
+--- `sizeCap`: number? — *Optional*. *Default*: `1`. The maximum possible size of the projectile.
 --- 
---- `speed`: number? — *Default*: `1`. No description yet available.
+--- `speed`: number? — *Optional*. *Default*: `1`. No description yet available.
 --- 
---- `description`: string? — *Default*: `No description available.`. Description for the effect.
+--- `description`: string? — *Optional*. *Default*: `No description available.`. Description for the effect.
 --- 
 --- `lighting`: table? — *Optional*. No description yet available.
 --- 
@@ -164,41 +164,41 @@ function tes3.addJournalEntry(params) end
 --- 
 --- `areaVFX`: tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3bodyPart|tes3book|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3door|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3repairTool|tes3static|tes3weapon|string|nil — *Optional*. The visual played when a spell with this effect, with area of effect hits something.
 --- 
---- `allowEnchanting`: boolean? — *Default*: `true`. A flag which controls whether this effect can be used in a custom enchantment.
+--- `allowEnchanting`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect can be used in a custom enchantment.
 --- 
---- `allowSpellmaking`: boolean? — *Default*: `true`. A flag which controls whether this effect can be used in a custom spell.
+--- `allowSpellmaking`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect can be used in a custom spell.
 --- 
---- `appliesOnce`: boolean? — *Default*: `true`. A flag which controls whether this effect applies once or is a ticking effect.
+--- `appliesOnce`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect applies once or is a ticking effect.
 --- 
---- `canCastSelf`: boolean? — *Default*: `true`. A flag which controls whether this effect can be used with cast on self range.
+--- `canCastSelf`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect can be used with cast on self range.
 --- 
---- `canCastTarget`: boolean? — *Default*: `true`. A flag which controls whether this effect can be used with cast on target range.
+--- `canCastTarget`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect can be used with cast on target range.
 --- 
---- `canCastTouch`: boolean? — *Default*: `true`. A flag which controls whether this effect can be used with cast on touch range.
+--- `canCastTouch`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect can be used with cast on touch range.
 --- 
---- `casterLinked`: boolean? — *Default*: `true`. Access to the base flag that determines if this effect must end if caster is dead, or not an NPC/creature. Not allowed in container or door trap spells.
+--- `casterLinked`: boolean? — *Optional*. *Default*: `true`. Access to the base flag that determines if this effect must end if caster is dead, or not an NPC/creature. Not allowed in container or door trap spells.
 --- --- 
 --- --- Note that this property is hidden in the Construction Set.
 --- 
---- `hasContinuousVFX`: boolean? — *Default*: `true`. A flag which controls whether the effect's visual is continuously played during the whole duration of the effect.
+--- `hasContinuousVFX`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether the effect's visual is continuously played during the whole duration of the effect.
 --- 
---- `hasNoDuration`: boolean? — *Default*: `true`. A flag which controls whether this effect doesn't have duration.
+--- `hasNoDuration`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect doesn't have duration.
 --- 
---- `hasNoMagnitude`: boolean? — *Default*: `true`. A flag which controls whether this effect doesn't have magnitude.
+--- `hasNoMagnitude`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect doesn't have magnitude.
 --- 
---- `illegalDaedra`: boolean? — *Default*: `true`. A flag which controls whether this effect is illegal to use in public, because it summons Daedra. Note: this mechanic is not implemented in the game. Some mods might rely on this parameter.
+--- `illegalDaedra`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect is illegal to use in public, because it summons Daedra. Note: this mechanic is not implemented in the game. Some mods might rely on this parameter.
 --- 
---- `isHarmful`: boolean? — *Default*: `true`. A flag which controls whether this effect is considered harmful and casting it can be considered as an attack.
+--- `isHarmful`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect is considered harmful and casting it can be considered as an attack.
 --- 
---- `nonRecastable`: boolean? — *Default*: `true`. A flag which controls whether this effect can be recast while it already is in duration.
+--- `nonRecastable`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect can be recast while it already is in duration.
 --- 
---- `targetsAttributes`: boolean? — *Default*: `true`. A flag which controls whether this effect targets a certain attribute or attributes.
+--- `targetsAttributes`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect targets a certain attribute or attributes.
 --- 
---- `targetsSkills`: boolean? — *Default*: `true`. A flag which controls whether this effect targets a certain skill or skills.
+--- `targetsSkills`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect targets a certain skill or skills.
 --- 
---- `unreflectable`: boolean? — *Default*: `true`. A flag which controls whether this effect can be reflected.
+--- `unreflectable`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect can be reflected.
 --- 
---- `usesNegativeLighting`: boolean? — *Default*: `true`. A flag which controls whether this effect uses negative lighting.
+--- `usesNegativeLighting`: boolean? — *Optional*. *Default*: `true`. A flag which controls whether this effect uses negative lighting.
 --- 
 --- `onTick`: function? — *Optional*. A function which will be called on each tick of a spell containing this effect. A table `tickParams` will be passed to the callback function. Note: `dt`(frame time) scaling is handled automatically.
 --- --- 		- `tickParams` (table)
@@ -247,13 +247,13 @@ function tes3.addMagicEffect(params) end
 ---Table parameter definitions for `tes3.addMagicEffect`.
 --- @class tes3.addMagicEffect.params
 --- @field id number Id of the new effect. Maps to newly claimed `tes3.effect` constants with `tes3.claimSpellEffectId()`. If the effect of this id already exists, an error will be thrown.
---- @field name string? *Default*: `Unnamed Effect`. Name of the effect.
---- @field baseCost number? *Default*: `1`. Base magicka cost for the effect.
---- @field school integer? *Default*: `tes3.magicSchool.alteration`. The magic school the new effect will be assigned to. Maps to [`tes3.magicSchool`](https://mwse.github.io/MWSE/references/magic-schools/) constants.
---- @field size number? *Default*: `1`. Controls how much the visual effect scales with its magnitude.
---- @field sizeCap number? *Default*: `1`. The maximum possible size of the projectile.
---- @field speed number? *Default*: `1`. No description yet available.
---- @field description string? *Default*: `No description available.`. Description for the effect.
+--- @field name string? *Optional*. *Default*: `Unnamed Effect`. Name of the effect.
+--- @field baseCost number? *Optional*. *Default*: `1`. Base magicka cost for the effect.
+--- @field school integer? *Optional*. *Default*: `tes3.magicSchool.alteration`. The magic school the new effect will be assigned to. Maps to [`tes3.magicSchool`](https://mwse.github.io/MWSE/references/magic-schools/) constants.
+--- @field size number? *Optional*. *Default*: `1`. Controls how much the visual effect scales with its magnitude.
+--- @field sizeCap number? *Optional*. *Default*: `1`. The maximum possible size of the projectile.
+--- @field speed number? *Optional*. *Default*: `1`. No description yet available.
+--- @field description string? *Optional*. *Default*: `No description available.`. Description for the effect.
 --- @field lighting table? *Optional*. No description yet available.
 --- @field icon string Path to the effect icon. Must be a string no longer than 31 characters long. Use double \ as path separator.
 --- @field particleTexture string Path to the particle texture to use for the effect. Must be a string no longer than 31 characters long.
@@ -265,25 +265,25 @@ function tes3.addMagicEffect(params) end
 --- @field boltVFX tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3bodyPart|tes3book|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3door|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3repairTool|tes3static|tes3weapon|string|nil *Optional*. The visual played when a spell with this effect is in flight.
 --- @field hitVFX tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3bodyPart|tes3book|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3door|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3repairTool|tes3static|tes3weapon|string|nil *Optional*. The visual played when a spell with this effect hits something.
 --- @field areaVFX tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3bodyPart|tes3book|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3door|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3repairTool|tes3static|tes3weapon|string|nil *Optional*. The visual played when a spell with this effect, with area of effect hits something.
---- @field allowEnchanting boolean? *Default*: `true`. A flag which controls whether this effect can be used in a custom enchantment.
---- @field allowSpellmaking boolean? *Default*: `true`. A flag which controls whether this effect can be used in a custom spell.
---- @field appliesOnce boolean? *Default*: `true`. A flag which controls whether this effect applies once or is a ticking effect.
---- @field canCastSelf boolean? *Default*: `true`. A flag which controls whether this effect can be used with cast on self range.
---- @field canCastTarget boolean? *Default*: `true`. A flag which controls whether this effect can be used with cast on target range.
---- @field canCastTouch boolean? *Default*: `true`. A flag which controls whether this effect can be used with cast on touch range.
---- @field casterLinked boolean? *Default*: `true`. Access to the base flag that determines if this effect must end if caster is dead, or not an NPC/creature. Not allowed in container or door trap spells.
+--- @field allowEnchanting boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect can be used in a custom enchantment.
+--- @field allowSpellmaking boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect can be used in a custom spell.
+--- @field appliesOnce boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect applies once or is a ticking effect.
+--- @field canCastSelf boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect can be used with cast on self range.
+--- @field canCastTarget boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect can be used with cast on target range.
+--- @field canCastTouch boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect can be used with cast on touch range.
+--- @field casterLinked boolean? *Optional*. *Default*: `true`. Access to the base flag that determines if this effect must end if caster is dead, or not an NPC/creature. Not allowed in container or door trap spells.
 --- 
 --- Note that this property is hidden in the Construction Set.
---- @field hasContinuousVFX boolean? *Default*: `true`. A flag which controls whether the effect's visual is continuously played during the whole duration of the effect.
---- @field hasNoDuration boolean? *Default*: `true`. A flag which controls whether this effect doesn't have duration.
---- @field hasNoMagnitude boolean? *Default*: `true`. A flag which controls whether this effect doesn't have magnitude.
---- @field illegalDaedra boolean? *Default*: `true`. A flag which controls whether this effect is illegal to use in public, because it summons Daedra. Note: this mechanic is not implemented in the game. Some mods might rely on this parameter.
---- @field isHarmful boolean? *Default*: `true`. A flag which controls whether this effect is considered harmful and casting it can be considered as an attack.
---- @field nonRecastable boolean? *Default*: `true`. A flag which controls whether this effect can be recast while it already is in duration.
---- @field targetsAttributes boolean? *Default*: `true`. A flag which controls whether this effect targets a certain attribute or attributes.
---- @field targetsSkills boolean? *Default*: `true`. A flag which controls whether this effect targets a certain skill or skills.
---- @field unreflectable boolean? *Default*: `true`. A flag which controls whether this effect can be reflected.
---- @field usesNegativeLighting boolean? *Default*: `true`. A flag which controls whether this effect uses negative lighting.
+--- @field hasContinuousVFX boolean? *Optional*. *Default*: `true`. A flag which controls whether the effect's visual is continuously played during the whole duration of the effect.
+--- @field hasNoDuration boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect doesn't have duration.
+--- @field hasNoMagnitude boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect doesn't have magnitude.
+--- @field illegalDaedra boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect is illegal to use in public, because it summons Daedra. Note: this mechanic is not implemented in the game. Some mods might rely on this parameter.
+--- @field isHarmful boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect is considered harmful and casting it can be considered as an attack.
+--- @field nonRecastable boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect can be recast while it already is in duration.
+--- @field targetsAttributes boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect targets a certain attribute or attributes.
+--- @field targetsSkills boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect targets a certain skill or skills.
+--- @field unreflectable boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect can be reflected.
+--- @field usesNegativeLighting boolean? *Optional*. *Default*: `true`. A flag which controls whether this effect uses negative lighting.
 --- @field onTick function? *Optional*. A function which will be called on each tick of a spell containing this effect. A table `tickParams` will be passed to the callback function. Note: `dt`(frame time) scaling is handled automatically.
 --- 		- `tickParams` (table)
 --- 			- `effectId` (number)
@@ -396,17 +396,17 @@ function tes3.adjustSoundVolume(params) end
 --- 
 --- `hours`: number — How many hours to progress.
 --- 
---- `resting`: boolean? — *Default*: `false`. Should advancing time count as resting? If set to true invokes usual sleeping mechanics: health, fatigue and magicka restoration, and possible rest interruption. The length of the rest will be equal to hours parameter, rounded down to nearest natural number.
+--- `resting`: boolean? — *Optional*. *Default*: `false`. Should advancing time count as resting? If set to true invokes usual sleeping mechanics: health, fatigue and magicka restoration, and possible rest interruption. The length of the rest will be equal to hours parameter, rounded down to nearest natural number.
 --- 
---- `updateEnvironment`: boolean? — *Default*: `true`. Controls if the weather system is updated for each hour passed.
+--- `updateEnvironment`: boolean? — *Optional*. *Default*: `true`. Controls if the weather system is updated for each hour passed.
 --- @return number hoursPassed No description yet available.
 function tes3.advanceTime(params) end
 
 ---Table parameter definitions for `tes3.advanceTime`.
 --- @class tes3.advanceTime.params
 --- @field hours number How many hours to progress.
---- @field resting boolean? *Default*: `false`. Should advancing time count as resting? If set to true invokes usual sleeping mechanics: health, fatigue and magicka restoration, and possible rest interruption. The length of the rest will be equal to hours parameter, rounded down to nearest natural number.
---- @field updateEnvironment boolean? *Default*: `true`. Controls if the weather system is updated for each hour passed.
+--- @field resting boolean? *Optional*. *Default*: `false`. Should advancing time count as resting? If set to true invokes usual sleeping mechanics: health, fatigue and magicka restoration, and possible rest interruption. The length of the rest will be equal to hours parameter, rounded down to nearest natural number.
+--- @field updateEnvironment boolean? *Optional*. *Default*: `true`. Controls if the weather system is updated for each hour passed.
 
 --- 
 --- @param params tes3.applyMagicSource.params This table accepts the following values:
@@ -419,7 +419,7 @@ function tes3.advanceTime(params) end
 --- 
 --- `effects`: table? — *Optional*. A table of custom effects to apply as a potion. Maximal number of effects is 8.
 --- 
---- `createCopy`: boolean? — *Default*: `true`. This parameter controls whether the function will return the original magic source or a copy of the magic source. This parameter is only used if source is alchemy.
+--- `createCopy`: boolean? — *Optional*. *Default*: `true`. This parameter controls whether the function will return the original magic source or a copy of the magic source. This parameter is only used if source is alchemy.
 --- 
 --- `fromStack`: tes3equipmentStack? — *Optional*. The piece of equipment this magic source is coming from. The fromStack has to be an already equipped item from tes3actor.equipment. This will probably change in the future.
 --- 
@@ -427,7 +427,7 @@ function tes3.advanceTime(params) end
 --- 
 --- `target`: tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string|nil — *Optional*. The target of the magic.
 --- 
---- `bypassResistances`: boolean? — *Default*: `false`. Is this effect going to bypass magic resistance?
+--- `bypassResistances`: boolean? — *Optional*. *Default*: `false`. Is this effect going to bypass magic resistance?
 --- @return tes3magicSourceInstance instance No description yet available.
 function tes3.applyMagicSource(params) end
 
@@ -437,11 +437,11 @@ function tes3.applyMagicSource(params) end
 --- @field source tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3bodyPart|tes3book|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3door|tes3enchantment|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3reference|tes3repairTool|tes3spell|tes3static|tes3weapon|nil *Optional*. A magic source to apply.
 --- @field name string? *Optional*. While optional for other uses, if applying alchemy as a source, you must specify a name for the magic source.
 --- @field effects table? *Optional*. A table of custom effects to apply as a potion. Maximal number of effects is 8.
---- @field createCopy boolean? *Default*: `true`. This parameter controls whether the function will return the original magic source or a copy of the magic source. This parameter is only used if source is alchemy.
+--- @field createCopy boolean? *Optional*. *Default*: `true`. This parameter controls whether the function will return the original magic source or a copy of the magic source. This parameter is only used if source is alchemy.
 --- @field fromStack tes3equipmentStack? *Optional*. The piece of equipment this magic source is coming from. The fromStack has to be an already equipped item from tes3actor.equipment. This will probably change in the future.
 --- @field castChance number? *Optional*. This parameter allows overriding the casting chance of the magic source.
 --- @field target tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string|nil *Optional*. The target of the magic.
---- @field bypassResistances boolean? *Default*: `false`. Is this effect going to bypass magic resistance?
+--- @field bypassResistances boolean? *Optional*. *Default*: `false`. Is this effect going to bypass magic resistance?
 
 --- Returns a string with all the [text defines](https://en.uesp.net/wiki/Morrowind_Mod:Text_Defines) replaced in the input string. This can be used to replicate the behavior of book and dialogue text.
 --- @param params tes3.applyTextDefines.params This table accepts the following values:
@@ -1041,9 +1041,9 @@ function tes3.getDialogueInfo(dialogue, id) end
 --- 
 --- `effect`: number — Effect ID. Can be any of the predefined spell effects, or one added by `tes3.claimSpellEffectId()`. Maps to values of [`tes3.effect`](https://mwse.github.io/MWSE/references/magic-effects/) constants
 --- 
---- `skill`: number? — *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Skill, a skill should be provided. This also applies to any custom spell effect which operates on a certain skill. This value maps to [`tes3.skill`](https://mwse.github.io/MWSE/references/skills/) constants.
+--- `skill`: number? — *Optional*. *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Skill, a skill should be provided. This also applies to any custom spell effect which operates on a certain skill. This value maps to [`tes3.skill`](https://mwse.github.io/MWSE/references/skills/) constants.
 --- 
---- `attribute`: number? — *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Attribute, an attribute should be provided. This also applies to any custom spell effect which operates on a certain attribute. This value maps to [`tes3.attribute`](https://mwse.github.io/MWSE/references/attributes/) constants.
+--- `attribute`: number? — *Optional*. *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Attribute, an attribute should be provided. This also applies to any custom spell effect which operates on a certain attribute. This value maps to [`tes3.attribute`](https://mwse.github.io/MWSE/references/attributes/) constants.
 --- @return number effectiveMagnitude The effective magnitude after all the actor's resistances are applied.
 --- @return integer magnitude The magnitude before any of the actor's resistances are applied.
 function tes3.getEffectMagnitude(params) end
@@ -1052,8 +1052,8 @@ function tes3.getEffectMagnitude(params) end
 --- @class tes3.getEffectMagnitude.params
 --- @field reference tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string An associated mobile should exist for this function to be able to work.
 --- @field effect number Effect ID. Can be any of the predefined spell effects, or one added by `tes3.claimSpellEffectId()`. Maps to values of [`tes3.effect`](https://mwse.github.io/MWSE/references/magic-effects/) constants
---- @field skill number? *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Skill, a skill should be provided. This also applies to any custom spell effect which operates on a certain skill. This value maps to [`tes3.skill`](https://mwse.github.io/MWSE/references/skills/) constants.
---- @field attribute number? *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Attribute, an attribute should be provided. This also applies to any custom spell effect which operates on a certain attribute. This value maps to [`tes3.attribute`](https://mwse.github.io/MWSE/references/attributes/) constants.
+--- @field skill number? *Optional*. *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Skill, a skill should be provided. This also applies to any custom spell effect which operates on a certain skill. This value maps to [`tes3.skill`](https://mwse.github.io/MWSE/references/skills/) constants.
+--- @field attribute number? *Optional*. *Default*: `-1`. If effect parameter specified is: Absorb, Damage, Drain, Fortify or Restore Attribute, an attribute should be provided. This also applies to any custom spell effect which operates on a certain attribute. This value maps to [`tes3.attribute`](https://mwse.github.io/MWSE/references/attributes/) constants.
 
 --- Returns an actor's equipped item stack, provided a given filter
 ---
@@ -1294,7 +1294,7 @@ function tes3.getQuickKey(params) end
 function tes3.getReference(id) end
 
 --- Gets the current region the player is in. This checks the player's current cell first, but will fall back to the last exterior cell.
---- @param useDoors boolean? *Default*: `false`. No description yet available.
+--- @param useDoors boolean? *Optional*. *Default*: `false`. No description yet available.
 --- @return tes3region region No description yet available.
 function tes3.getRegion(useDoors) end
 
@@ -1352,23 +1352,23 @@ function tes3.getSpecializationName(specializationId) end
 --- 
 --- `target`: tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3npc|tes3npcInstance — The actor to get the spells of. Must be able to cast spells.
 --- 
---- `spellType`: number? — *Default*: `-1`. The spell type to filter for. Only spells with this spell type will be returned. A value of `-1` will return spells of all types. Maps to values in the [`tes3.spellType`](https://mwse.github.io/MWSE/references/spell-types/) table.
+--- `spellType`: number? — *Optional*. *Default*: `-1`. The spell type to filter for. Only spells with this spell type will be returned. A value of `-1` will return spells of all types. Maps to values in the [`tes3.spellType`](https://mwse.github.io/MWSE/references/spell-types/) table.
 --- 
---- `getActorSpells`: boolean? — *Default*: `true`. If `true`, the spells of the actor itself will be included in the result. This includes every spell except racial and birthsign spells.
+--- `getActorSpells`: boolean? — *Optional*. *Default*: `true`. If `true`, the spells of the actor itself will be included in the result. This includes every spell except racial and birthsign spells.
 --- 
---- `getRaceSpells`: boolean? — *Default*: `true`. If `true`, the spells of the actor's race will be included in the result.
+--- `getRaceSpells`: boolean? — *Optional*. *Default*: `true`. If `true`, the spells of the actor's race will be included in the result.
 --- 
---- `getBirthsignSpells`: boolean? — *Default*: `true`. If `true`, the spells of the actor's birthsign will be included in the result.
+--- `getBirthsignSpells`: boolean? — *Optional*. *Default*: `true`. If `true`, the spells of the actor's birthsign will be included in the result.
 --- @return tes3spell[] result No description yet available.
 function tes3.getSpells(params) end
 
 ---Table parameter definitions for `tes3.getSpells`.
 --- @class tes3.getSpells.params
 --- @field target tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3npc|tes3npcInstance The actor to get the spells of. Must be able to cast spells.
---- @field spellType number? *Default*: `-1`. The spell type to filter for. Only spells with this spell type will be returned. A value of `-1` will return spells of all types. Maps to values in the [`tes3.spellType`](https://mwse.github.io/MWSE/references/spell-types/) table.
---- @field getActorSpells boolean? *Default*: `true`. If `true`, the spells of the actor itself will be included in the result. This includes every spell except racial and birthsign spells.
---- @field getRaceSpells boolean? *Default*: `true`. If `true`, the spells of the actor's race will be included in the result.
---- @field getBirthsignSpells boolean? *Default*: `true`. If `true`, the spells of the actor's birthsign will be included in the result.
+--- @field spellType number? *Optional*. *Default*: `-1`. The spell type to filter for. Only spells with this spell type will be returned. A value of `-1` will return spells of all types. Maps to values in the [`tes3.spellType`](https://mwse.github.io/MWSE/references/spell-types/) table.
+--- @field getActorSpells boolean? *Optional*. *Default*: `true`. If `true`, the spells of the actor itself will be included in the result. This includes every spell except racial and birthsign spells.
+--- @field getRaceSpells boolean? *Optional*. *Default*: `true`. If `true`, the spells of the actor's race will be included in the result.
+--- @field getBirthsignSpells boolean? *Optional*. *Default*: `true`. If `true`, the spells of the actor's birthsign will be included in the result.
 
 --- Gets the top-level UI menu.
 --- @return tes3uiElement menu No description yet available.
@@ -1536,7 +1536,7 @@ function tes3.loadGame(filename) end
 
 --- Loads a mesh file and provides a scene graph object.
 --- @param path string Path, relative to Data Files/Meshes.
---- @param useCache boolean? *Default*: `true`. If false, a new object will be created even if it had been previously loaded.
+--- @param useCache boolean? *Optional*. *Default*: `true`. If false, a new object will be created even if it had been previously loaded.
 --- @return niBillboardNode|niCollisionSwitch|niNode|niSwitchNode model No description yet available.
 function tes3.loadMesh(path, useCache) end
 
@@ -1583,7 +1583,7 @@ function tes3.menuMode() end
 --- 
 --- `callback`: function — No description yet available.
 --- 
---- `showInDialog`: boolean? — *Default*: `true`. Specifying showInDialog = false forces the toast-style message, which is not shown in the dialog menu.
+--- `showInDialog`: boolean? — *Optional*. *Default*: `true`. Specifying showInDialog = false forces the toast-style message, which is not shown in the dialog menu.
 --- 
 --- `duration`: number? — *Optional*. Overrides how long the toast-style message remains visible.
 --- @param ... any? *Optional*. Only used if messageOrParams is a string.
@@ -1595,7 +1595,7 @@ function tes3.messageBox(messageOrParams, ...) end
 --- @field message string No description yet available.
 --- @field buttons string[]? *Optional*. An array of strings to use for buttons.
 --- @field callback function No description yet available.
---- @field showInDialog boolean? *Default*: `true`. Specifying showInDialog = false forces the toast-style message, which is not shown in the dialog menu.
+--- @field showInDialog boolean? *Optional*. *Default*: `true`. Specifying showInDialog = false forces the toast-style message, which is not shown in the dialog menu.
 --- @field duration number? *Optional*. Overrides how long the toast-style message remains visible.
 
 --- Modifies a statistic on a given actor. This should be used instead of manually setting values on the game structures, to ensure that events and GUI elements are properly handled. Either skill, attribute, or name must be provided.
@@ -1766,11 +1766,11 @@ function tes3.playVoiceover(params) end
 --- 
 --- `orientation`: tes3vector3|table|nil — *Optional*. The new orientation of the reference.
 --- 
---- `forceCellChange`: boolean? — *Default*: `false`. When true, forces the game to update a reference that has moved within a single cell, as if it was moved into a new cell.
+--- `forceCellChange`: boolean? — *Optional*. *Default*: `false`. When true, forces the game to update a reference that has moved within a single cell, as if it was moved into a new cell.
 --- 
---- `suppressFader`: boolean? — *Default*: `false`. When moving the player, can be used to prevent the fade in and out visual effect.
+--- `suppressFader`: boolean? — *Optional*. *Default*: `false`. When moving the player, can be used to prevent the fade in and out visual effect.
 --- 
---- `teleportCompanions`: boolean? — *Default*: `true`. If used on the player, determines if companions should also be teleported.
+--- `teleportCompanions`: boolean? — *Optional*. *Default*: `true`. If used on the player, determines if companions should also be teleported.
 --- @return boolean executed No description yet available.
 function tes3.positionCell(params) end
 
@@ -1780,9 +1780,9 @@ function tes3.positionCell(params) end
 --- @field cell tes3cell? *Optional*. The cell to move the reference to. If not provided, the reference will be moved to a cell in the exterior worldspace at the position provided.
 --- @field position tes3vector3|table The position to move the reference to.
 --- @field orientation tes3vector3|table|nil *Optional*. The new orientation of the reference.
---- @field forceCellChange boolean? *Default*: `false`. When true, forces the game to update a reference that has moved within a single cell, as if it was moved into a new cell.
---- @field suppressFader boolean? *Default*: `false`. When moving the player, can be used to prevent the fade in and out visual effect.
---- @field teleportCompanions boolean? *Default*: `true`. If used on the player, determines if companions should also be teleported.
+--- @field forceCellChange boolean? *Optional*. *Default*: `false`. When true, forces the game to update a reference that has moved within a single cell, as if it was moved into a new cell.
+--- @field suppressFader boolean? *Optional*. *Default*: `false`. When moving the player, can be used to prevent the fade in and out visual effect.
+--- @field teleportCompanions boolean? *Optional*. *Default*: `true`. If used on the player, determines if companions should also be teleported.
 
 --- Simulates pushing a keyboard key.
 --- @param keyCode number Maps to values in [`tes3.scanCode`](https://mwse.github.io/MWSE/references/scan-codes/) namespace.
@@ -2073,7 +2073,7 @@ function tes3.setAIActivate(params) end
 --- 
 --- `destination`: tes3vector3|table — No description yet available.
 --- 
---- `duration`: number? — *Default*: `0`. How long the escorter will do the escorting, in hours.
+--- `duration`: number? — *Optional*. *Default*: `0`. How long the escorter will do the escorting, in hours.
 --- 
 --- `cell`: tes3cell|string|nil — *Optional*. No description yet available.
 --- 
@@ -2085,7 +2085,7 @@ function tes3.setAIEscort(params) end
 --- @field reference tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3reference The escorting actor.
 --- @field target tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer The actor being escorted.
 --- @field destination tes3vector3|table No description yet available.
---- @field duration number? *Default*: `0`. How long the escorter will do the escorting, in hours.
+--- @field duration number? *Optional*. *Default*: `0`. How long the escorter will do the escorting, in hours.
 --- @field cell tes3cell|string|nil *Optional*. No description yet available.
 --- @field reset boolean? *Default*: `true`. No description yet available.
 
@@ -2098,7 +2098,7 @@ function tes3.setAIEscort(params) end
 --- 
 --- `destination`: tes3vector3|table|nil — *Optional*. No description yet available.
 --- 
---- `duration`: number? — *Default*: `0`. How long the follower will follow, in hours.
+--- `duration`: number? — *Optional*. *Default*: `0`. How long the follower will follow, in hours.
 --- 
 --- `cell`: tes3cell|string|nil — *Optional*. No description yet available.
 --- 
@@ -2110,7 +2110,7 @@ function tes3.setAIFollow(params) end
 --- @field reference tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3reference This is the actor that will follow another one.
 --- @field target tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer The actor to follow.
 --- @field destination tes3vector3|table|nil *Optional*. No description yet available.
---- @field duration number? *Default*: `0`. How long the follower will follow, in hours.
+--- @field duration number? *Optional*. *Default*: `0`. How long the follower will follow, in hours.
 --- @field cell tes3cell|string|nil *Optional*. No description yet available.
 --- @field reset boolean? *Default*: `true`. No description yet available.
 
@@ -2137,11 +2137,11 @@ function tes3.setAITravel(params) end
 --- 
 --- `idles`: number[] — An array with 8 values that corresponds to the chance of playing each idle animation. For more info see [tes3aiPackageWander.idles](https://mwse.github.io/MWSE/types/tes3aiPackageWander/#idles).
 --- 
---- `range`: number? — *Default*: `0`. No description yet available.
+--- `range`: number? — *Optional*. *Default*: `0`. No description yet available.
 --- 
---- `duration`: number? — *Default*: `0`. How long the actor will be wandering around, in hours.
+--- `duration`: number? — *Optional*. *Default*: `0`. How long the actor will be wandering around, in hours.
 --- 
---- `time`: number? — *Default*: `0`. No description yet available.
+--- `time`: number? — *Optional*. *Default*: `0`. No description yet available.
 --- 
 --- `reset`: boolean? — *Default*: `true`. No description yet available.
 function tes3.setAIWander(params) end
@@ -2150,9 +2150,9 @@ function tes3.setAIWander(params) end
 --- @class tes3.setAIWander.params
 --- @field reference tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3reference This actor will wander around.
 --- @field idles number[] An array with 8 values that corresponds to the chance of playing each idle animation. For more info see [tes3aiPackageWander.idles](https://mwse.github.io/MWSE/types/tes3aiPackageWander/#idles).
---- @field range number? *Default*: `0`. No description yet available.
---- @field duration number? *Default*: `0`. How long the actor will be wandering around, in hours.
---- @field time number? *Default*: `0`. No description yet available.
+--- @field range number? *Optional*. *Default*: `0`. No description yet available.
+--- @field duration number? *Optional*. *Default*: `0`. How long the actor will be wandering around, in hours.
+--- @field time number? *Optional*. *Default*: `0`. No description yet available.
 --- @field reset boolean? *Default*: `true`. No description yet available.
 
 --- This function sets a reference's animation groups' timings to a specified value.
@@ -2278,7 +2278,7 @@ function tes3.setLockLevel(params) end
 --- 
 --- `position`: tes3vector3 — Coordinates of the mark's position.
 --- 
---- `rotation`: number? — *Default*: `Player's current rotation.`. This argument controls which direction the player's mark location will be facing.
+--- `rotation`: number? — *Optional*. *Default*: `Player's current rotation.`. This argument controls which direction the player's mark location will be facing.
 --- 
 --- `cell`: tes3cell? — *Optional*. A cell in which the mark should be placed.
 function tes3.setMarkLocation(params) end
@@ -2286,7 +2286,7 @@ function tes3.setMarkLocation(params) end
 ---Table parameter definitions for `tes3.setMarkLocation`.
 --- @class tes3.setMarkLocation.params
 --- @field position tes3vector3 Coordinates of the mark's position.
---- @field rotation number? *Default*: `Player's current rotation.`. This argument controls which direction the player's mark location will be facing.
+--- @field rotation number? *Optional*. *Default*: `Player's current rotation.`. This argument controls which direction the player's mark location will be facing.
 --- @field cell tes3cell? *Optional*. A cell in which the mark should be placed.
 
 --- This function sets the owner of a reference.
@@ -2294,52 +2294,52 @@ function tes3.setMarkLocation(params) end
 --- 
 --- `reference`: tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string — A reference whose owner to set.
 --- 
---- `remove`: boolean? — *Default*: `false`. If this parameter is set to true, reference's owner field will be removed.
+--- `remove`: boolean? — *Optional*. *Default*: `false`. If this parameter is set to true, reference's owner field will be removed.
 --- 
 --- `owner`: tes3npc|tes3faction|string — Assigns this NPC or a faction as the owner of the reference.
 --- 
 --- `requiredGlobal`: tes3globalVariable? — *Optional*. If `owner` is set to NPC, `requiredGlobal` variable can be set.
 --- 
---- `requiredRank`: number? — *Default*: `0`. If `owner` is set to faction, `requitedRank` variable controls minimal rank in faction the player has to have to be able to freely take the reference.
+--- `requiredRank`: number? — *Optional*. *Default*: `0`. If `owner` is set to faction, `requitedRank` variable controls minimal rank in faction the player has to have to be able to freely take the reference.
 function tes3.setOwner(params) end
 
 ---Table parameter definitions for `tes3.setOwner`.
 --- @class tes3.setOwner.params
 --- @field reference tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string A reference whose owner to set.
---- @field remove boolean? *Default*: `false`. If this parameter is set to true, reference's owner field will be removed.
+--- @field remove boolean? *Optional*. *Default*: `false`. If this parameter is set to true, reference's owner field will be removed.
 --- @field owner tes3npc|tes3faction|string Assigns this NPC or a faction as the owner of the reference.
 --- @field requiredGlobal tes3globalVariable? *Optional*. If `owner` is set to NPC, `requiredGlobal` variable can be set.
---- @field requiredRank number? *Default*: `0`. If `owner` is set to faction, `requitedRank` variable controls minimal rank in faction the player has to have to be able to freely take the reference.
+--- @field requiredRank number? *Optional*. *Default*: `0`. If `owner` is set to faction, `requitedRank` variable controls minimal rank in faction the player has to have to be able to freely take the reference.
 
 --- Enables or disables player's controls state.
 --- @param params tes3.setPlayerControlState.params? This table accepts the following values:
 --- 
---- `enabled`: boolean? — *Default*: `false`. Setting this to false will disable any kind of control.
+--- `enabled`: boolean? — *Optional*. *Default*: `false`. Setting this to false will disable any kind of control.
 --- 
---- `attack`: boolean? — *Default*: `false`. If this is false, it will block player from attacking.
+--- `attack`: boolean? — *Optional*. *Default*: `false`. If this is false, it will block player from attacking.
 --- 
---- `jumping`: boolean? — *Default*: `false`. If this is false, it will block player from jumping.
+--- `jumping`: boolean? — *Optional*. *Default*: `false`. If this is false, it will block player from jumping.
 --- 
---- `magic`: boolean? — *Default*: `false`. If this is false, it will block player from using magic.
+--- `magic`: boolean? — *Optional*. *Default*: `false`. If this is false, it will block player from using magic.
 --- 
---- `vanity`: boolean? — *Default*: `false`. If this is false, it will block player from going to vanity mode.
+--- `vanity`: boolean? — *Optional*. *Default*: `false`. If this is false, it will block player from going to vanity mode.
 --- 
---- `viewSwitch`: boolean? — *Default*: `false`. If this is false, it will block player changing view mod from 1st to 3rd person camera and vice versa.
+--- `viewSwitch`: boolean? — *Optional*. *Default*: `false`. If this is false, it will block player changing view mod from 1st to 3rd person camera and vice versa.
 --- @return boolean changedControlState No description yet available.
 function tes3.setPlayerControlState(params) end
 
 ---Table parameter definitions for `tes3.setPlayerControlState`.
 --- @class tes3.setPlayerControlState.params
---- @field enabled boolean? *Default*: `false`. Setting this to false will disable any kind of control.
---- @field attack boolean? *Default*: `false`. If this is false, it will block player from attacking.
---- @field jumping boolean? *Default*: `false`. If this is false, it will block player from jumping.
---- @field magic boolean? *Default*: `false`. If this is false, it will block player from using magic.
---- @field vanity boolean? *Default*: `false`. If this is false, it will block player from going to vanity mode.
---- @field viewSwitch boolean? *Default*: `false`. If this is false, it will block player changing view mod from 1st to 3rd person camera and vice versa.
+--- @field enabled boolean? *Optional*. *Default*: `false`. Setting this to false will disable any kind of control.
+--- @field attack boolean? *Optional*. *Default*: `false`. If this is false, it will block player from attacking.
+--- @field jumping boolean? *Optional*. *Default*: `false`. If this is false, it will block player from jumping.
+--- @field magic boolean? *Optional*. *Default*: `false`. If this is false, it will block player from using magic.
+--- @field vanity boolean? *Optional*. *Default*: `false`. If this is false, it will block player from going to vanity mode.
+--- @field viewSwitch boolean? *Optional*. *Default*: `false`. If this is false, it will block player changing view mod from 1st to 3rd person camera and vice versa.
 
 --- Sets an object (of any kind) to be sourceless, which are objects the game does not store in savegames. This can be useful for mod-created temporary objects which are not necessary to save.
 --- @param object tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3birthsign|tes3bodyPart|tes3book|tes3cell|tes3class|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3dialogue|tes3dialogueInfo|tes3door|tes3enchantment|tes3faction|tes3gameSetting|tes3globalVariable|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3magicSourceInstance|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3quest|tes3race|tes3reference|tes3region|tes3repairTool|tes3script|tes3skill|tes3sound|tes3soundGenerator|tes3spell|tes3startScript|tes3static|tes3weapon The object whose sourceless flag to modify.
---- @param sourceless boolean? *Default*: `true`. Allows flagging an object as sourceless or undoing that action.
+--- @param sourceless boolean? *Optional*. *Default*: `true`. Allows flagging an object as sourceless or undoing that action.
 function tes3.setSourceless(object, sourceless) end
 
 --- Sets a statistic on a given actor. This should be used instead of manually setting values on the game structures, to ensure that events and GUI elements are properly handled. Either skill, attribute, or name must be provided.
@@ -2392,19 +2392,19 @@ function tes3.setTrap(params) end
 --- Note that unlike the vanity mode caused by not doing anything for a while, this vanity mode must be toggled to go off.
 --- @param params tes3.setVanityMode.params? This table accepts the following values:
 --- 
---- `enabled`: boolean? — *Default*: `true`. This flag sets the vanity mode as enabled or disabled.
+--- `enabled`: boolean? — *Optional*. *Default*: `true`. This flag sets the vanity mode as enabled or disabled.
 --- 
---- `checkVanityDisabled`: boolean? — *Default*: `true`. This will prevent changing vanity mode according to vanityDisabled flag on tes3.mobilePlayer.
+--- `checkVanityDisabled`: boolean? — *Optional*. *Default*: `true`. This will prevent changing vanity mode according to vanityDisabled flag on tes3.mobilePlayer.
 --- 
---- `toggle`: boolean? — *Default*: `false`. When this flag is set to true. The vanity mode will be toggled. If the player was in vanity mode, this will make the player leave vanity mode. Conversly, if the player wasn't in the vanity mode, this will turn on the vanity mode.
+--- `toggle`: boolean? — *Optional*. *Default*: `false`. When this flag is set to true. The vanity mode will be toggled. If the player was in vanity mode, this will make the player leave vanity mode. Conversly, if the player wasn't in the vanity mode, this will turn on the vanity mode.
 --- @return boolean changedVanityMode No description yet available.
 function tes3.setVanityMode(params) end
 
 ---Table parameter definitions for `tes3.setVanityMode`.
 --- @class tes3.setVanityMode.params
---- @field enabled boolean? *Default*: `true`. This flag sets the vanity mode as enabled or disabled.
---- @field checkVanityDisabled boolean? *Default*: `true`. This will prevent changing vanity mode according to vanityDisabled flag on tes3.mobilePlayer.
---- @field toggle boolean? *Default*: `false`. When this flag is set to true. The vanity mode will be toggled. If the player was in vanity mode, this will make the player leave vanity mode. Conversly, if the player wasn't in the vanity mode, this will turn on the vanity mode.
+--- @field enabled boolean? *Optional*. *Default*: `true`. This flag sets the vanity mode as enabled or disabled.
+--- @field checkVanityDisabled boolean? *Optional*. *Default*: `true`. This will prevent changing vanity mode according to vanityDisabled flag on tes3.mobilePlayer.
+--- @field toggle boolean? *Optional*. *Default*: `false`. When this flag is set to true. The vanity mode will be toggled. If the player was in vanity mode, this will make the player leave vanity mode. Conversly, if the player wasn't in the vanity mode, this will turn on the vanity mode.
 
 --- Sets player's kill count as a werewolf.
 --- @param params tes3.setWerewolfKillCount.params This table accepts the following values:
@@ -2450,43 +2450,43 @@ function tes3.showDialogueMenu(params) end
 --- This function opens the repair service menu.
 --- @param params tes3.showRepairServiceMenu.params? This table accepts the following values:
 --- 
---- `serviceActor`: tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3reference|string|nil — *Default*: `tes3mobilePlayer`. The actor to use for calculating the service price.
+--- `serviceActor`: tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3reference|string|nil — *Optional*. *Default*: `tes3mobilePlayer`. The actor to use for calculating the service price.
 function tes3.showRepairServiceMenu(params) end
 
 ---Table parameter definitions for `tes3.showRepairServiceMenu`.
 --- @class tes3.showRepairServiceMenu.params
---- @field serviceActor tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3reference|string|nil *Default*: `tes3mobilePlayer`. The actor to use for calculating the service price.
+--- @field serviceActor tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|tes3reference|string|nil *Optional*. *Default*: `tes3mobilePlayer`. The actor to use for calculating the service price.
 
 --- This function opens the resting menu and returns true on success. If the player can't rest currently, it returns false.
 --- 
 --- Various parameters can be used to allow resting in situations not normally possible.
 --- @param params tes3.showRestMenu.params? This table accepts the following values:
 --- 
---- `checkForEnemies`: boolean? — *Default*: `true`. Perform a check whether there are enemies nearby before opening rest menu. If there are, false is returned.
+--- `checkForEnemies`: boolean? — *Optional*. *Default*: `true`. Perform a check whether there are enemies nearby before opening rest menu. If there are, false is returned.
 --- 
---- `checkForSolidGround`: boolean? — *Default*: `true`. Perform a check if the player is underwater. If underwater, false is returned.
+--- `checkForSolidGround`: boolean? — *Optional*. *Default*: `true`. Perform a check if the player is underwater. If underwater, false is returned.
 --- 
---- `checkSleepingIllegal`: boolean? — *Default*: `true`. Perform a check if the sleeping in the current cell is illegal. If illegal, then the player will be prompted to wait instead of rest.
+--- `checkSleepingIllegal`: boolean? — *Optional*. *Default*: `true`. Perform a check if the sleeping in the current cell is illegal. If illegal, then the player will be prompted to wait instead of rest.
 --- 
---- `checkIsWerewolf`: boolean? — *Default*: `true`. Perform a check if the player is Werewolf. If they are, then the player will be prompted to wait instead of rest.
+--- `checkIsWerewolf`: boolean? — *Optional*. *Default*: `true`. Perform a check if the player is Werewolf. If they are, then the player will be prompted to wait instead of rest.
 --- 
---- `showMessage`: boolean? — *Default*: `true`. Should a messagebox be shown if the player can't open resting menu because some condition isn't met.
+--- `showMessage`: boolean? — *Optional*. *Default*: `true`. Should a messagebox be shown if the player can't open resting menu because some condition isn't met.
 --- 
---- `resting`: boolean? — *Default*: `true`. Should this be a rest?
+--- `resting`: boolean? — *Optional*. *Default*: `true`. Should this be a rest?
 --- 
---- `waiting`: boolean? — *Default*: `false`. Or, is this a wait?
+--- `waiting`: boolean? — *Optional*. *Default*: `false`. Or, is this a wait?
 --- @return boolean success No description yet available.
 function tes3.showRestMenu(params) end
 
 ---Table parameter definitions for `tes3.showRestMenu`.
 --- @class tes3.showRestMenu.params
---- @field checkForEnemies boolean? *Default*: `true`. Perform a check whether there are enemies nearby before opening rest menu. If there are, false is returned.
---- @field checkForSolidGround boolean? *Default*: `true`. Perform a check if the player is underwater. If underwater, false is returned.
---- @field checkSleepingIllegal boolean? *Default*: `true`. Perform a check if the sleeping in the current cell is illegal. If illegal, then the player will be prompted to wait instead of rest.
---- @field checkIsWerewolf boolean? *Default*: `true`. Perform a check if the player is Werewolf. If they are, then the player will be prompted to wait instead of rest.
---- @field showMessage boolean? *Default*: `true`. Should a messagebox be shown if the player can't open resting menu because some condition isn't met.
---- @field resting boolean? *Default*: `true`. Should this be a rest?
---- @field waiting boolean? *Default*: `false`. Or, is this a wait?
+--- @field checkForEnemies boolean? *Optional*. *Default*: `true`. Perform a check whether there are enemies nearby before opening rest menu. If there are, false is returned.
+--- @field checkForSolidGround boolean? *Optional*. *Default*: `true`. Perform a check if the player is underwater. If underwater, false is returned.
+--- @field checkSleepingIllegal boolean? *Optional*. *Default*: `true`. Perform a check if the sleeping in the current cell is illegal. If illegal, then the player will be prompted to wait instead of rest.
+--- @field checkIsWerewolf boolean? *Optional*. *Default*: `true`. Perform a check if the player is Werewolf. If they are, then the player will be prompted to wait instead of rest.
+--- @field showMessage boolean? *Optional*. *Default*: `true`. Should a messagebox be shown if the player can't open resting menu because some condition isn't met.
+--- @field resting boolean? *Optional*. *Default*: `true`. Should this be a rest?
+--- @field waiting boolean? *Optional*. *Default*: `false`. Or, is this a wait?
 
 --- This function opens the spellmaking menu and returns true on success.
 --- @param params tes3.showSpellmakingMenu.params This table accepts the following values:
@@ -2609,22 +2609,22 @@ function tes3.transferItem(params) end
 --- Emulates the player committing a crime. Returns `true` if the crime was witnessed by an actor.
 --- @param params tes3.triggerCrime.params This table accepts the following values:
 --- 
---- `type`: number? — *Default*: `tes3.crimeType.theft`. The type of crime to be committed. Maps to values in the [`tes3.crimeType`](https://mwse.github.io/MWSE/references/crime-types/) table.
+--- `type`: number? — *Optional*. *Default*: `tes3.crimeType.theft`. The type of crime to be committed. Maps to values in the [`tes3.crimeType`](https://mwse.github.io/MWSE/references/crime-types/) table.
 --- 
---- `victim`: tes3mobileNPC|tes3mobilePlayer|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3npc|tes3npcInstance|tes3faction|nil — *Default*: `tes3.mobilePlayer`. The victim of the crime. This can be an individual actor or a entire faction. Has no effect on crimes with a `type` of `tes3.crimeType.trespass` or `tes3.crimeType.werewolf`.
+--- `victim`: tes3mobileNPC|tes3mobilePlayer|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3npc|tes3npcInstance|tes3faction|nil — *Optional*. *Default*: `tes3.mobilePlayer`. The victim of the crime. This can be an individual actor or a entire faction. Has no effect on crimes with a `type` of `tes3.crimeType.trespass` or `tes3.crimeType.werewolf`.
 --- 
---- `value`: number? — *Default*: `0`. Only valid if `type` is `tes3.crimeType.theft`. The value of the stolen objects.
+--- `value`: number? — *Optional*. *Default*: `0`. Only valid if `type` is `tes3.crimeType.theft`. The value of the stolen objects.
 --- 
---- `forceDetection`: boolean? — *Default*: `false`. If `true`, bypasses regular detection logic and forces all nearby actors to detect the crime.
+--- `forceDetection`: boolean? — *Optional*. *Default*: `false`. If `true`, bypasses regular detection logic and forces all nearby actors to detect the crime.
 --- @return boolean result No description yet available.
 function tes3.triggerCrime(params) end
 
 ---Table parameter definitions for `tes3.triggerCrime`.
 --- @class tes3.triggerCrime.params
---- @field type number? *Default*: `tes3.crimeType.theft`. The type of crime to be committed. Maps to values in the [`tes3.crimeType`](https://mwse.github.io/MWSE/references/crime-types/) table.
---- @field victim tes3mobileNPC|tes3mobilePlayer|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3npc|tes3npcInstance|tes3faction|nil *Default*: `tes3.mobilePlayer`. The victim of the crime. This can be an individual actor or a entire faction. Has no effect on crimes with a `type` of `tes3.crimeType.trespass` or `tes3.crimeType.werewolf`.
---- @field value number? *Default*: `0`. Only valid if `type` is `tes3.crimeType.theft`. The value of the stolen objects.
---- @field forceDetection boolean? *Default*: `false`. If `true`, bypasses regular detection logic and forces all nearby actors to detect the crime.
+--- @field type number? *Optional*. *Default*: `tes3.crimeType.theft`. The type of crime to be committed. Maps to values in the [`tes3.crimeType`](https://mwse.github.io/MWSE/references/crime-types/) table.
+--- @field victim tes3mobileNPC|tes3mobilePlayer|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3npc|tes3npcInstance|tes3faction|nil *Optional*. *Default*: `tes3.mobilePlayer`. The victim of the crime. This can be an individual actor or a entire faction. Has no effect on crimes with a `type` of `tes3.crimeType.trespass` or `tes3.crimeType.werewolf`.
+--- @field value number? *Optional*. *Default*: `0`. Only valid if `type` is `tes3.crimeType.theft`. The value of the stolen objects.
+--- @field forceDetection boolean? *Optional*. *Default*: `false`. If `true`, bypasses regular detection logic and forces all nearby actors to detect the crime.
 
 --- Changes a reference back from werewolf form to human. This function works only on a reference infected with Lycanthropy, be it the player or any other reference. Returns true if successful.
 --- @param params tes3.undoTransform.params This table accepts the following values:

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
@@ -217,25 +217,25 @@ function tes3ui.showBookMenu(text) end
 --- This function creates a dialogue message. The message can have three styles. The style `2` makes a selectable text. That way by calling this function multiple time you can create a selection of responses.
 --- @param params tes3ui.showDialogueMessage.params This table accepts the following values:
 --- 
---- `text`: string? — *Default*: ``. The text of the shown message.
+--- `text`: string? — *Optional*. *Default*: ``. The text of the shown message.
 --- 
---- `style`: number? — *Default*: `0`. This argument controls the text color of the message. Value `0` makes the message text the same color as the text in the dialogue window. Value `1` makes the text white, and also print a newline after the message. Value `2` turns the message into a selectable text inside the dialogue window. Value `3` looks the same as `1` but there isn't a newline after each message. Value `4` is the same as value `1`. All the other values work as `0`.
+--- `style`: number? — *Optional*. *Default*: `0`. This argument controls the text color of the message. Value `0` makes the message text the same color as the text in the dialogue window. Value `1` makes the text white, and also print a newline after the message. Value `2` turns the message into a selectable text inside the dialogue window. Value `3` looks the same as `1` but there isn't a newline after each message. Value `4` is the same as value `1`. All the other values work as `0`.
 --- 
---- `answerIndex`: number? — *Default*: `0`. This number can be used later to identify which response was selected.
+--- `answerIndex`: number? — *Optional*. *Default*: `0`. This number can be used later to identify which response was selected.
 function tes3ui.showDialogueMessage(params) end
 
 ---Table parameter definitions for `tes3ui.showDialogueMessage`.
 --- @class tes3ui.showDialogueMessage.params
---- @field text string? *Default*: ``. The text of the shown message.
---- @field style number? *Default*: `0`. This argument controls the text color of the message. Value `0` makes the message text the same color as the text in the dialogue window. Value `1` makes the text white, and also print a newline after the message. Value `2` turns the message into a selectable text inside the dialogue window. Value `3` looks the same as `1` but there isn't a newline after each message. Value `4` is the same as value `1`. All the other values work as `0`.
---- @field answerIndex number? *Default*: `0`. This number can be used later to identify which response was selected.
+--- @field text string? *Optional*. *Default*: ``. The text of the shown message.
+--- @field style number? *Optional*. *Default*: `0`. This argument controls the text color of the message. Value `0` makes the message text the same color as the text in the dialogue window. Value `1` makes the text white, and also print a newline after the message. Value `2` turns the message into a selectable text inside the dialogue window. Value `3` looks the same as `1` but there isn't a newline after each message. Value `4` is the same as value `1`. All the other values work as `0`.
+--- @field answerIndex number? *Optional*. *Default*: `0`. This number can be used later to identify which response was selected.
 
 --- This function opens the inventory select menu which lets the player select items from an inventory. These items can be selected from any actor's inventory and can be filtered with the `filter` callback. The selected item can be retrieved in the function assigned to `callback`.
 ---
 --- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/tes3ui/#tes3uishowinventoryselectmenu).
 --- @param params tes3ui.showInventorySelectMenu.params This table accepts the following values:
 --- 
---- `reference`: tes3reference? — *Default*: `tes3player`. The reference of a `tes3actor` whose inventory will be used.
+--- `reference`: tes3reference? — *Optional*. *Default*: `tes3player`. The reference of a `tes3actor` whose inventory will be used.
 --- 
 --- `title`: string — The text used for the title of the inventory select menu.
 --- 
@@ -277,7 +277,7 @@ function tes3ui.showInventorySelectMenu(params) end
 
 ---Table parameter definitions for `tes3ui.showInventorySelectMenu`.
 --- @class tes3ui.showInventorySelectMenu.params
---- @field reference tes3reference? *Default*: `tes3player`. The reference of a `tes3actor` whose inventory will be used.
+--- @field reference tes3reference? *Optional*. *Default*: `tes3player`. The reference of a `tes3actor` whose inventory will be used.
 --- @field title string The text used for the title of the inventory select menu.
 --- @field leaveMenuMode boolean? *Optional*. Determines if menu mode should be exited after closing the inventory select menu. By default, it will be in the state it was in before this function was called.
 --- @field noResultsText string? *Optional*. The text used for the message that gets shown to the player if no items have been found in the inventory. The default text is equivalent to the `sInventorySelectNoItems` GMST value, unless `"ingredients"` or `"soulgemFilled"` has been assigned to `filter`, in which case the default text is equivalent to either the `sInventorySelectNoIngredients` or `sInventorySelectNoSoul` GMST value respectively.

--- a/misc/package/Data Files/MWSE/core/meta/lib/timer.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/timer.lua
@@ -16,7 +16,7 @@ timer = {}
 
 --- Creates a timer that will finish the next frame. It defaults to the next simulation frame.
 --- @param callback function The callback function that will execute when the timer expires.
---- @param type number? *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.
+--- @param type number? *Optional*. *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.
 --- @return mwseTimer timer No description yet available.
 function timer.delayOneFrame(callback, type) end
 
@@ -32,15 +32,15 @@ function timer.register(name, fn) end
 --- [Examples available in online documentation](https://mwse.github.io/MWSE/apis/timer/#timerstart).
 --- @param params timer.start.params This table accepts the following values:
 --- 
---- `type`: number? — *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.
+--- `type`: number? — *Optional*. *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.
 --- 
 --- `duration`: number — Duration of the timer. The method of time passing depends on the timer type.
 --- 
 --- `callback`: function — The callback function that will execute when the timer expires.
 --- 
---- `iterations`: number? — *Default*: `1`. The number of iterations to run. Use `-1` for infinite looping.
+--- `iterations`: number? — *Optional*. *Default*: `1`. The number of iterations to run. Use `-1` for infinite looping.
 --- 
---- `persist`: boolean? — *Default*: `true`. Registering a timer with persist flag set to `true` will serialize the callback string in the save to persist between sessions. Only a registered timer will persist between sessions. See `timer.register()`.
+--- `persist`: boolean? — *Optional*. *Default*: `true`. Registering a timer with persist flag set to `true` will serialize the callback string in the save to persist between sessions. Only a registered timer will persist between sessions. See `timer.register()`.
 --- 
 --- `data`: table? — *Optional*. Data to be attached to the timer. If this is a persistent timer, the data must be json-serializable, matching the same limitations as data stored on references.
 --- @return mwseTimer timer No description yet available.
@@ -48,10 +48,10 @@ function timer.start(params) end
 
 ---Table parameter definitions for `timer.start`.
 --- @class timer.start.params
---- @field type number? *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.
+--- @field type number? *Optional*. *Default*: ``timer.simulate``. Type of the timer. This value can be `timer.simulate`, `timer.game` or `timer.real`.
 --- @field duration number Duration of the timer. The method of time passing depends on the timer type.
 --- @field callback function The callback function that will execute when the timer expires.
---- @field iterations number? *Default*: `1`. The number of iterations to run. Use `-1` for infinite looping.
---- @field persist boolean? *Default*: `true`. Registering a timer with persist flag set to `true` will serialize the callback string in the save to persist between sessions. Only a registered timer will persist between sessions. See `timer.register()`.
+--- @field iterations number? *Optional*. *Default*: `1`. The number of iterations to run. Use `-1` for infinite looping.
+--- @field persist boolean? *Optional*. *Default*: `true`. Registering a timer with persist flag set to `true` will serialize the callback string in the save to persist between sessions. Only a registered timer will persist between sessions. See `timer.register()`.
 --- @field data table? *Optional*. Data to be attached to the timer. If this is a persistent timer, the data must be json-serializable, matching the same limitations as data stored on references.
 


### PR DESCRIPTION
IIRC, Seph you desired to always show it. So here I changed that so the *Optional* will always show up in the argument descriptions.