### PR TITLE
Add an option to log to console to lua logger API

### DIFF
--- a/docs/source/guides/logging.md
+++ b/docs/source/guides/logging.md
@@ -30,8 +30,9 @@ In the MWSE MCM, there is an option to enable log colors. This will display logs
 ```lua
 local logger = require("logging.logger")
 local log = logger.new{
-    name = "Test Mod",
-    logLevel = "TRACE",
+	name = "Test Mod",
+	logLevel = "TRACE",
+	logToConsole = true,
 }
 log:trace("This is a trace message")
 log:debug("This is a debug message")
@@ -40,6 +41,11 @@ log:warn("This is a warn message")
 log:error("This is an error message")
 
 log:setLogLevel("INFO")
+
+-- To disable logging to the in-game console, set the logToConsole field to false
+log.logToConsole = false
+
+-- After this point no logging messages will be logged to the in-game console
 ```
 
 ## Using your logger in different source files
@@ -59,19 +65,19 @@ log:info("This is an info message")
 In your MCM config, create a dropdown with the following options:
 ```lua
 settings:createDropdown{
-  label = "Logging Level",
-  description = "Set the log level.",
-  options = {
-    { label = "TRACE", value = "TRACE"},
-    { label = "DEBUG", value = "DEBUG"},
-    { label = "INFO", value = "INFO"},
-    { label = "WARN", value = "WARN"},
-    { label = "ERROR", value = "ERROR"},
-    { label = "NONE", value = "NONE"},
-  },
-  variable = mwse.mcm.createTableVariable{ id = "logLevel", table = mcmConfig },
-  callback = function(self)
-    log:setLogLevel(self.variable.value)
-  end
+	label = "Logging Level",
+	description = "Set the log level.",
+	options = {
+		{ label = "TRACE", value = "TRACE"},
+		{ label = "DEBUG", value = "DEBUG"},
+		{ label = "INFO", value = "INFO"},
+		{ label = "WARN", value = "WARN"},
+		{ label = "ERROR", value = "ERROR"},
+		{ label = "NONE", value = "NONE"},
+	},
+	variable = mwse.mcm.createTableVariable{ id = "logLevel", table = mcmConfig },
+	callback = function(self)
+		log:setLogLevel(self.variable.value)
+	end
 }
 ```

--- a/docs/source/guides/logging.md
+++ b/docs/source/guides/logging.md
@@ -6,6 +6,7 @@ The MWSE Logger library allows you to register a logger for your mod. It provide
 - Change log level via MCM
 - Log messages can be color coded according to log level (via MWSE MCM)
 - Optional setting to print messages to a separate log file
+- Optional setting to print messages to the in-game console
 
 ## Log Levels
 
@@ -47,6 +48,7 @@ In your main.lua, place the logger creation before other source files are includ
 
 In the other source files:
 ```lua
+local logger = require("logging.logger")
 local log = logger.getLogger("Test Mod")
 
 log:info("This is an info message")

--- a/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
+++ b/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
@@ -16,6 +16,7 @@ local ansicolors = require("logging.colors")
 
 ---@class MWSELogger
 ---@field name string Name of mod, also counts as unique id of logger
+---@field logToConsole boolean If `true`, all the logged messages will also be logged to console
 ---@field doLog fun(self: MWSELogger, logLevel: MWSELoggerLogLevels): boolean Check log level to determine if log should be written out
 ---@field info fun(self: MWSELogger, message: string, ...) Log info message
 ---@field debug fun(self: MWSELogger, message: string, ...) Log debug message

--- a/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
+++ b/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
@@ -12,6 +12,7 @@ local ansicolors = require("logging.colors")
 ---@field name string Name of mod, also counts as unique id of logger
 ---@field outputFile string? Optional. If set, logs will be sent to a file of this name
 ---@field logLevel MWSELoggerLogLevels? Set the log level. Options are: TRACE, DEBUG, INFO, WARN, ERROR and NONE
+---@field logToConsole boolean? Default: `false`. If set to `true`, all the logged messages will also be logged to console
 
 ---@class MWSELogger
 ---@field name string Name of mod, also counts as unique id of logger
@@ -56,6 +57,14 @@ end
 
 --- Creates a new instance of a logger.
 ---@param data MWSELoggerInputData
+---
+--- `name`: string — Name of mod, also counts as unique id of logger
+---
+--- `outputFile`: string? *Optional*. If set, logs will be sent to a file of this name
+---
+--- `logLevel`: MWSELoggerLogLevels? Set the log level. Options are: TRACE, DEBUG, INFO, WARN, ERROR and NONE
+---
+--- `logToConsole` boolean? Default: `false`. If set to `true`, all the messages will be logged to console
 ---@return MWSELogger
 function Logger.new(data)
 	local newLogger = table.copy(data) ---@class MWSELogger
@@ -122,8 +131,12 @@ function Logger:write(logLevel, color, message, ...)
 	local output = string.format("[%s: %s] %s", self.name, logLevel, tostring(message):format(...))
 
 	-- Add log colors if enabled
-	if mwse.getConfig("EnableLogColors") then
+	if mwse.getConfig("EnableLogColors") then ---@diagnostic disable-line: undefined-field
 		output = addColor(output, color)
+	end
+
+	if self.logToConsole then
+		tes3ui.log(output)
 	end
 
 	-- Prints to custom file if defined


### PR DESCRIPTION
Usage example:

```Lua
local logger = require("logging.logger")
local log = logger.new{
    name = "Test Mod",
    logLevel = "TRACE",
    -- Make all the logged messages also be logged to the in-game console
    logToConsole = true,
}
log:trace("This is a trace message")
log:debug("This is a debug message")
log:info("This is an info message")
log:warn("This is a warn message")
log:error("This is an error message")


-- Changing the logToConsole setting later:
log.logToConsole = false

-- No logging messages will be printed to the in-game console after this point
log:setLogLevel("INFO")
```