### PR TITLE
Add a reference page on NI classes hierarchy

### DIFF
--- a/autocomplete/definitions/global/mwscript/stopScript.lua
+++ b/autocomplete/definitions/global/mwscript/stopScript.lua
@@ -1,6 +1,6 @@
 return {
 	type = "function",
-	description = [[Wrapper for the `StopCombat` mwscript function.]],
+	description = [[Wrapper for the `StopScript` mwscript function.]],
 	arguments = {{
 		name = "params",
 		type = "table",

--- a/autocomplete/definitions/global/tes3/get3rdPersonCameraOffset.lua
+++ b/autocomplete/definitions/global/tes3/get3rdPersonCameraOffset.lua
@@ -1,8 +1,9 @@
 return {
 	type = "function",
-	description = [[Returns the camera's offset from the player's head while in 3rd person view.
+	description = [[Returns the camera offset from the player's head while in 3rd person view.
 
-Note this function can be used once WorldController and MobilePlayer have finished initializing.]],
+!!! tip
+	If used before initialized event, this function returns empty table.]],
 	returns = "cameraOffset",
 	valuetype = "tes3vector3",
 }

--- a/autocomplete/definitions/global/tes3/set3rdPersonCameraOffset.lua
+++ b/autocomplete/definitions/global/tes3/set3rdPersonCameraOffset.lua
@@ -1,9 +1,14 @@
 return {
 	type = "function",
-	description = [[Changes the 3rd person camera's offset from the player's head.
+	description = [[Changes the 3rd person camera offset from the player's head.
 
-Note this function can be used once WorldController and MobilePlayer have finished initializing.]],
-	arguments = {
-		{ name = "offset", type = "tes3vector3", description = "The offset vector." },
-	},
+!!! important
+	This function can be used once tes3worldController and tes3mobilePlayer have finished initializing.]],
+	arguments = {{
+		name = "params",
+		type = "table",
+		tableParams = {
+			{ name = "offset", type = "tes3vector3", description = "The offset vector." },
+		},
+	}},
 }

--- a/autocomplete/definitions/namedTypes/tes3bodyPartManager/setBodyPartForObject.lua
+++ b/autocomplete/definitions/namedTypes/tes3bodyPartManager/setBodyPartForObject.lua
@@ -1,6 +1,6 @@
 return {
 	type = "method",
-	description = [[The method sets a new body part for a given object.]],
+	description = [[The method sets a new body part for a given object. Triggers `bodyPart` event.]],
 	arguments = {
 		{ name = "object", type = "tes3physicalObject", description = "An object whose body part to set." },
 		{ name = "index", type = "number", description = "A value from [`tes3.activeBodyPart`](https://mwse.github.io/MWSE/references/active-body-parts/) namespace." },

--- a/docs/source/apis/mwscript.md
+++ b/docs/source/apis/mwscript.md
@@ -729,7 +729,7 @@ local executed = mwscript.stopCombat({ reference = ..., target = ... })
 
 ### `mwscript.stopScript`
 
-Wrapper for the `StopCombat` mwscript function.
+Wrapper for the `StopScript` mwscript function.
 
 ```lua
 local executed = mwscript.stopScript({ reference = ..., script = ... })

--- a/docs/source/apis/tes3.md
+++ b/docs/source/apis/tes3.md
@@ -1464,9 +1464,10 @@ local changedPOV = tes3.force3rdPerson()
 
 ### `tes3.get3rdPersonCameraOffset`
 
-Returns the camera's offset from the player's head while in 3rd person view.
+Returns the camera offset from the player's head while in 3rd person view.
 
-Note this function can be used once WorldController and MobilePlayer have finished initializing.
+!!! tip
+	If used before initialized event, this function returns empty table.
 
 ```lua
 local cameraOffset = tes3.get3rdPersonCameraOffset()
@@ -3604,17 +3605,19 @@ tes3.say({ reference = ..., soundPath = ..., pitch = ..., volume = ..., forceSub
 
 ### `tes3.set3rdPersonCameraOffset`
 
-Changes the 3rd person camera's offset from the player's head.
+Changes the 3rd person camera offset from the player's head.
 
-Note this function can be used once WorldController and MobilePlayer have finished initializing.
+!!! important
+	This function can be used once tes3worldController and tes3mobilePlayer have finished initializing.
 
 ```lua
-tes3.set3rdPersonCameraOffset(offset)
+tes3.set3rdPersonCameraOffset({ offset = ... })
 ```
 
 **Parameters**:
 
-* `offset` ([tes3vector3](../../types/tes3vector3)): The offset vector.
+* `params` (table)
+	* `offset` ([tes3vector3](../../types/tes3vector3)): The offset vector.
 
 ***
 

--- a/docs/source/references/other/ni-class-hierarchy.md
+++ b/docs/source/references/other/ni-class-hierarchy.md
@@ -1,227 +1,224 @@
-# NI Class Hiererchy
+# The Hierarchy of NetImmerse Classes
+
+This page puts into relation various classes that compromise Morrowind's scene graph. Some of these classes are abstract, meaning they aren't directly found in the scene graph, but are used by other classes to inherit common variables and methods. Game's scene graph can be inspected by entering ssg (show scene graph) command in the console. Morrowind's engine is Gamebryo, which was before known as NetImmerse. That's why these classes have prefix ni in their name. These classes in MWSE follow the naming as in the vanilla engine. But, there are some classes that contain information about the scene graph in MWSE and have tes3 prefix such as `tes3vector3`.
+
+The primary building blocks of scene graph are called nodes. Each node has one parent and zero or more child nodes. For example, the base node of the Morrowind's world scene graph, named `worldRoot`, and all the game world objects are represented by nodes that are children of `worldRoot` node.
+
+Note that the relations described here don't reflect how these types are organized in the scene graph. For instance, `worldRoot` node mentioned earlier is of type `niNode`, but is the root node of the world's scene graph, while the base class of most types described here is `niObject`.
+
+The types are arranged into functional groupings. Within each grouping, indentation implies inheritance from the class of the previous indentation level. The color of the taxt carries the following meanings:
+ - <span style = "color:Turquoise">Turquoise - Classes read by MWSE but not yet exposed to Lua scripts</span>
+ - <span style = "color:YellowGreen">Green - Classes present in Morrowind but not yet read by MWSE</span>
+ - All the other classes in standard text color in this list are available in Lua scripts
+
+---
 
 ## niMain
 
 ### Basic Foundation Types
-- niColor
-- niColorA
-- niPackedColor
-- niRTTI
+ - niColor
+ - niColorA
+ - niPackedColor
+ - niRTTI
 
 ### Basic Math and Geometry Classes
-- niBound - not exposed yet!!
-- tes3boundingBox - not a NI Class
-- tes3matrix33 - not a NI Class
-- tes3vector2 - not a NI Class
-- tes3vector3 - not a NI Class
-- niQuaternion
-- tes3transform - not a NI Class
+ - <span style = "color:Turquoise">niBound</span>
+ - tes3boundingBox
+ - tes3matrix33
+ - tes3vector2
+ - tes3vector3
+ - niQuaternion
+ - tes3transform
 
 ### Templated Container Classes
-- niTArray - not exposed as a type but can be iterated as a standard lua array
-- niLinkedList
+ - niTArray - not exposed as a type but can be iterated as a standard Lua array.
+ - niLinkedList
 	- niDynamicEffectLinkedList
 	- niNodeLinkedList
 	- niPropertyLinkedList
 
 ### Animation Classes
-- niRefObject
-	- niObject
-		- niTimeController
-
-### Collision Classes
-- niCollisionObject
+ - niObject
+	- niTimeController
+	- niObjectNET
+		- niAVObject
+			- niNode
+				- <span  style = "color:YellowGreen">niBSAnimationManager</span>
+				- <span  style = "color:YellowGreen">niBSAnimationNode</span>
+					- <span  style = "color:YellowGreen">niBSParticleNode</span>
+		- <span  style = "color:YellowGreen">niSequenceStreamHelper</span>
 
 ### Texturing Classes
-- niRefObject
-	- niObject
-		- niObjectNET
-			- niTexture
-				- niRenderedTexture - Not exposed
-					- niRenderedCubeMap - We don't have this one
-				- niSourceTexture
-					- niSourceCubeMap - We don't have this one
-		- niPalette - We don't have this one
-		- niPixelData
-		- niScreenTexture - We don't have this one
+- niObject
+	- <span  style = "color:YellowGreen">niBltSource</span>
+	- niObjectNET
+		- niTexture
+			- <span style = "color:Turquoise">niRenderedTexture</span>
+				- <span  style = "color:YellowGreen">niRenderedCubeMap</span >
+			- niSourceTexture
+	- <span  style = "color:YellowGreen">niPalette</span>
+	- niPixelData
+- <span style = "color:Turquoise">niPixelFormat</span>
 
 ### Object Depth Sorting Classes
-- niRefObject
-	- niObject
-		- niAccumulator - We don't have this one
-			- niBackToFrontAccumulator/niClusterAccumulator (are the two the same?) - We don't have neither one
-				- niAlphaAccumulator - We don't have this one
-					- niTextureAccumulator - We don't have this one
+- niObject
+	- <span  style = "color:YellowGreen">niAccumulator</span>
+		- <span  style = "color:YellowGreen">niClusterAccumulator</span>
+			- <span  style = "color:YellowGreen">niAlphaAccumulator</span>
 
 ### Geometry Data Classes
-- niRefObject
-	- niObject
-		- niGeometryData
-			- niLinesData - not exposed yet!!
-			- niTriBasedGeomData
-				- niParticlesData
-					- niParticleMeshesData - We don't have this one
-					- niAutoNormalParticlesData - We don't have this one
-					- niRotatingParticlesData
-				- niTriShapeData
-					- NiScreenGeometryData - We don't have this one
-					- niTriShapeDynamicData - We don't have this one
-				- niTriStripsData - We don't have this one
+- niObject
+	- niGeometryData
+		- <span style = "color:Turquoise">niLinesData</span>
+		- niTriBasedGeomData
+			- niParticlesData
+				- <span  style = "color:YellowGreen">niAutoNormalParticlesData</span>
+				- niRotatingParticlesData
+			- niTriShapeData
+				- <span  style = "color:YellowGreen">niTriShapeDynamicData</span>
+			- <span  style = "color:YellowGreen">niTriStripsData</span>
 
 ### Geometry Rendering Classes
-- niRefObject
-	- niObject
-		- niObjectNET
-			- niAVObject
-				- niGeometry - not exposed yet!!
-					- niLines - not exposed yet!!
-					- niTriBasedGeometry - not exposed yet!!
-						- niTriShape
-							- niScreenGeometry - We don't have this one
-						- niTriStrips - We don't have this one
-						- niParticles
-							- niParticleMeshes - We don't have this one
-							- niRotatingParticles
-		- niScreenPolygon - not exposed yet!!
-		- niSkinData
-		- niSkinInstance
+- niObject
+	- niObjectNET
+		- niAVObject
+			- <span style = "color:Turquoise">niGeometry</span>
+				- <span style = "color:Turquoise">niLines</span>
+				- <span style = "color:Turquoise">niTriBasedGeometry</span>
+					- niTriShape
+					- <span  style = "color:YellowGreen">niTriStrips</span>
+					- niParticles
+						- <span  style = "color:YellowGreen">niAutoNormalParticles</span>
+						- niRotatingParticles
+	- <span style = "color:Turquoise">niScreenPolygon</span>
+	- niSkinData
+	- niSkinDataBoneData
+	- niSkinDataBoneDataVertexWeight
+	- niSkinInstance
+	- niSkinPartition
+	- niSkinPartitionPartition
 
 ### Scene Graph Organization Classes
-- niRefObject
-	- niObject
-		- niExtraData
-			- niBinaryExtraData - We don't have this one
-			- niBooleanExtraData - We don't have this one
-			- niColorExtraData - We don't have this one
-			- niFloatExtraData - We don't have this one
-			- niFloatsExtraData - We don't have this one
-			- niIntegerExtraData - We don't have this one
-			- niIntegersExtraData - We don't have this one
-			- niStringExtraData
-			- niStringsExtraData - We don't have this one
-			- niSwitchStringExtraData - We don't have this one
-			- niTES3ExtraData
-			- niTextKeyExtraData
-			- niVectorExtraData - We don't have this one
-		- niObjectNET
-			- niAVObject
-				- niNode
-					- niBillboardNode
-					- niBSPNode - We don't have this one
-					- niCollisionSwitch
-					- niSortAdjustNode - We don't have this one
-					- niSwitchNode
-						- niLODNode - We don't have this one
-- niTextKey - animation class
+- niObject
+	- niExtraData
+		- <span  style = "color:YellowGreen">BrickNiExtraData</span>
+		- niStringExtraData
+		- niTES3ExtraData
+		- niTextKeyExtraData
+		- <span  style = "color:YellowGreen">niVertWeightsExtraData</span>
+	- niObjectNET
+		- niAVObject
+			- niNode
+				- <span  style = "color:YellowGreen">AvoidNode</span>
+				- niBillboardNode
+				- <span  style = "color:YellowGreen">niBSPNode</span>
+				- <span  style = "color:YellowGreen">niSortAdjustNode</span>
+				- niSwitchNode
+					- <span  style = "color:YellowGreen">niFltAnimationNode</span>
+					- <span  style = "color:YellowGreen">niLODNode</span>
 
 ### Lightning and Effects Classes
-- niRefObject
-	- niObject
-		- niObjectNET
-			- niAVObject
-				- niDynamicEffect
-			    	- niLight
-				    	- niAmbientLight
-						- niDirectionalLight
-						- niPointLight
-							- niSpotLight
-					- niTextureEffect
+- niObject
+	- niObjectNET
+		- niAVObject
+			- niDynamicEffect
+				- niLight
+					- niAmbientLight
+					- niDirectionalLight
+					- niPointLight
+						- niSpotLight
+				- niTextureEffect
 
 ### Rendering and Property Classes
-- niRefObject
-	- niObject
-		- niObjectNET
-			- niAVObject
-				- niCamera
-					- niScreenSpaceCamera - We don't have this one
-			- niProperty
-				- niAlphaProperty
-				- niDitherProperty - We don't have this one
-				- niFogProperty
-				- niMaterialProperty
-				- niRendererSpecificProperty - We don't have this one
-				- niShadeProperty - We don't have this one
-				- niSpecularProperty - We don't have this one
-				- niStencilProperty
-				- niTexturingProperty
-				- niVertexColorProperty
-				- niWireframeProperty - We don't have this one (yet)
-				- niZBufferProperty
-		- niRenderer - no exposed yet
-	- niPropertyState
+- niObject
+	- niObjectNET
+		- niAVObject
+			- niCamera
+		- niProperty
+			- niAlphaProperty
+			- <span  style = "color:YellowGreen">niDitherProperty</span>
+			- niFogProperty
+			- niMaterialProperty
+			- <span  style = "color:YellowGreen">niRendererSpecificProperty</span>
+			- <span  style = "color:YellowGreen">niShadeProperty</span>
+			- <span  style = "color:YellowGreen">niSpecularProperty</span>
+			- niStencilProperty
+			- niTexturingProperty
+			- niVertexColorProperty
+			- <span  style = "color:YellowGreen">niWireframeProperty</span>
+			- niZBufferProperty
+	- <span style = "color:Turquoise">niRenderer</span>
+		- <span  style = "color:YellowGreen">niDX8Renderer</span>
 
+---
 
-## niOldParticle
+## niParticle
 
 ### Particle System Classes
-- niRefObject
-	- niObject
-		- niEmitterModifier - Wo don't have this one
-		- niParticleModifier
-			- niGravity
-			- niParticleBomb
-			- niParticleCollider
-				- niPlanarCollider
-				- niSphericalCollider
-			- niParticleColorModifier
-			- niParticleGrowFade
-			- niParticleMeshModifier
-			- niParticleRotation
-		- niTimeController - Not only related to particles
-			- niParticleSystemController
-- niPerParticleData
+- niObject
+	- <span  style = "color:YellowGreen">niEmitterModifier - Wo don't have this one</span>
+	- niParticleModifier
+		- niGravity
+		- niParticleBomb
+		- niParticleCollider
+			- niPlanarCollider
+			- niSphericalCollider
+		- niParticleColorModifier
+		- niParticleGrowFade
+		- niParticleRotation
+	- niTimeController - Not only related to particles
+		- niParticleSystemController
+- <span style = "color:Turquoise">niPerParticleData</span>
 
+---
 
 ## niCollision
 
 ### Collision Classes
 - niCollisionGroup
 - niCollisionGroupRecord
-- niRefObject
-	- niObject
-		- niObjectNET
-			- niAVObject
-				- niNode
-					- niCollisionSwitch
+- niObject
+	- niObjectNET
+		- niAVObject
+			- niNode
+				- <span  style = "color:YellowGreen">RootCollisionNode</span>
+				- niCollisionSwitch
 - niPick
+- niPickRecord
 
+---
 
 ## niAnimation
 
 ### Animation Classes
-- niRefObject - TODO REMOVE
-	- niActorManager - We don't have this one
-	- niKGMTool - We don't have this one
-	- niObject
-		- niColorData
-		- niControllerSequence - We don't have this one
-		- niExtraData - Not related to animation
-			- niTextKeyExtraData
-		- niKeyframeData
-		- niMorphData - We don't have this one yet
-		- niPosData - Not exposed yet
-		- niSequence - not exposed yet
-		- niTimeController -- TODO Document all of the subtypes
-			- niControllerManager - We don't have this one
-			- niFlipController - Not exposed yet
-			- niFloatController - We don't have this one
-				- niAlphaController - We don't have this one yet
-				- niRollController - We don't have this one
-			- niKeyframeController
-			- niKeyframeManager - Not exposed yet
-			- niLightColorController - We don't have this one
-			- niLookAtController
-			- niMaterialColorController - We don't have this one yet
-			- niMorpherController - We don't have this one
-				- niGeomMorpherController - We don't have this one
-			- niParticleSystemController
-				- niBSPArrayController - We don't have this one yet
-			- niPathController - We don't have this one yet
-			- niTextureTransformController - We don't have this one
-			- niUVController - Not exposed yet
-			- niVisController - We don't have this one yet
-		- niUVData - not exposed yet
-		- niVisData - we don't have this one yet
+- niObject
+	- niColorData
+	- niExtraData - Not related to animation
+		- niTextKeyExtraData
+	- <span  style = "color:YellowGreen">niFloatData</span>
+	- niKeyframeData
+	- <span  style = "color:YellowGreen">niMorphData</span>
+	- <span style = "color:Turquoise">niPosData</span>
+	- <span style = "color:Turquoise">niSequence</span>
+	- niTimeController
+		- <span style = "color:Turquoise">niFlipController</span>
+		- <span  style = "color:YellowGreen">niFloatController</span>
+			- <span  style = "color:YellowGreen">niAlphaController</span>
+			- <span  style = "color:YellowGreen">niRollController</span>
+		- niKeyframeController
+		- <span style = "color:Turquoise">niKeyframeManager</span>
+		- <span  style = "color:YellowGreen">niLightColorController</span>
+		- niLookAtController
+		- <span  style = "color:YellowGreen">niMaterialColorController</span>
+		- <span  style = "color:YellowGreen">niMorpherController</span>
+			- <span  style = "color:YellowGreen">niGeomMorpherController</span>
+		- niParticleSystemController
+			- <span  style = "color:YellowGreen">niBSPArrayController</span>
+		- <span  style = "color:YellowGreen">niPathController</span>
+		- <span style = "color:Turquoise">niUVController</span>
+		- <span  style = "color:YellowGreen">niVisController</span>
+	- <span style = "color:Turquoise">niUVData</span>
+	- <span  style = "color:YellowGreen">niVisData</span>
 - niAnimationKey
 	- niColorKey
 	- niFloatKey
@@ -235,7 +232,6 @@
 		- niTCBRotKey
 		- niEulerRotKey
 - niTextKey
-- niVisKey - We don't have this one
 
 
 ```mermaid
@@ -256,4 +252,10 @@ graph LR
     L --> M(NiLight);
     M --> N(NiPointLight);
     N --> O(NiSpotLight);
+
+    classDef notExposed fill:#ADFF2F,stroke:#333,stroke-width:2px;
+    class B,C,D notExposed;
+
+    classDef notResearched fill:#40E0D0,stroke:#333,stroke-width:2px;
+    class F,J notResearched;
 ```

--- a/docs/source/references/other/ni-class-hierarchy.md
+++ b/docs/source/references/other/ni-class-hierarchy.md
@@ -1,0 +1,259 @@
+# NI Class Hiererchy
+
+## niMain
+
+### Basic Foundation Types
+- niColor
+- niColorA
+- niPackedColor
+- niRTTI
+
+### Basic Math and Geometry Classes
+- niBound - not exposed yet!!
+- tes3boundingBox - not a NI Class
+- tes3matrix33 - not a NI Class
+- tes3vector2 - not a NI Class
+- tes3vector3 - not a NI Class
+- niQuaternion
+- tes3transform - not a NI Class
+
+### Templated Container Classes
+- niTArray - not exposed as a type but can be iterated as a standard lua array
+- niLinkedList
+	- niDynamicEffectLinkedList
+	- niNodeLinkedList
+	- niPropertyLinkedList
+
+### Animation Classes
+- niRefObject
+	- niObject
+		- niTimeController
+
+### Collision Classes
+- niCollisionObject
+
+### Texturing Classes
+- niRefObject
+	- niObject
+		- niObjectNET
+			- niTexture
+				- niRenderedTexture - Not exposed
+					- niRenderedCubeMap - We don't have this one
+				- niSourceTexture
+					- niSourceCubeMap - We don't have this one
+		- niPalette - We don't have this one
+		- niPixelData
+		- niScreenTexture - We don't have this one
+
+### Object Depth Sorting Classes
+- niRefObject
+	- niObject
+		- niAccumulator - We don't have this one
+			- niBackToFrontAccumulator/niClusterAccumulator (are the two the same?) - We don't have neither one
+				- niAlphaAccumulator - We don't have this one
+					- niTextureAccumulator - We don't have this one
+
+### Geometry Data Classes
+- niRefObject
+	- niObject
+		- niGeometryData
+			- niLinesData - not exposed yet!!
+			- niTriBasedGeomData
+				- niParticlesData
+					- niParticleMeshesData - We don't have this one
+					- niAutoNormalParticlesData - We don't have this one
+					- niRotatingParticlesData
+				- niTriShapeData
+					- NiScreenGeometryData - We don't have this one
+					- niTriShapeDynamicData - We don't have this one
+				- niTriStripsData - We don't have this one
+
+### Geometry Rendering Classes
+- niRefObject
+	- niObject
+		- niObjectNET
+			- niAVObject
+				- niGeometry - not exposed yet!!
+					- niLines - not exposed yet!!
+					- niTriBasedGeometry - not exposed yet!!
+						- niTriShape
+							- niScreenGeometry - We don't have this one
+						- niTriStrips - We don't have this one
+						- niParticles
+							- niParticleMeshes - We don't have this one
+							- niRotatingParticles
+		- niScreenPolygon - not exposed yet!!
+		- niSkinData
+		- niSkinInstance
+
+### Scene Graph Organization Classes
+- niRefObject
+	- niObject
+		- niExtraData
+			- niBinaryExtraData - We don't have this one
+			- niBooleanExtraData - We don't have this one
+			- niColorExtraData - We don't have this one
+			- niFloatExtraData - We don't have this one
+			- niFloatsExtraData - We don't have this one
+			- niIntegerExtraData - We don't have this one
+			- niIntegersExtraData - We don't have this one
+			- niStringExtraData
+			- niStringsExtraData - We don't have this one
+			- niSwitchStringExtraData - We don't have this one
+			- niTES3ExtraData
+			- niTextKeyExtraData
+			- niVectorExtraData - We don't have this one
+		- niObjectNET
+			- niAVObject
+				- niNode
+					- niBillboardNode
+					- niBSPNode - We don't have this one
+					- niCollisionSwitch
+					- niSortAdjustNode - We don't have this one
+					- niSwitchNode
+						- niLODNode - We don't have this one
+- niTextKey - animation class
+
+### Lightning and Effects Classes
+- niRefObject
+	- niObject
+		- niObjectNET
+			- niAVObject
+				- niDynamicEffect
+			    	- niLight
+				    	- niAmbientLight
+						- niDirectionalLight
+						- niPointLight
+							- niSpotLight
+					- niTextureEffect
+
+### Rendering and Property Classes
+- niRefObject
+	- niObject
+		- niObjectNET
+			- niAVObject
+				- niCamera
+					- niScreenSpaceCamera - We don't have this one
+			- niProperty
+				- niAlphaProperty
+				- niDitherProperty - We don't have this one
+				- niFogProperty
+				- niMaterialProperty
+				- niRendererSpecificProperty - We don't have this one
+				- niShadeProperty - We don't have this one
+				- niSpecularProperty - We don't have this one
+				- niStencilProperty
+				- niTexturingProperty
+				- niVertexColorProperty
+				- niWireframeProperty - We don't have this one (yet)
+				- niZBufferProperty
+		- niRenderer - no exposed yet
+	- niPropertyState
+
+
+## niOldParticle
+
+### Particle System Classes
+- niRefObject
+	- niObject
+		- niEmitterModifier - Wo don't have this one
+		- niParticleModifier
+			- niGravity
+			- niParticleBomb
+			- niParticleCollider
+				- niPlanarCollider
+				- niSphericalCollider
+			- niParticleColorModifier
+			- niParticleGrowFade
+			- niParticleMeshModifier
+			- niParticleRotation
+		- niTimeController - Not only related to particles
+			- niParticleSystemController
+- niPerParticleData
+
+
+## niCollision
+
+### Collision Classes
+- niCollisionGroup
+- niCollisionGroupRecord
+- niRefObject
+	- niObject
+		- niObjectNET
+			- niAVObject
+				- niNode
+					- niCollisionSwitch
+- niPick
+
+
+## niAnimation
+
+### Animation Classes
+- niRefObject - TODO REMOVE
+	- niActorManager - We don't have this one
+	- niKGMTool - We don't have this one
+	- niObject
+		- niColorData
+		- niControllerSequence - We don't have this one
+		- niExtraData - Not related to animation
+			- niTextKeyExtraData
+		- niKeyframeData
+		- niMorphData - We don't have this one yet
+		- niPosData - Not exposed yet
+		- niSequence - not exposed yet
+		- niTimeController -- TODO Document all of the subtypes
+			- niControllerManager - We don't have this one
+			- niFlipController - Not exposed yet
+			- niFloatController - We don't have this one
+				- niAlphaController - We don't have this one yet
+				- niRollController - We don't have this one
+			- niKeyframeController
+			- niKeyframeManager - Not exposed yet
+			- niLightColorController - We don't have this one
+			- niLookAtController
+			- niMaterialColorController - We don't have this one yet
+			- niMorpherController - We don't have this one
+				- niGeomMorpherController - We don't have this one
+			- niParticleSystemController
+				- niBSPArrayController - We don't have this one yet
+			- niPathController - We don't have this one yet
+			- niTextureTransformController - We don't have this one
+			- niUVController - Not exposed yet
+			- niVisController - We don't have this one yet
+		- niUVData - not exposed yet
+		- niVisData - we don't have this one yet
+- niAnimationKey
+	- niColorKey
+	- niFloatKey
+		- niBezFloatKey
+		- niTCBFloatKey
+	- niPosKey
+		- niBezPosKey
+		- niTCBPosKey
+	- niRotKey
+		- niBezRotKey
+		- niTCBRotKey
+		- niEulerRotKey
+- niTextKey
+- niVisKey - We don't have this one
+
+
+```mermaid
+graph LR
+    A(NiObject) --> B(NiAccumulator);
+    B --> C(NiClusterAccumulator);
+    C --> D(NiAlphaAccumulator);
+
+    A --> E(NiExtraData);
+    E --> F(BrickNiExtraData);
+    E --> G(TES3ObjectExtraData);
+    E --> H(NiStringExtraData);
+    E --> I(NiTextKeyExtraData);
+    E --> J(NiVertWeightsExtraData);
+
+    A --> K(NiObjectNET);
+    K --> L(NiDynamicEffect);
+    L --> M(NiLight);
+    M --> N(NiPointLight);
+    N --> O(NiSpotLight);
+```

--- a/docs/source/types/tes3bodyPartManager.md
+++ b/docs/source/types/tes3bodyPartManager.md
@@ -153,7 +153,7 @@ myObject:setBodyPartByIdForObject(object, index, bodyPartId, isFirstPerson)
 
 ### `setBodyPartForObject`
 
-The method sets a new body part for a given object.
+The method sets a new body part for a given object. Triggers `bodyPart` event.
 
 ```lua
 myObject:setBodyPartForObject(object, index, bodyPart, isFirstPerson)

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPartManager.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3bodyPartManager.lua
@@ -46,7 +46,7 @@ function tes3bodyPartManager:setActivePartData(layer, index, overwriteData, node
 --- @param isFirstPerson boolean? *Default*: `false`. A flag which controls whether the body part is used in first person.
 function tes3bodyPartManager:setBodyPartByIdForObject(object, index, bodyPartId, isFirstPerson) end
 
---- The method sets a new body part for a given object.
+--- The method sets a new body part for a given object. Triggers `bodyPart` event.
 --- @param object tes3activator|tes3alchemy|tes3apparatus|tes3armor|tes3bodyPart|tes3book|tes3clothing|tes3container|tes3containerInstance|tes3creature|tes3creatureInstance|tes3door|tes3ingredient|tes3leveledCreature|tes3leveledItem|tes3light|tes3lockpick|tes3misc|tes3npc|tes3npcInstance|tes3probe|tes3repairTool|tes3static|tes3weapon An object whose body part to set.
 --- @param index number A value from [`tes3.activeBodyPart`](https://mwse.github.io/MWSE/references/active-body-parts/) namespace.
 --- @param bodyPart tes3bodyPart The `tes3bodyPart` object to set as a new body part for given object.

--- a/misc/package/Data Files/MWSE/core/meta/lib/mwscript.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mwscript.lua
@@ -547,7 +547,7 @@ function mwscript.stopCombat(params) end
 --- @field reference tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string|nil *Optional*. The target reference for this command to be executed on. Defaults to the normal script execution reference.
 --- @field target tes3reference|tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string Actor to stop combat with.
 
---- Wrapper for the `StopCombat` mwscript function.
+--- Wrapper for the `StopScript` mwscript function.
 --- @deprecated
 --- @param params mwscript.stopScript.params This table accepts the following values:
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -922,9 +922,10 @@ function tes3.force1stPerson() end
 --- @return boolean changedPOV No description yet available.
 function tes3.force3rdPerson() end
 
---- Returns the camera's offset from the player's head while in 3rd person view.
+--- Returns the camera offset from the player's head while in 3rd person view.
 --- 
---- Note this function can be used once WorldController and MobilePlayer have finished initializing.
+--- !!! tip
+--- 	If used before initialized event, this function returns empty table.
 --- @return tes3vector3 cameraOffset No description yet available.
 function tes3.get3rdPersonCameraOffset() end
 
@@ -2056,11 +2057,18 @@ function tes3.say(params) end
 --- @field forceSubtitle boolean? *Default*: `false`. If true a subtitle will be shown, even if subtitles are disabled.
 --- @field subtitle string? *Optional*. The subtitle to show if subtitles are enabled, or if forceSubtitle is set.
 
---- Changes the 3rd person camera's offset from the player's head.
+--- Changes the 3rd person camera offset from the player's head.
 --- 
---- Note this function can be used once WorldController and MobilePlayer have finished initializing.
---- @param offset tes3vector3 The offset vector.
-function tes3.set3rdPersonCameraOffset(offset) end
+--- !!! important
+--- 	This function can be used once tes3worldController and tes3mobilePlayer have finished initializing.
+--- @param params tes3.set3rdPersonCameraOffset.params This table accepts the following values:
+--- 
+--- `offset`: tes3vector3 — The offset vector.
+function tes3.set3rdPersonCameraOffset(params) end
+
+---Table parameter definitions for `tes3.set3rdPersonCameraOffset`.
+--- @class tes3.set3rdPersonCameraOffset.params
+--- @field offset tes3vector3 The offset vector.
 
 --- Configures a mobile actor to activate an object.
 --- @param params tes3.setAIActivate.params This table accepts the following values:


### PR DESCRIPTION
I'd like some feedback:
1. Which classes should I remove? Some only exist in newer versions of Gamebryo so they aren't relevant for Morrowind, some exist in Morrowind but they aren't present in MWSE's code, while some are present in MWSE, but aren't yet exposed to Lua scripting. I'd prefer to leave all the classes supported by Morrowind be they exposed to Lua/MWSE or not.
2. I mostly followed the grouping as in the official documentation, so I also put some classes which we use in place of NI classes such as tes3matrix33. What are your opinions on that?
3. Any other thoughts or suggestions?


Please ignore the first commit, it wasn't meant to end in this PR.

I might organize this into a Mermaid diagram once we settle on how this should look like. That's why I have an example of such a diagram at the bottom of the page.