### PR TITLE
Update parent scrolling when Dropdown is expanded or collapsed

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
@@ -77,6 +77,18 @@ function Dropdown:createDropdown()
 		self.elements.dropdownParent:getTopLevelParent():updateLayout()
 	end
 
+	---@param element tes3uiElement
+	local function recursiveContentsChanged(element)
+		if element then
+			if element.widget and element.widget.contentsChanged then
+				element.widget:contentsChanged()
+			end
+			recursiveContentsChanged(element.parent)
+		end
+	end
+	-- Recursively go back to parent and call contentsChanged because scrolling is affected.
+	recursiveContentsChanged(self.elements.outerContainer.parent)
+
 end
 
 function Dropdown:makeComponent(parentBlock)


### PR DESCRIPTION
This fixes a problem that previously caused scrolling to not update length when using mcm Dropdown in Mod Config.
In particular, if there was a dropdown at the bottom of the page, items could not be selected, but this will now be available.

Previous: expanding logging level but cannot scroll.
<img width="242" alt="image" src="https://user-images.githubusercontent.com/29576246/233877842-c734b399-23df-4242-84fe-cf46d89c4f18.png">

PR: can scroll.
<img width="241" alt="image" src="https://user-images.githubusercontent.com/29576246/233877739-ede5ae30-8f0d-4d95-a463-5acd89c3edcc.png">
