### PR TITLE
Docs: add revision date to the pages

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-mermaid2-plugin
+          pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-mermaid2-plugin mkdocs-git-revision-date-localized-plugin
 
       - name: Deploy
         run: |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,6 +6,9 @@ repo_url: https://github.com/MWSE/MWSE
 
 plugins:
   - awesome-pages
+  - git-revision-date-localized:
+      type: datetime
+      enable_creation_date: true
   - mermaid2:
       arguments:
         theme: |
@@ -44,7 +47,6 @@ theme:
     - content.tabs.link
     # - header.autohide
     # - navigation.expand
-    # - navigation.footer
     - navigation.indexes
     - navigation.instant
     - navigation.sections


### PR DESCRIPTION
Adds them by using the [plugin suggested by MkDocs](https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#document-dates).

For available date types you can look at the mkdocs-git-revision-date-localized-plugin's [docs](https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/options/). I'll list the ones supported by Material for MkDocs here:
```
November 28, 2019           # type: date (default)
November 28, 2019 13:57:28  # type: datetime
2019-11-28                  # type: iso_date
2019-11-28 13:57:26         # type: iso_datetime
20 hours ago                # type: timeago
```

I decided to use `datetime`, and I set `enable_creation_date: true`, so also the date the page was first created is also shown.