### PR TITLE
Convert string keys to integers in mwse.loadConfig

### DIFF
--- a/autocomplete/definitions/global/json/decode.lua
+++ b/autocomplete/definitions/global/json/decode.lua
@@ -1,6 +1,10 @@
 return {
 	type = "function",
-	description = [[Decode string into a table.]],
+	description = [[Decode string into a table.
+
+!!! warning
+	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+]],
 	link = "http://dkolf.de/src/dkjson-lua.fsl/wiki?name=Documentation",
 	arguments = {
 		{ name = "s", type = "string" },

--- a/autocomplete/definitions/global/json/encode.lua
+++ b/autocomplete/definitions/global/json/encode.lua
@@ -1,6 +1,10 @@
 return {
 	type = "function",
-	description = [[Create a string representing the object. Object can be a table, a string, a number, a boolean, nil, json.null or any object with a function __tojson in its metatable. A table can only use strings and numbers as keys and its values have to be valid objects as well. It raises an error for any invalid data types or reference cycles.]],
+	description = [[Create a string representing the object. Object can be a table, a string, a number, a boolean, nil, json.null or any object with a function __tojson in its metatable. A table can only use strings and numbers as keys and its values have to be valid objects as well. It raises an error for any invalid data types or reference cycles.
+
+!!! warning
+	If the table you are encoding as json has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+]],
 	link = "http://dkolf.de/src/dkjson-lua.fsl/wiki?name=Documentation",
 	arguments = {
 		{ name = "object", type = "table" },

--- a/autocomplete/definitions/global/json/loadfile.lua
+++ b/autocomplete/definitions/global/json/loadfile.lua
@@ -1,6 +1,10 @@
 return {
 	type = "function",
-	description = [[Loads the contents of a file through json.decode. Files loaded from Data Files\\MWSE\\{fileName}.json.]],
+	description = [[Loads the contents of a file through json.decode. Files loaded from Data Files\\MWSE\\{fileName}.json.
+
+!!! warning
+	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered. If you need to save and load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) as that function will do this for you.
+]],
 	arguments = {
 		{ name = "fileName", type = "string" },
 	},

--- a/autocomplete/definitions/global/mwse/loadConfig.lua
+++ b/autocomplete/definitions/global/mwse/loadConfig.lua
@@ -1,8 +1,13 @@
 return {
 	type = "function",
 	description = [[Loads a config table from Data Files\\MWSE\\config\\{fileName}.json.
-	
-If the default values table is passed, empty keys in the config will be filled in using its values. Additionally, if no file exists, the function will return the default table.]],
+
+If the default values table is passed:
+
+ - Empty keys in the config will be filled in using its values.
+ - If no file exists, the function will return the default table.
+ - In json, tables can be either arrays with integer keys or dictionaries with string keys. If your configuration table is mixed (has both string and integer indices), saving and loading from json will effectively convert all your integer indices to strings. This function will convert your configuration table's integer indices back if defaults table is given.
+]],
 	arguments = {
 		{ name = "fileName", type = "string", description = "The non-extensioned name of the config file." },
 		{ name = "defaults", type = "table", optional = true, description = "A table of default values." },

--- a/docs/source/apis/json.md
+++ b/docs/source/apis/json.md
@@ -39,6 +39,10 @@ Current version of dkjson.
 
 Decode string into a table.
 
+!!! warning
+	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+
+
 ```lua
 local result = json.decode(s, position, nullValue)
 ```
@@ -60,6 +64,10 @@ local result = json.decode(s, position, nullValue)
 
 Create a string representing the object. Object can be a table, a string, a number, a boolean, nil, json.null or any object with a function __tojson in its metatable. A table can only use strings and numbers as keys and its values have to be valid objects as well. It raises an error for any invalid data types or reference cycles.
 
+!!! warning
+	If the table you are encoding as json has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+
+
 ```lua
 local result = json.encode(object, state)
 ```
@@ -79,6 +87,10 @@ local result = json.encode(object, state)
 <div class="search_terms" style="display: none">loadfile</div>
 
 Loads the contents of a file through json.decode. Files loaded from Data Files\\MWSE\\{fileName}.json.
+
+!!! warning
+	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered. If you need to save and load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) as that function will do this for you.
+
 
 ```lua
 local result = json.loadfile(fileName)

--- a/docs/source/apis/mwse.md
+++ b/docs/source/apis/mwse.md
@@ -184,8 +184,13 @@ local converted = mwse.iconv(languageCode, utf8string)
 <div class="search_terms" style="display: none">loadconfig</div>
 
 Loads a config table from Data Files\\MWSE\\config\\{fileName}.json.
-	
-If the default values table is passed, empty keys in the config will be filled in using its values. Additionally, if no file exists, the function will return the default table.
+
+If the default values table is passed:
+
+ - Empty keys in the config will be filled in using its values.
+ - If no file exists, the function will return the default table.
+ - In json, tables can be either arrays with integer keys or dictionaries with string keys. If your configuration table is mixed (has both string and integer indices), saving and loading from json will effectively convert all your integer indices to strings. This function will convert your configuration table's integer indices back if defaults table is given.
+
 
 ```lua
 local result = mwse.loadConfig(fileName, defaults)

--- a/misc/package/Data Files/MWSE/core/initialize.lua
+++ b/misc/package/Data Files/MWSE/core/initialize.lua
@@ -821,7 +821,7 @@ end
 -- json dictionaries can only have string keys. Use defaults
 -- table to check which keys are integers.
 local function restoreIntegerKeys(configTable, defaults)
-	for key, val in pairs(defaults) do
+	for key, val in pairs(defaults or {}) do
 		local defaultKeyType = type(key)
 		local defaultValType = type(val)
 		local stringKey = tostring(key)

--- a/misc/package/Data Files/MWSE/core/meta/lib/json.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/json.lua
@@ -9,6 +9,10 @@
 json = {}
 
 --- Decode string into a table.
+--- 
+--- !!! warning
+--- 	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+--- 
 --- @param s string No description yet available.
 --- @param position number? *Default*: `1`. No description yet available.
 --- @param nullValue string|nil *Default*: `nil`. No description yet available.
@@ -16,12 +20,20 @@ json = {}
 function json.decode(s, position, nullValue) end
 
 --- Create a string representing the object. Object can be a table, a string, a number, a boolean, nil, json.null or any object with a function __tojson in its metatable. A table can only use strings and numbers as keys and its values have to be valid objects as well. It raises an error for any invalid data types or reference cycles.
+--- 
+--- !!! warning
+--- 	If the table you are encoding as json has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+--- 
 --- @param object table No description yet available.
 --- @param state table? No description yet available.
 --- @return string result No description yet available.
 function json.encode(object, state) end
 
 --- Loads the contents of a file through json.decode. Files loaded from Data Files\\MWSE\\{fileName}.json.
+--- 
+--- !!! warning
+--- 	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered. If you need to save and load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) as that function will do this for you.
+--- 
 --- @param fileName string No description yet available.
 --- @return table result No description yet available.
 function json.loadfile(fileName) end

--- a/misc/package/Data Files/MWSE/core/meta/lib/mwse.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mwse.lua
@@ -43,8 +43,13 @@ function mwse.getVirtualMemoryUsage() end
 function mwse.iconv(languageCode, utf8string) end
 
 --- Loads a config table from Data Files\\MWSE\\config\\{fileName}.json.
---- 	
---- If the default values table is passed, empty keys in the config will be filled in using its values. Additionally, if no file exists, the function will return the default table.
+--- 
+--- If the default values table is passed:
+--- 
+---  - Empty keys in the config will be filled in using its values.
+---  - If no file exists, the function will return the default table.
+---  - In json, tables can be either arrays with integer keys or dictionaries with string keys. If your configuration table is mixed (has both string and integer indices), saving and loading from json will effectively convert all your integer indices to strings. This function will convert your configuration table's integer indices back if defaults table is given.
+--- 
 --- @param fileName string The non-extensioned name of the config file.
 --- @param defaults table? *Optional*. A table of default values.
 --- @return table result No description yet available.


### PR DESCRIPTION
This is my attempt at resolving an issue people usually stumble upon when using `mwse.loadConfig()`. 

If the `defaults` table is given, then loop through checking if a key k in the `defaults` table is a `number` and if there exists an entry in the loaded config table with key `tostring(k)`. If such a key exists, convert it to an integer.