### PR TITLE
Switch pickup sounds for `tes3.addItem`, `tes3.removeItem` and `tes3.transferItem`

### DIFF
--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -60,7 +60,7 @@
 #include "TES3MobileCreature.h"
 #include "TES3MobilePlayer.h"
 #include "TES3NPC.h"
-#include "TES3PlayerAnimationController.h" 
+#include "TES3PlayerAnimationController.h"
 #include "TES3Race.h"
 #include "TES3Reference.h"
 #include "TES3Region.h"
@@ -481,7 +481,7 @@ namespace mwse::lua {
 			// Set up our event callback.
 			LuaManager::getInstance().setButtonPressedCallback(params["callback"]);
 
-			// Temporary hook into the function that creates message boxes. 
+			// Temporary hook into the function that creates message boxes.
 			reinterpret_cast<void(__cdecl*)(const char*, ...)>(0x5F1AA0)(message.c_str(), buttonTextStruct, NULL);
 			return TES3::UI::findMenu("MenuMessage");
 		}
@@ -3281,7 +3281,7 @@ namespace mwse::lua {
 		auto playerMobile = worldController->getMobilePlayer();
 		if (mobile == playerMobile) {
 			if (getOptionalParam<bool>(params, "playSound", true)) {
-				worldController->playItemUpDownSound(item, TES3::ItemSoundState::Down);
+				worldController->playItemUpDownSound(item, TES3::ItemSoundState::Up);
 			}
 
 			if (getOptionalParam<bool>(params, "showMessage", false)) {
@@ -3456,9 +3456,9 @@ namespace mwse::lua {
 		// Play the relevant sound.
 		auto worldController = TES3::WorldController::get();
 		auto playerMobile = worldController->getMobilePlayer();
-		if (playerMobile && getOptionalParam<bool>(params, "playSound", true)) {
+		if (mobile == playerMobile && getOptionalParam<bool>(params, "playSound", true)) {
 			if (mobile == playerMobile) {
-				worldController->playItemUpDownSound(item, TES3::ItemSoundState::Up);
+				worldController->playItemUpDownSound(item, TES3::ItemSoundState::Down);
 			}
 		}
 
@@ -3690,10 +3690,10 @@ namespace mwse::lua {
 		// Play the relevant sound.
 		if (playerMobile && getOptionalParam<bool>(params, "playSound", true)) {
 			if (toMobile == playerMobile) {
-				worldController->playItemUpDownSound(item, TES3::ItemSoundState::Down);
+				worldController->playItemUpDownSound(item, TES3::ItemSoundState::Up);
 			}
 			else if (fromMobile == playerMobile) {
-				worldController->playItemUpDownSound(item, TES3::ItemSoundState::Up);
+				worldController->playItemUpDownSound(item, TES3::ItemSoundState::Down);
 			}
 		}
 
@@ -5461,7 +5461,7 @@ namespace mwse::lua {
 			throw std::invalid_argument("Invalid positional params provided. Must provided two references or two positions/heights.");
 		}
 
-		// 
+		//
 		sol::optional<TES3::Vector3> position2;
 		float height1, height2;
 


### PR DESCRIPTION
Item pickup/down sounds are played for the player. In my opinion, it makes more sense to play the Up sound when an item gets added to the player's inventory since that sound is played when the player picks up items from the game world. The opposite is true for dropping an item. That's my reasoning for making the switch.

Also, I added a `mobile == playerMobile` check in `tes3.removeItem`.