### PR TITLE
Fix issue with exclusionsPage

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
@@ -91,7 +91,7 @@ function ExclusionsPage:toggle(e)
 	if list == self.elements.leftList then
 		list = self.elements.rightList
 		local var = self.variable.value
-		var[text] = nil
+		var[text] = false
 		self.variable.value = var
 	else
 		list = self.elements.leftList


### PR DESCRIPTION
This will prevent the removed default entries in the exclusionsPage from reappearing on each call of the `mwse.loadConfig`. 

Before, this usually occurred when the game was restarted and the mod's mcm was opened again. The `mwse.loadConfig` would fill in the missing values in the table from the ones in `defaultConfig`, which made the entries in the exclusionsPage removed by the user in the last game run reappear.

An alternative to #387, but this one doesn't require the mods using exclusionsPage to change any of their code to make their pages work. On the other hand, this one makes all the explicitly disabled entries end up in the mod's configuration `.json` file.