### PR TITLE
Update config load to support recursive param

### DIFF
--- a/misc/package/Data Files/MWSE/core/mwse_init.lua
+++ b/misc/package/Data Files/MWSE/core/mwse_init.lua
@@ -788,9 +788,7 @@ function mwse.log(str, ...)
 end
 
 function mwse.loadConfig(fileName, defaults, recursive)
-	if (recursive == nil) then
-		recursive = true
-	end
+	local recursive = recursive or true
 
 	local result = json.loadfile(string.format("config\\%s", fileName))
 

--- a/misc/package/Data Files/MWSE/core/mwse_init.lua
+++ b/misc/package/Data Files/MWSE/core/mwse_init.lua
@@ -352,13 +352,13 @@ function table.deepcopy(t)
 	return copy
 end
 
-function table.copymissing(to, from)
+function table.copymissing(to, from, recursive)
 	if (type(to) ~= "table" or type(from) ~= "table") then
 		error("Arguments for table.copymissing must be tables.")
 	end
 
 	for k, v in pairs(from) do
-		if (type(to[k]) == "table" and type(v) == "table") then
+		if (recursive) and (type(to[k]) == "table" and type(v) == "table") then
 			table.copymissing(to[k], v)
 		else
 			if (to[k] == nil) then
@@ -787,12 +787,16 @@ function mwse.log(str, ...)
 	print(tostring(str):format(...))
 end
 
-function mwse.loadConfig(fileName, defaults)
+function mwse.loadConfig(fileName, defaults, recursive)
+	if (recursive == nil) then
+		recursive = true
+	end
+
 	local result = json.loadfile(string.format("config\\%s", fileName))
 
 	if (result) then
 		if (type(defaults) == "table") then
-			table.copymissing(result, defaults)
+			table.copymissing(result, defaults, recursive)
 		end
 	else
 		result = defaults


### PR DESCRIPTION
Refer to https://github.com/MWSE/MWSE/pull/378 for rationale.

This is a non-invasive solution that would require modders to introduce a third parameter to `mwse.loadConfig` calls. This will be a boolean argument that will revert to `true` if missing, but if `false` is passed instead, the config will load tables non-recursively, allowing exclusion pages to work as expected.

Modders should be made aware (I will gladly update the docs if the solution is accepted) that this means any complex tables will only be copied non-recursively.