### PR TITLE
Small MCM refactoring

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
@@ -126,17 +126,15 @@ end
 
 --- @param mouseOverList tes3uiElement[]?
 function Component:registerMouseOverElements(mouseOverList)
-	if mouseOverList then
-		for _, element in ipairs(mouseOverList) do
-			element:register("mouseOver", function(e)
-				event.trigger("MCM:MouseOver", self)
-				e.source:forwardEvent(e)
-			end)
-			element:register("mouseLeave", function(e)
-				event.trigger("MCM:MouseLeave")
-				e.source:forwardEvent(e)
-			end)
-		end
+	for _, element in ipairs(mouseOverList or {}) do
+		element:register("mouseOver", function(e)
+			event.trigger("MCM:MouseOver", self)
+			e.source:forwardEvent(e)
+		end)
+		element:register("mouseLeave", function(e)
+			event.trigger("MCM:MouseLeave")
+			e.source:forwardEvent(e)
+		end)
 	end
 end
 
@@ -177,21 +175,23 @@ end
 
 --- @param parentBlock tes3uiElement
 function Component:createLabel(parentBlock)
-	if self.label then
-		self:createLabelBlock(parentBlock)
-
-		local id = ("Label: " .. self.label)
-		local label = self.elements.labelBlock:createLabel({ id = tes3ui.registerID(id), text = self.label })
-		label.borderBottom = self.paddingBottom
-		label.borderAllSides = 0
-		label.paddingAllSides = 0
-		label.wrapText = true
-		label.widthProportional = 1.0
-		label.alignY = 0.5
-
-		self.elements.label = label
-		table.insert(self.mouseOvers, label)
+	if not self.label then
+		return
 	end
+
+	self:createLabelBlock(parentBlock)
+
+	local id = ("Label: " .. self.label)
+	local label = self.elements.labelBlock:createLabel({ id = tes3ui.registerID(id), text = self.label })
+	label.borderBottom = self.paddingBottom
+	label.borderAllSides = 0
+	label.paddingAllSides = 0
+	label.wrapText = true
+	label.widthProportional = 1.0
+	label.childAlignY = 0.5
+
+	self.elements.label = label
+	table.insert(self.mouseOvers, label)
 end
 
 --[[

--- a/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
@@ -108,7 +108,7 @@ function Component:getComponent(componentData)
 	for _, path in pairs(classPaths.components) do
 		local classPath = (path .. componentData.class)
 		local fullPath = lfs.currentdir() .. classPaths.basePath .. classPath .. ".lua"
-		local fileExists = lfs.attributes(fullPath, "mode") == "file"
+		local fileExists = lfs.fileexists(fullPath)
 
 		if fileExists then
 			component = require(classPath)

--- a/misc/package/Data Files/MWSE/core/mcm/components/categories/Category.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/categories/Category.lua
@@ -133,7 +133,7 @@ function Category.__index(tbl, key)
 
 			local classPath = (path .. class)
 			local fullPath = lfs.currentdir() .. classPaths.basePath .. classPath .. ".lua"
-			local fileExists = lfs.attributes(fullPath, "mode") == "file"
+			local fileExists = lfs.fileexists(fullPath)
 
 			if fileExists then
 				component = require(classPath)

--- a/misc/package/Data Files/MWSE/core/mcm/components/categories/Category.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/categories/Category.lua
@@ -118,7 +118,7 @@ function Category:createContentsContainer(parentBlock)
 	self:createInnerContainer(parentBlock)
 	self:createSubcomponentsContainer(self.elements.innerContainer)
 	self:createSubcomponents(self.elements.subcomponentsContainer, self.components)
-	parentBlock:getTopLevelParent():updateLayout()
+	parentBlock:getTopLevelMenu():updateLayout()
 end
 
 function Category.__index(tbl, key)

--- a/misc/package/Data Files/MWSE/core/mcm/components/categories/Category.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/categories/Category.lua
@@ -102,13 +102,11 @@ end
 --- @param parentBlock tes3uiElement
 --- @param components mwseMCMComponent.getComponent.componentData[]
 function Category:createSubcomponents(parentBlock, components)
-	if components then
-		for _, component in pairs(components) do
-			component.parentComponent = self
-			local newComponent = self:getComponent(component)
+	for _, component in pairs(components or {}) do
+		component.parentComponent = self
+		local newComponent = self:getComponent(component)
 
-			newComponent:create(parentBlock)
-		end
+		newComponent:create(parentBlock)
 	end
 end
 

--- a/misc/package/Data Files/MWSE/core/mcm/components/infos/Info.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/infos/Info.lua
@@ -46,7 +46,7 @@ function Info:makeComponent(parentBlock)
 	self.elements.info = info
 	table.insert(self.mouseOvers, info)
 	self:update()
-	info:getTopLevelParent():updateLayout()
+	info:getTopLevelMenu():updateLayout()
 end
 
 return Info

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
@@ -67,13 +67,12 @@ local function getSortedObjectList(params)
 	for obj in tes3.iterateObjects(params.objectType) do
 		local doAdd = true
 		-- Check that all filters match
-		if params.objectFilters then
-			for field, value in pairs(params.objectFilters) do
-				if obj[field] ~= value then
-					doAdd = false
-				end
+		for field, value in pairs(params.objectFilters or {}) do
+			if obj[field] ~= value then
+				doAdd = false
 			end
 		end
+
 		if params.noScripted and obj.script ~= nil then
 			doAdd = false
 		end
@@ -434,16 +433,18 @@ end
 
 --- @param parentBlock tes3uiElement
 function ExclusionsPage:createDescription(parentBlock)
-	if self.description then
-		local description = parentBlock:createLabel{ text = self.description }
-		-- description.heightProportional = -1
-		description.autoHeight = true
-		description.widthProportional = 1.0
-		description.wrapText = true
-		description.borderLeft = self.indent
-		description.borderRight = self.indent
-		self.elements.description = description
+	if not self.description then
+		return
 	end
+
+	local description = parentBlock:createLabel{ text = self.description }
+	-- description.heightProportional = -1
+	description.autoHeight = true
+	description.widthProportional = 1.0
+	description.wrapText = true
+	description.borderLeft = self.indent
+	description.borderRight = self.indent
+	self.elements.description = description
 end
 
 --- @param parentBlock tes3uiElement

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
@@ -122,12 +122,10 @@ function ExclusionsPage:toggle(e)
 
 	-- update sorting
 	local container = list:getContentElement()
-	for i, child in pairs(container.children) do
-		if child.text > text then
-			container:reorderChildren(i - 1, -1, 1)
-			break
-		end
-	end
+	container:sortChildren(function(a, b)
+			return a.text < b.text
+	end)
+
 	-- update display
 	self.elements.outerContainer:getTopLevelMenu():updateLayout()
 end

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
@@ -135,14 +135,14 @@ end
 --- @param listName mwseMCMExclusionsPageListId
 function ExclusionsPage:updateSearch(listName)
 
-	local searchString = self.elements.searchBarInput[listName].text --[[@as string]]
+	local searchString = self.elements.searchBarInput[listName].text:lower() --[[@as string]]
 	local thisList = self.elements[listName] --[[@as tes3uiElement]]
 	local child = thisList:findChild(itemID)
 
 	if child then
 		local itemList = child.parent.children
 		for _, item in ipairs(itemList) do
-			if item.text:lower():find(searchString:lower(), 1, true) then
+			if item.text:lower():find(searchString, 1, true) then
 				item.visible = true
 			else
 				item.visible = false

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
@@ -130,7 +130,7 @@ function ExclusionsPage:toggle(e)
 		end
 	end
 	-- update display
-	self.elements.outerContainer:getTopLevelParent():updateLayout()
+	self.elements.outerContainer:getTopLevelMenu():updateLayout()
 end
 
 --- @param listName mwseMCMExclusionsPageListId
@@ -152,7 +152,7 @@ function ExclusionsPage:updateSearch(listName)
 	end
 
 	self.elements[listName].widget:contentsChanged()
-	self.elements.outerContainer:getTopLevelParent():updateLayout()
+	self.elements.outerContainer:getTopLevelMenu():updateLayout()
 end
 
 --- @param items string[]

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/FilterPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/FilterPage.lua
@@ -12,10 +12,15 @@ function FilterPage:filterComponents()
 	local searchText = self.elements.searchBarInput.text:lower()
 	for _, component in ipairs(self.components) do
 		-- look for search text inside setting label
-		if component.label:lower():find(searchText) then
-			component.elements.outerContainer.visible = true
-		else
-			component.elements.outerContainer.visible = false
+		local label = component.label and component.label:lower()
+		if label then
+			if label:find(searchText) then
+				component.elements.outerContainer.visible = true
+			else
+				component.elements.outerContainer.visible = false
+			end
+
+			-- Do nothing for components without a label.
 		end
 	end
 end

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/FilterPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/FilterPage.lua
@@ -23,13 +23,15 @@ end
 
 --- @param parentBlock tes3uiElement
 function FilterPage:createDescription(parentBlock)
-	if self.description then
-		local description = parentBlock:createLabel{ text = self.description }
-		description.autoHeight = true
-		description.widthProportional = 1.0
-		description.wrapText = true
-		self.elements.description = description
+	if not self.description then
+		return
 	end
+
+	local description = parentBlock:createLabel{ text = self.description }
+	description.autoHeight = true
+	description.widthProportional = 1.0
+	description.wrapText = true
+	self.elements.description = description
 end
 
 --- @param parentBlock tes3uiElement

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/FilterPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/FilterPage.lua
@@ -9,9 +9,10 @@ local FilterPage = Parent:new()
 FilterPage.placeholderSearchText = mwse.mcm.i18n("Search...")
 
 function FilterPage:filterComponents()
+	local searchText = self.elements.searchBarInput.text:lower()
 	for _, component in ipairs(self.components) do
 		-- look for search text inside setting label
-		if component.label:lower():find(self.elements.searchBarInput.text:lower()) then
+		if component.label:lower():find(searchText) then
 			component.elements.outerContainer.visible = true
 		else
 			component.elements.outerContainer.visible = false

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/MouseOverPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/MouseOverPage.lua
@@ -46,7 +46,7 @@ function MouseOverPage:createContentsContainer(parentBlock)
 	self:createSubcomponentsContainer(self.elements.innerContainer)
 	self:createSubcomponents(self.elements.subcomponentsContainer, self.components)
 
-	parentBlock:getTopLevelParent():updateLayout()
+	parentBlock:getTopLevelMenu():updateLayout()
 end
 
 return MouseOverPage

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
@@ -74,13 +74,13 @@ function Dropdown:createDropdown()
 			end
 		end
 		self.elements.dropdown = dropdown
-		dropdown:getTopLevelParent():updateLayout()
+		dropdown:getTopLevelMenu():updateLayout()
 
 		-- Destroy dropdown
 	else
 		self.elements.dropdownParent:destroyChildren()
 		self.dropdownActive = false
-		self.elements.dropdownParent:getTopLevelParent():updateLayout()
+		self.elements.dropdownParent:getTopLevelMenu():updateLayout()
 	end
 
 	--- @param element tes3uiElement

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
@@ -85,12 +85,14 @@ function Dropdown:createDropdown()
 
 	--- @param element tes3uiElement
 	local function recursiveContentsChanged(element)
-		if element then
-			if element.widget and element.widget.contentsChanged then
-				element.widget:contentsChanged()
-			end
-			recursiveContentsChanged(element.parent)
+		if not element then
+			return
 		end
+
+		if element.widget and element.widget.contentsChanged then
+			element.widget:contentsChanged()
+		end
+		recursiveContentsChanged(element.parent)
 	end
 	-- Recursively go back to parent and call contentsChanged because scrolling is affected.
 	recursiveContentsChanged(self.elements.outerContainer.parent)

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
@@ -32,13 +32,11 @@ end
 --- @param keyCode integer
 --- @return string|nil letter
 function KeyBinder:getLetter(keyCode)
-	for letter, code in pairs(tes3.scanCode) do
-		if code == keyCode then
-			local returnString = tes3.scanCodeToNumber[code] or letter
-			return string.upper(returnString)
-		end
+	local letter = table.find(tes3.scanCode, keyCode)
+	local returnString = tes3.scanCodeToNumber[keyCode] or letter
+	if returnString then
+		return string.upper(returnString)
 	end
-	return nil
 end
 
 --- @param keyCombo mwseKeyCombo

--- a/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
@@ -154,76 +154,77 @@ function Template:createTabsBlock(parentBlock)
 	outerTabsBlock.widthProportional = 1.0
 
 	-- Create a tab for each page (no need if only one page)
-	if #self.pages > 1 then
-
-		-- Previous Button
-		local prevButton = outerTabsBlock:createButton{ id = tes3ui.registerID("MCM_PreviousButton"), text = "<--" }
-		formatTabButton(prevButton)
-		toggleButtonState(prevButton, false)
-		self.elements.previousTabButton = prevButton
-
-		-- Create page tab buttons
-		local tabsBlock = outerTabsBlock:createBlock()
-		self.elements.tabsBlock = tabsBlock
-		tabsBlock.autoHeight = true
-		tabsBlock.widthProportional = 1.0
-		for _, page in ipairs(self.pages) do
-			self:createTab(page)
-		end
-		local firstTab = parentBlock:findChild(self.pages[1].tabUID)
-		firstTab.widget.state = 4
-
-		-- Next Button
-		local nextButton = outerTabsBlock:createButton{ id = tes3ui.registerID("MCM_NextButton"), text = "-->" }
-		formatTabButton(nextButton)
-		self.elements.nextTabButton = nextButton
-
-		-- Pagination
-
-		local hiddenTabCount = 0
-		nextButton:register("mouseClick", function()
-			-- Hide next tab
-			local tabToHide = parentBlock:findChild(self.pages[hiddenTabCount + 1].tabUID)
-			tabToHide.visible = false
-			-- Move active tab forward 1
-			for i, page in ipairs(self.pages) do
-				local tab = tabsBlock:findChild(page.tabUID)
-				if tab.widget.state == 4 and self.pages[i + 1] then
-					self:clickTab(self.pages[i + 1])
-					break
-				end
-			end
-			-- increment hiddenTabCount
-			hiddenTabCount = math.min(hiddenTabCount + 1, #self.pages)
-			-- If only last tab is visible, disable Next button
-			if hiddenTabCount >= #self.pages - 1 then
-				toggleButtonState(nextButton, false)
-			end
-			toggleButtonState(prevButton, true)
-		end)
-
-		prevButton:register("mouseClick", function()
-			-- Move active tab back 1
-			for i, page in ipairs(self.pages) do
-				local tab = tabsBlock:findChild(page.tabUID)
-				if tab.widget.state == 4 and self.pages[i - 1] then
-					local prevTab = parentBlock:findChild(self.pages[i - 1].tabUID)
-					if prevTab.visible == false then
-						-- decrement hiddenTabCount
-						hiddenTabCount = math.max(hiddenTabCount - 1, 0)
-						prevTab.visible = true
-					end
-					self:clickTab(self.pages[i - 1])
-					break
-				end
-			end
-			-- If first tab is active, disable Prev button
-			if tabsBlock:findChild(self.pages[1].tabUID).widget.state == 4 then
-				toggleButtonState(prevButton, false)
-			end
-			toggleButtonState(nextButton, true)
-		end)
+	if #self.pages <= 1 then
+		return
 	end
+
+	-- Previous Button
+	local prevButton = outerTabsBlock:createButton{ id = tes3ui.registerID("MCM_PreviousButton"), text = "<--" }
+	formatTabButton(prevButton)
+	toggleButtonState(prevButton, false)
+	self.elements.previousTabButton = prevButton
+
+	-- Create page tab buttons
+	local tabsBlock = outerTabsBlock:createBlock()
+	self.elements.tabsBlock = tabsBlock
+	tabsBlock.autoHeight = true
+	tabsBlock.widthProportional = 1.0
+	for _, page in ipairs(self.pages) do
+		self:createTab(page)
+	end
+	local firstTab = parentBlock:findChild(self.pages[1].tabUID)
+	firstTab.widget.state = 4
+
+	-- Next Button
+	local nextButton = outerTabsBlock:createButton{ id = tes3ui.registerID("MCM_NextButton"), text = "-->" }
+	formatTabButton(nextButton)
+	self.elements.nextTabButton = nextButton
+
+	-- Pagination
+
+	local hiddenTabCount = 0
+	nextButton:register("mouseClick", function()
+		-- Hide next tab
+		local tabToHide = parentBlock:findChild(self.pages[hiddenTabCount + 1].tabUID)
+		tabToHide.visible = false
+		-- Move active tab forward 1
+		for i, page in ipairs(self.pages) do
+			local tab = tabsBlock:findChild(page.tabUID)
+			if tab.widget.state == 4 and self.pages[i + 1] then
+				self:clickTab(self.pages[i + 1])
+				break
+			end
+		end
+		-- increment hiddenTabCount
+		hiddenTabCount = math.min(hiddenTabCount + 1, #self.pages)
+		-- If only last tab is visible, disable Next button
+		if hiddenTabCount >= #self.pages - 1 then
+			toggleButtonState(nextButton, false)
+		end
+		toggleButtonState(prevButton, true)
+	end)
+
+	prevButton:register("mouseClick", function()
+		-- Move active tab back 1
+		for i, page in ipairs(self.pages) do
+			local tab = tabsBlock:findChild(page.tabUID)
+			if tab.widget.state == 4 and self.pages[i - 1] then
+				local prevTab = parentBlock:findChild(self.pages[i - 1].tabUID)
+				if prevTab.visible == false then
+					-- decrement hiddenTabCount
+					hiddenTabCount = math.max(hiddenTabCount - 1, 0)
+					prevTab.visible = true
+				end
+				self:clickTab(self.pages[i - 1])
+				break
+			end
+		end
+		-- If first tab is active, disable Prev button
+		if tabsBlock:findChild(self.pages[1].tabUID).widget.state == 4 then
+			toggleButtonState(prevButton, false)
+		end
+		toggleButtonState(nextButton, true)
+	end)
 end
 
 --- @param parentBlock tes3uiElement

--- a/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
@@ -31,9 +31,11 @@ function Template:new(data)
 	return t --[[@as mwseMCMTemplate]]
 end
 
-function Template:saveOnClose(configPath, config)
+--- @param fileName string
+--- @param config unknown
+function Template:saveOnClose(fileName, config)
 	self.onClose = function()
-		mwse.saveConfig(configPath, config)
+		mwse.saveConfig(fileName, config)
 	end
 end
 

--- a/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
@@ -116,7 +116,7 @@ function Template:clickTab(thisPage)
 	-- Enable tab for this page
 	tabsBlock:findChild(thisPage.tabUID).widget.state = 4
 	-- update view
-	pageBlock:getTopLevelParent():updateLayout()
+	pageBlock:getTopLevelMenu():updateLayout()
 
 	-- Enable Prev button if first tab is not active
 	local tab1 = tabsBlock:findChild(self.pages[1].tabUID)

--- a/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
@@ -273,7 +273,7 @@ function Template.__index(tbl, key)
 		local classPaths = require("mcm.classPaths")
 		local classPath = classPaths.all.pages .. class
 		local fullPath = lfs.currentdir() .. classPaths.basePath .. classPath .. ".lua"
-		local fileExists = lfs.attributes(fullPath, "mode") == "file"
+		local fileExists = lfs.fileexists(fullPath)
 		if fileExists then
 			component = require(classPath)
 		end

--- a/misc/package/Data Files/MWSE/core/mcm/mcm.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/mcm.lua
@@ -81,7 +81,7 @@ function mcm.__index(tbl, key)
 
 			local classPath = path .. class
 			local fullPath = lfs.currentdir() .. classPaths.basePath .. classPath .. ".lua"
-			local fileExists = lfs.attributes(fullPath, "mode") == "file"
+			local fileExists = lfs.fileexists(fullPath)
 			if fileExists then
 				component = require(classPath)
 			end

--- a/misc/package/Data Files/MWSE/core/mcm/variables/GlobalBoolean.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/variables/GlobalBoolean.lua
@@ -19,12 +19,10 @@ function GlobalVar:get()
 	local global = tes3.findGlobal(self.id)
 	if not global then
 		mwse.log("ERROR: global %s does not exist", self.id)
-		return nil
+		return
 	end
 	if global.value ~= nil then
 		return global.value ~= 0
-	else
-		return nil
 	end
 end
 
@@ -33,7 +31,7 @@ function GlobalVar:set(newValue)
 	local global = tes3.findGlobal(self.id)
 	if not global then
 		mwse.log("ERROR: global %s does not exist", self.id)
-		return nil
+		return
 	end
 	global.value = newValue and 1 or 0
 end

--- a/misc/package/Data Files/MWSE/core/mcm/variables/PlayerData.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/variables/PlayerData.lua
@@ -34,28 +34,28 @@ function PlayerDataVar:get()
 			current[self.id] = self.defaultSetting
 		end
 		return current[self.id]
-	else
-		return self.defaultSetting
 	end
 
-	return nil
+	return self.defaultSetting
 end
 
 --- @param newValue unknown
 function PlayerDataVar:set(newValue)
-	if tes3.player then
-		local converter = self.converter
-		if (converter) then
-			newValue = converter(newValue)
-		end
-
-		local table = tes3.player.data
-		for v in string.gmatch(self.path, "[^%.]+") do
-			table = table[v]
-		end
-
-		table[self.id] = newValue
+	if not tes3.player then
+		return
 	end
+
+	local converter = self.converter
+	if (converter) then
+		newValue = converter(newValue)
+	end
+
+	local table = tes3.player.data
+	for v in string.gmatch(self.path, "[^%.]+") do
+		table = table[v]
+	end
+
+	table[self.id] = newValue
 end
 
 return PlayerDataVar


### PR DESCRIPTION
In short, use more standard library functions where possible, reduce nesting, and use tes3uiElement:getTopLevelMenu instead of deprecated getTopLevelParent, since that causes Lua Language Server to produce warnings.