### PR TITLE
Implement operator definitions #374

### DIFF
--- a/autocomplete/builders/emmy.lua
+++ b/autocomplete/builders/emmy.lua
@@ -241,6 +241,19 @@ local function build(package)
 		writeFunction(package, file)
 	end
 
+	-- Write out operator overloads
+	for _, operator in ipairs(package.operators or {}) do
+		for _, overload in ipairs(operator.overloads) do
+			-- Handle unary operators
+			local rightSideType = ""
+			if overload.rightType then
+				rightSideType = string.format("(%s)", overload.rightType)
+			end
+
+			file:write(string.format("--- @operator %s%s: %s\n", operator.key, rightSideType, overload.resultType))
+		end
+	end
+
 	-- Write out fields.
 	for _, value in ipairs(package.values or {}) do
 		if (not value.deprecated) then

--- a/autocomplete/definitions/namedTypes/niColor/add.lua
+++ b/autocomplete/definitions/namedTypes/niColor/add.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "niColor", resultType = "niColor" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/niColor/mul.lua
+++ b/autocomplete/definitions/namedTypes/niColor/mul.lua
@@ -1,0 +1,7 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "niColor", resultType = "niColor" },
+		{ rightType = "number", resultType = "niColor" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/niColor/sub.lua
+++ b/autocomplete/definitions/namedTypes/niColor/sub.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "niColor", resultType = "niColor" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/niQuaternion/mul.lua
+++ b/autocomplete/definitions/namedTypes/niQuaternion/mul.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "niQuaternion", resultType = "niQuaternion" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3matrix33/add.lua
+++ b/autocomplete/definitions/namedTypes/tes3matrix33/add.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3matrix33", resultType = "tes3matrix33" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3matrix33/mul.lua
+++ b/autocomplete/definitions/namedTypes/tes3matrix33/mul.lua
@@ -1,0 +1,8 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3matrix33", resultType = "tes3matrix33" },
+		{ rightType = "tes3vector3", resultType = "tes3vector3" },
+		{ rightType = "number", resultType = "tes3matrix33" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3matrix33/sub.lua
+++ b/autocomplete/definitions/namedTypes/tes3matrix33/sub.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3matrix33", resultType = "tes3matrix33" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3matrix44/add.lua
+++ b/autocomplete/definitions/namedTypes/tes3matrix44/add.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3matrix44", resultType = "tes3matrix44" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3matrix44/mul.lua
+++ b/autocomplete/definitions/namedTypes/tes3matrix44/mul.lua
@@ -1,0 +1,7 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3matrix44", resultType = "tes3matrix44" },
+		{ rightType = "number", resultType = "tes3matrix44" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3matrix44/sub.lua
+++ b/autocomplete/definitions/namedTypes/tes3matrix44/sub.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3matrix44", resultType = "tes3matrix44" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector2/add.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector2/add.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3vector2", resultType = "tes3vector2" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector2/div.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector2/div.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "number", resultType = "tes3vector2" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector2/mul.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector2/mul.lua
@@ -1,0 +1,7 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3vector2", resultType = "tes3vector2" },
+		{ rightType = "number", resultType = "tes3vector2" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector2/sub.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector2/sub.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3vector2", resultType = "tes3vector2" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector3/add.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector3/add.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3vector3", resultType = "tes3vector3" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector3/div.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector3/div.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "number", resultType = "tes3vector3" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector3/len.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector3/len.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ resultType = "number" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector3/mul.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector3/mul.lua
@@ -1,0 +1,7 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3vector3", resultType = "tes3vector3" },
+		{ rightType = "number", resultType = "tes3vector3" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector3/sub.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector3/sub.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3vector3", resultType = "tes3vector3" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector4/add.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector4/add.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3vector4", resultType = "tes3vector4" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector4/div.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector4/div.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "number", resultType = "tes3vector4" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector4/len.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector4/len.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ resultType = "number" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector4/mul.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector4/mul.lua
@@ -1,0 +1,7 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3vector4", resultType = "tes3vector4" },
+		{ rightType = "number", resultType = "tes3vector4" },
+	}
+}

--- a/autocomplete/definitions/namedTypes/tes3vector4/sub.lua
+++ b/autocomplete/definitions/namedTypes/tes3vector4/sub.lua
@@ -1,0 +1,6 @@
+return {
+	type = "operator",
+	overloads = {
+		{ rightType = "tes3vector4", resultType = "tes3vector4" },
+	}
+}

--- a/misc/package/Data Files/MWSE/core/meta/class/niColor.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niColor.lua
@@ -6,6 +6,10 @@
 
 --- An object that represents a RGB color.
 --- @class niColor
+--- @operator add(niColor): niColor
+--- @operator mul(niColor): niColor
+--- @operator mul(number): niColor
+--- @operator sub(niColor): niColor
 --- @field b number The blue value of the color.
 --- @field blue number Alias for the blue value of the color.
 --- @field g number The green value of the color.

--- a/misc/package/Data Files/MWSE/core/meta/class/niQuaternion.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/niQuaternion.lua
@@ -6,6 +6,7 @@
 
 --- A rotation in quaternion representation.
 --- @class niQuaternion
+--- @operator mul(niQuaternion): niQuaternion
 --- @field w number The W component of the quaternion.
 --- @field x number The X component of the quaternion.
 --- @field y number The Y component of the quaternion.

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3matrix33.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3matrix33.lua
@@ -6,6 +6,11 @@
 
 --- A 3 by 3 matrix. You can perform following arithmetic with this type: `+`, `-`, `*`, and `==`.
 --- @class tes3matrix33
+--- @operator add(tes3matrix33): tes3matrix33
+--- @operator mul(tes3matrix33): tes3matrix33
+--- @operator mul(tes3vector3): tes3vector3
+--- @operator mul(number): tes3matrix33
+--- @operator sub(tes3matrix33): tes3matrix33
 --- @field x tes3vector3 The first row of the matrix.
 --- @field y tes3vector3 The second row of the matrix.
 --- @field z tes3vector3 The third row of the matrix.

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3matrix44.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3matrix44.lua
@@ -6,6 +6,10 @@
 
 --- A 4 by 4 matrix. You can perform following arithmetic with this type: `+`, `-`, `*`, and `==`.
 --- @class tes3matrix44
+--- @operator add(tes3matrix44): tes3matrix44
+--- @operator mul(tes3matrix44): tes3matrix44
+--- @operator mul(number): tes3matrix44
+--- @operator sub(tes3matrix44): tes3matrix44
 --- @field w tes3vector4 The 1st row of the matrix.
 --- @field x tes3vector4 The 2nd row of the matrix.
 --- @field y tes3vector4 The 3rd row of the matrix.

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3vector2.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3vector2.lua
@@ -6,6 +6,11 @@
 
 --- A simple pair of floating-point numbers. You can perform following arithmetic with this type: `+`, `-`, and `*`.
 --- @class tes3vector2
+--- @operator add(tes3vector2): tes3vector2
+--- @operator div(number): tes3vector2
+--- @operator mul(tes3vector2): tes3vector2
+--- @operator mul(number): tes3vector2
+--- @operator sub(tes3vector2): tes3vector2
 --- @field x number The first value in the vector.
 --- @field y number The second value in the vector.
 tes3vector2 = {}

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3vector3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3vector3.lua
@@ -6,6 +6,12 @@
 
 --- A simple trio of floating-point numbers. You can perform following arithmetic with this type: `+`, `-`, and `*`.
 --- @class tes3vector3
+--- @operator add(tes3vector3): tes3vector3
+--- @operator div(number): tes3vector3
+--- @operator len: number
+--- @operator mul(tes3vector3): tes3vector3
+--- @operator mul(number): tes3vector3
+--- @operator sub(tes3vector3): tes3vector3
 --- @field angle number The angle between the vector and the water plane.
 --- @field b number The third value in the vector. An alias for `z`.
 --- @field g number The second value in the vector. An alias for `y`.

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3vector4.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3vector4.lua
@@ -6,6 +6,12 @@
 
 --- A set of 4 floating-point numbers. You can perform following arithmetic with this type: `+`, `-`, and `*`.
 --- @class tes3vector4
+--- @operator add(tes3vector4): tes3vector4
+--- @operator div(number): tes3vector4
+--- @operator len: number
+--- @operator mul(tes3vector4): tes3vector4
+--- @operator mul(number): tes3vector4
+--- @operator sub(tes3vector4): tes3vector4
 --- @field w number The 1st value in the vector.
 --- @field x number The 2nd value in the vector.
 --- @field y number The 3rd value in the vector.


### PR DESCRIPTION
Adds support for documenting operators as per Sumneko's EmmyLua [specification](https://github.com/sumneko/lua-language-server/wiki/Annotations#operator). Currently supported operators (the names are the standard lua operator [metamethod names](http://lua-users.org/wiki/MetatableEvents) without the starting two underscores):
- unm - unary minus
- add - addition
- sub - subtraction
- mul - multiplication
- div - division
- idiv - floor division (division with rounding down to nearest integer), the `//` operator.
- mod - modulo, the `%` operator
- pow - the `^` operator
- concat - the `..` operator.
- len - the `#` operator

Sumneko's Lua language server supports annotations for other operators, which are bitwise operators (Lua 5.3), which don't make much sense in our classes.


## Writing operator definitions

To make annotations for operator overloads, you need to name your file like the Lua metamethod name of the operator (see the list above). The operator definitions should follow this format:
```Lua
return {
	type = "operator", -- Necessary for operator definitions
	overloads = {
		{ rightType = "niColor", resultType = "niColor" }, --first overload
		{ rightType = "number", resultType = "niColor" }, --second overload
		...
	}
}
```
The `rightType` field should be the right operand type, while the `resultType` is the resulting type of the expression. For example, the second overload is there for this kind of expressions:
```Lua
local myColor = niColor.new(1, 1, 1)
local mult = 0.5

local newColor = myColor * mult
-- newColor is of "niColor" type here
```


### Unary operators

In the unary operator definitions, you just don't specify the `rightType` field in the `overloads` table. Here is an example of a length (`#`) operator definition:
```Lua
return {
	type = "operator",
	overloads = {
		{ resultType = "number" },
	}
}
```
