### PR TITLE
Mwselogger timestamp

### DIFF
--- a/autocomplete/definitions/namedTypes/mwseLogger/includeTimestamp.lua
+++ b/autocomplete/definitions/namedTypes/mwseLogger/includeTimestamp.lua
@@ -1,0 +1,5 @@
+return {
+	type = "value",
+	description = "If set to `true`, all the logged messages will include a timestamp.",
+	valuetype = "boolean",
+}

--- a/docs/source/guides/logging.md
+++ b/docs/source/guides/logging.md
@@ -7,6 +7,7 @@ The MWSE Logger library allows you to register a logger for your mod. It provide
 - Log messages can be color coded according to log level (via MWSE MCM)
 - Optional setting to print messages to a separate log file
 - Optional setting to print messages to the in-game console
+- Optional setting to print messages with a timestamp prepended
 
 ## Log Levels
 
@@ -33,6 +34,7 @@ local log = logger.new{
 	name = "Test Mod",
 	logLevel = "TRACE",
 	logToConsole = true,
+	includeTimestamp = true,
 }
 log:trace("This is a trace message")
 log:debug("This is a debug message")

--- a/docs/source/types/mwseLogger.md
+++ b/docs/source/types/mwseLogger.md
@@ -10,6 +10,17 @@ A logging class. Needs to be required before use. See [this guide](https://mwse.
 
 ## Properties
 
+### `includeTimestamp`
+<div class="search_terms" style="display: none">includetimestamp</div>
+
+If set to `true`, all the logged messages will include a timestamp.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `logToConsole`
 <div class="search_terms" style="display: none">logtoconsole</div>
 

--- a/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
+++ b/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
@@ -3,7 +3,7 @@ local ansicolors = require("logging.colors")
 ---@alias mwseLoggerLogLevel
 ---|  "TRACE"
 ---|  "DEBUG"
----|> "INFO" # The dafault log level
+---|> "INFO" # The default log level
 ---|  "WARN"
 ---|  "ERROR"
 ---|  "NONE"

--- a/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
+++ b/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
@@ -3,7 +3,7 @@ local ansicolors = require("logging.colors")
 ---@alias mwseLoggerLogLevel
 ---|  "TRACE"
 ---|  "DEBUG"
----|> "INFO" # The default log level
+---|> "INFO" # The dafault log level
 ---|  "WARN"
 ---|  "ERROR"
 ---|  "NONE"
@@ -13,6 +13,7 @@ local ansicolors = require("logging.colors")
 ---@field outputFile string? Optional. If set, logs will be sent to a file of this name
 ---@field logLevel mwseLoggerLogLevel? Set the log level. Options are: TRACE, DEBUG, INFO, WARN, ERROR and NONE
 ---@field logToConsole boolean? Default: `false`. If set to `true`, all the logged messages will also be logged to console
+---@field includeTimestamp boolean? Default: `false`. If set to `true`, all the logged messages will include a timestamp
 
 --[[
 	A logger class that can be registered by multiple mods.
@@ -54,6 +55,8 @@ end
 --- `logLevel`: mwseLoggerLogLevel? Set the log level. Options are: TRACE, DEBUG, INFO, WARN, ERROR and NONE
 ---
 --- `logToConsole` boolean? Default: `false`. If set to `true`, all the messages will be logged to console
+---
+--- `includeTimestamp` boolean? Default: `false`. If set to `true`, all the messages will include a timestamp
 ---@return mwseLogger
 function Logger.new(data)
 	local newLogger = table.copy(data) ---@type mwseLogger
@@ -118,6 +121,12 @@ end
 ---@param ...  any?
 function Logger:write(logLevel, color, message, ...)
 	local output = string.format("[%s: %s] %s", self.name, logLevel, tostring(message):format(...))
+    if self.includeTimestamp then
+        local timestamp = os.clock()
+        local seconds = math.floor(timestamp)
+        local milliseconds = math.floor((timestamp - seconds) * 1000)
+        output = string.format("[%s.%03d] %s", os.date("%H:%M:%S", seconds), milliseconds, output)
+    end
 
 	-- Add log colors if enabled
 	if mwse.getConfig("EnableLogColors") then

--- a/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
+++ b/misc/package/Data Files/MWSE/core/lib/logging/logger.lua
@@ -122,10 +122,17 @@ end
 function Logger:write(logLevel, color, message, ...)
 	local output = string.format("[%s: %s] %s", self.name, logLevel, tostring(message):format(...))
     if self.includeTimestamp then
-        local timestamp = os.clock()
-        local seconds = math.floor(timestamp)
-        local milliseconds = math.floor((timestamp - seconds) * 1000)
-        output = string.format("[%s.%03d] %s", os.date("%H:%M:%S", seconds), milliseconds, output)
+        local socket = require("socket")
+        local timestamp = socket.gettime()
+        local milliseconds = math.floor((timestamp % 1) * 1000)
+        timestamp = math.floor(timestamp)
+
+        -- convert timestamp to a table containing time components
+        local timeTable = os.date("*t", timestamp)
+
+        -- format time components into H:M:S:MS string
+        local formattedTime = string.format("%02d:%02d:%02d.%03d", timeTable.hour, timeTable.min, timeTable.sec, milliseconds)
+        output = string.format("[%s] %s", formattedTime, output)
     end
 
 	-- Add log colors if enabled

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseLogger.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseLogger.lua
@@ -4,6 +4,7 @@
 --- @meta
 --- A logging class. Needs to be required before use. See [this guide](https://mwse.github.io/MWSE/guides/logging/).
 --- @class mwseLogger
+--- @field includeTimestamp boolean If set to `true`, all the logged messages will include a timestamp.
 --- @field logToConsole boolean If `true`, all the logged messages will also be logged to console.
 --- @field name string Name of the mod, also counts as unique id of the logger.
 mwseLogger = {}


### PR DESCRIPTION
### Example Usage:
```lua
    local logger = MWSELogger.new{
        name = string.format("JoyOfPainting - %s", serviceName),
        logLevel = config.mcm.logLevel,
        includeTimestamp = true,
    }
```

### Example log:
```
[01:04:36.988] [JoyOfPainting - main: DEBUG] Initialising Interops
```