### PR TITLE
DependencyManager updates

### DIFF
--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -2581,7 +2581,7 @@ namespace mwse::lua {
 			}
 			const auto& lowerPath = maybeLowerPath.value();
 
-			// We only care *-metadata.toml files.
+			// We only care about *-metadata.toml files.
 			if (!string::ends_with(lowerPath, "-metadata.toml")) {
 				continue;
 			}
@@ -4345,7 +4345,7 @@ namespace mwse::lua {
 
 	//
 	// Patch: Modifiable physical hit detection cone and weapon reach;
-	// 
+	//
 
 	static float attackReach_saved, fCombatAngleXY_saved, fCombatAngleZ_saved;
 
@@ -4527,7 +4527,7 @@ namespace mwse::lua {
 			_putenv_s("Path", envPath.str().c_str());
 		}
 
-		// Execute mwse_init.lua
+		// Execute initialize.lua
 		try {
 			sol::protected_function_result result = luaState.safe_script_file("Data Files\\MWSE\\core\\initialize.lua");
 			if (!result.valid()) {

--- a/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyManager.lua
+++ b/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyManager.lua
@@ -84,22 +84,20 @@ function DependencyManager:checkDependencies()
         return true
     end
 
-    -- Don't check dependencies if a mod't plugin is not active.
+    -- Don't check dependencies if a mod's plugin is not active.
     -- Log if there is metadata.toml pointing to a partially installed/uninstalled mod.
     local plugin = self.metadata.package.plugin
     local pluginExists = plugin and util.pluginExists(plugin)
-    local pluginDisabled = pluginExists and not tes3.isModActive(plugin)
 
     local luaMod = self.metadata.tools and self.metadata.tools.mwse and self.metadata.tools.mwse["lua-mod"]
     local luaModExists = luaMod and util.luaModExists(luaMod)
 
-    local luaOnly = luaMod and not plugin or false
-    local pluginOnly = plugin and not luaMod or false
-    local luaPlugin = luaMod and plugin and true or false
-
-    local uncomplete = (luaOnly and not luaModExists) or
-                       (pluginOnly and not pluginExists) or
-                       (luaPlugin and not (luaModExists and pluginExists))
+    local uncomplete = false
+    if luaMod and not luaModExists then
+        uncomplete = true
+    elseif plugin and not pluginExists then
+        uncomplete = true
+    end
 
     if uncomplete then
         self.logger:warn("Metadata file (%s) found pointing to missing mod files:",
@@ -117,11 +115,9 @@ function DependencyManager:checkDependencies()
         return true
     end
 
+    local pluginDisabled = pluginExists and not tes3.isModActive(plugin)
     if pluginDisabled then
-        if self.showFailureMessage then
-            self.logger:info("Plugin \"%s\" is not active, skipping dependency check.", plugin)
-        end
-
+        self.logger:info("Plugin \"%s\" is not active, skipping dependency check.", plugin)
         return true
     end
 

--- a/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyManager.lua
+++ b/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyManager.lua
@@ -138,7 +138,6 @@ function DependencyManager:checkDependencies()
                 self.logger:debug("Checking dependency type: %s", typeId)
                 local passed, failures = dependencyType:checkDependency(dependency)
                 if failures and not passed then
-                    self.logger:error("Dependency failed: %s", typeId)
                     for _, failure in pairs(failures) do
                         table.insert(failedDependencies, failure)
                     end
@@ -150,7 +149,7 @@ function DependencyManager:checkDependencies()
     end
     if table.size(failedDependencies) > 0 then
         if self.showFailureMessage then
-            self.logger:error("Dependencies failed to load, adding to registered managers")
+            self.logger:debug("Dependencies failed to load, adding to registered managers")
             self.failedDependencies = failedDependencies
             table.insert(DependencyManager.registeredManagers, self)
         end

--- a/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyNotifier.lua
+++ b/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyNotifier.lua
@@ -1,5 +1,6 @@
 ---@class DependencyNotifier
 local DependencyNotifier = {
+    ---@type mwseLogger
     logger = nil,
     failedDependencies = nil,
     packageName = nil
@@ -41,6 +42,7 @@ function DependencyNotifier:dependenciesFailMessage(callback)
             scrollPane.paddingAllSides = 2
             scrollPane.minHeight = 500
 
+			self.logger:error("A list of dependencies not met:")
             for _, failure in pairs(self.failedDependencies) do
                 local dependencyBlock = scrollPane:createThinBorder()
                 dependencyBlock.flowDirection = "top_to_bottom"
@@ -59,13 +61,16 @@ function DependencyNotifier:dependenciesFailMessage(callback)
                 titleLabel.widthProportional = 1.0
                 titleLabel.borderBottom = 4
                 titleLabel.color = tes3ui.getPalette(tes3.palette.headerColor)
+				self.logger:error(title:gsub("\n", ""))
 
                 for _, reason in pairs(failure.reasons) do
-                    local depLabel = dependencyBlock:createLabel { text = "- " .. reason }
+					local text = "- " .. reason
+                    local depLabel = dependencyBlock:createLabel { text = text }
                     --depLabel.color = tes3ui.getPalette(tes3.palette.negativeColor)
                     depLabel.wrapText = true
                     --depLabel.justifyText = "center"
                     depLabel.widthProportional = 1.0
+					self.logger:error(text)
                 end
                 if failure.resolveButton then
                     self.logger:assert(type(failure.resolveButton.text) == "string",

--- a/misc/package/Data Files/MWSE/core/lib/dependencyManagement/types/mods.lua
+++ b/misc/package/Data Files/MWSE/core/lib/dependencyManagement/types/mods.lua
@@ -32,8 +32,7 @@ local function getDownloadButton(modId, dependency, text)
             text = string.format("%s %s", text or "Download", modId),
             tooltip = string.format('Go to "%s"', dependency.url),
             callback = function()
-                local downloadExe = string.format('start %s', dependency.url)
-                os.execute(downloadExe)
+                os.openURL(dependency.url)
                 os.exit()
             end
         }

--- a/misc/package/Data Files/MWSE/core/lib/dependencyManagement/util.lua
+++ b/misc/package/Data Files/MWSE/core/lib/dependencyManagement/util.lua
@@ -63,4 +63,17 @@ function util.getMissingAssets(assets)
     return missingAssets
 end
 
+---@param plugin string
+function util.pluginExists(plugin)
+	local path = tes3.installDirectory .. "\\Data Files\\" .. plugin
+	return lfs.fileexists(path)
+end
+
+---@param modName string
+function util.luaModExists(modName)
+	modName = modName:lower()
+	---@diagnostic disable-next-line: undefined-field
+	return mwse.activeLuaMods[modName] or false
+end
+
 return util

--- a/misc/package/Data Files/MWSE/core/mwse/dependencies/main.lua
+++ b/misc/package/Data Files/MWSE/core/mwse/dependencies/main.lua
@@ -6,8 +6,21 @@ local logger = require("logging.logger").new{
     name = "Dependencies",
     logLevel = LOG_LEVEL
 }
-local function isLuaFile(file) return file:sub(-4, -1) == ".lua" end
-local function isInitFile(file) return file == "init.lua" end
+---@param file string
+---@return boolean
+local function isLuaFile(file)
+    return file:lower():endswith(".lua")
+end
+---@param file string
+---@return boolean
+local function isInitFile(file)
+    return file:lower() == "init.lua"
+end
+---@param file string
+---@return boolean
+local function isMetadataFile(file)
+    return file:lower():endswith("-metadata.toml")
+end
 
 --[[
     Register all dependency types in the dependencyManagement.types folder.
@@ -29,14 +42,7 @@ for file in lfs.dir(path) do
 end
 
 local function checkDependencies()
-    if not mwse.getConfig("EnableDependencyChecks") then return end
     logger:debug("Checking dependencies")
-    ---@param file string
-    local function isMetadataFile(file)
-        file = file:lower()
-        --ends in `-metadata.toml`
-        return file:endswith("-metadata.toml")
-    end
     --[[
         For each `-metadata.toml` file in Data Files,
         that do not have a `tools.mwse.lua-mod` field,

--- a/misc/package/Data Files/MWSE/core/startLuaMods.lua
+++ b/misc/package/Data Files/MWSE/core/startLuaMods.lua
@@ -5,7 +5,7 @@ local function execLuaMod(runtime)
 	-- Check for dependencies if we need to.
 	if (runtime.metadata and runtime.metadata.dependencies) then
 		-- Generate a name from the key if we need one.
-		local name = runtime.package and runtime.package.name
+		local name = runtime.metadata.package and runtime.metadata.package.name
 		if (not name) then
 			name = runtime.key
 		end


### PR DESCRIPTION
Brief summary of changes:
1. Fix improper getting of package name in `startLuaMods.lua`
2. Refactoring. Use more standard functions we have. Made filename check case insensitive (based on https://github.com/MWSE/MWSE/commit/ecf4c61081ee9a4b2c62b094279432df719aff92).
Moved `mwse.getConfig("EnableDependencyChecks")` from `mwse\dependencies\main.lua` to `DependencyManager`. The package dependencies are checked twice: first from `execLuaMod` in `startLuaMods.lua`, then from `mwse\dependencies\main.lua`.  Previously, there was no `mwse.getConfig("EnableDependencyChecks")` check in  `startLuaMods.lua`.
3. Mod's plugin can be disabled in the launcher. Don't check dependencies for mods with disabled plugins (based on https://github.com/MWSE/MWSE/commit/aa646c5cbc6215dcc6a043da1403d1ff63ab4f53)
4. Mod can be partially installed or uninstalled. We had [a report](https://discord.com/channels/210394599246659585/381219559094616064/1120440999827734558) of a user that most probably had left the `-metadata.toml` file in their `Data files` folder after uninstalling a mod. This caused a notification spam for the user. I made an assumption that it's reasonable not to check dependencies for partially-installed mods. Here are the rules used to check if the mod is only partially installed:
    - For pure plugin (.esp, .esm) mods: plugin not found -> skip checking, log a warning
    - For pure MWSE lua-mod: no main.lua found -> skip checking, log a warning
    - For a mod that has a `plugin` and `lua-mod` fields in its `metadata.toml`, if missing any or both -> skip checking, log a warning
 5. It's useful to have in MWSE.log which assets are missing ([request by Amalie](https://discord.com/channels/210394599246659585/381219559094616064/1113831790344421416)). Added logging of failed dependency title and reasons to DependencyNotifier

<br>

Additional notes:

 - There was a report by OperatorJack that the wait-until-initialize [doesn't work](https://discord.com/channels/210394599246659585/381219559094616064/1137113967400067214). I couldn't reproduce the issue. In my tests the mods were correctly delayed until the `initialized` event.