### PR TITLE
Fix tes3actorAnimationController:updateOpacity

### DIFF
--- a/MWSE/TES3ActorAnimationController.cpp
+++ b/MWSE/TES3ActorAnimationController.cpp
@@ -36,7 +36,7 @@ namespace TES3 {
 		{
 			return 1.0;
 		}
-		
+
 		return std::clamp(mobileActor->actionData.swingTimer / (maxAttackTiming - startTime), 0.0f, 1.0f);
 	}
 
@@ -103,7 +103,7 @@ namespace TES3 {
 		}
 		// Fall back to chameleon, based on magnitude.
 		else if (chameleon > 0) {
-			setOpacity(std::clamp(1.0f - (float(chameleon) / 100.0f), 0.25f, 75.0f));
+			setOpacity(std::clamp(1.0f - (float(chameleon) / 100.0f), 0.25f, 0.75f));
 		}
 		// If all else fails we go for no Opacity.
 		else {


### PR DESCRIPTION
From the context in the file, it looks like the `setOpacity` should accept values in the [0.0 - 1.0] range. So, clamp the values to the right range.