### PR TITLE
Update DialogLandscapeEditSettingsWindow.cpp

### DIFF
--- a/CSSE/DialogLandscapeEditSettingsWindow.cpp
+++ b/CSSE/DialogLandscapeEditSettingsWindow.cpp
@@ -10,8 +10,8 @@
 #include "CSRegion.h"
 
 namespace se::cs::dialog::landscape_edit_settings_window {
-	constexpr auto MIN_WIDTH = 416u + 17u;
-	constexpr auto MIN_HEIGHT = 474u + 14u;
+	constexpr auto MIN_WIDTH = 430u;//CSSE = 416u + 17u;
+	constexpr auto MIN_HEIGHT = 540u;//CSSE = 474u + 14u;
 
 
 	namespace LandscapeEditFlag {
@@ -227,15 +227,15 @@ namespace se::cs::dialog::landscape_edit_settings_window {
 			width -= 270;
 			isVisible = FALSE;
 		}
-		
+
 		// hide/unhide the preview texture controls
 		ShowWindow(hDlgSelectedTextureStatic, isVisible);
 		ShowWindow(hDlgPreviewTextureFrameStatic, isVisible);
 		ShowWindow(hDlgPreviewTextureImage, isVisible);
 
-		SetWindowPos(hWnd, NULL, 0, 0, width, settings.landscape_window.size.height, SWP_NOMOVE);		
+		SetWindowPos(hWnd, NULL, 0, 0, width, settings.landscape_window.size.height, SWP_NOMOVE);
 
-		RedrawWindow(hWnd, NULL, NULL, RDW_ERASE | RDW_FRAME | RDW_ERASENOW | RDW_INVALIDATE | RDW_ALLCHILDREN);	
+		RedrawWindow(hWnd, NULL, NULL, RDW_ERASE | RDW_FRAME | RDW_ERASENOW | RDW_INVALIDATE | RDW_ALLCHILDREN);
 	}
 
 	//
@@ -293,7 +293,7 @@ namespace se::cs::dialog::landscape_edit_settings_window {
 
 		RemoveStyles(hWnd, DS_MODALFRAME | WS_SYSMENU);
 		AddStyles(hWnd, WS_POPUP | WS_CAPTION | WS_SIZEBOX);
-		
+
 		auto hInstance = (HINSTANCE)GetWindowLongA(hWnd, GWLP_HINSTANCE);
 		auto font = SendMessageA(hWnd, WM_GETFONT, FALSE, FALSE);
 
@@ -317,7 +317,42 @@ namespace se::cs::dialog::landscape_edit_settings_window {
 
 		//Change the selected texture static to be a single line
 		SetDlgItemText(hWnd, CONTROL_ID_SELECTED_TEXTURE_STATIC, "Selected Texture:");
-		
+
+		//RGBs with ':'
+		SetDlgItemText(hWnd, CONTROL_ID_PRIMARY_COLOR_RED_STATIC, "R:");
+		SetDlgItemText(hWnd, CONTROL_ID_PRIMARY_COLOR_GREEN_STATIC, "G:");
+		SetDlgItemText(hWnd, CONTROL_ID_PRIMARY_COLOR_BLUE_STATIC, "B:");
+		SetDlgItemText(hWnd, CONTROL_ID_SECONDARY_COLOR_RED_STATIC, "R:");
+		SetDlgItemText(hWnd, CONTROL_ID_SECONDARY_COLOR_GREEN_STATIC, "G:");
+		SetDlgItemText(hWnd, CONTROL_ID_SECONDARY_COLOR_BLUE_STATIC, "B:");
+
+		//Change element style
+		auto hStaticTextEditRadius = GetDlgItem(hWnd, CONTROL_ID_EDIT_RADIUS_STATIC);
+		auto hStaticTextEditFalloff = GetDlgItem(hWnd, CONTROL_ID_EDIT_FALLOFF_STATIC);
+		auto hStaticTextSelectedTexture = GetDlgItem(hWnd, CONTROL_ID_SELECTED_TEXTURE_STATIC);
+		auto hCheckBoxVertexColor = GetDlgItem(hWnd, CONTROL_ID_EDIT_COLORS_CHECKBOX);
+
+		{
+			// Get the current style of the element
+			auto styleEditRadius = GetWindowLongPtr(hStaticTextEditRadius, GWL_STYLE);
+			auto styleEditFalloff = GetWindowLongPtr(hStaticTextEditFalloff, GWL_STYLE);
+			auto styleSelectedTexture = GetWindowLongPtr(hStaticTextSelectedTexture, GWL_STYLE);
+			auto styleCheckBoxVertexColor = GetWindowLongPtr(hCheckBoxVertexColor, GWL_STYLE);
+
+			// Remove bits responsible for style and set a new style
+			styleEditRadius = (styleEditRadius & ~SS_TYPEMASK) | SS_RIGHT;
+			styleEditFalloff = (styleEditFalloff & ~SS_TYPEMASK) | SS_RIGHT;
+			styleSelectedTexture = (styleSelectedTexture & ~SS_TYPEMASK) | SS_LEFT;
+			styleCheckBoxVertexColor |= BS_LEFTTEXT;
+			styleCheckBoxVertexColor |= BS_RIGHT;
+
+			// Set a new style for the element
+			SetWindowLongPtr(hStaticTextEditRadius, GWL_STYLE, styleEditRadius);
+			SetWindowLongPtr(hStaticTextEditFalloff, GWL_STYLE, styleEditFalloff);
+			SetWindowLongPtr(hStaticTextSelectedTexture, GWL_STYLE, styleSelectedTexture);
+			SetWindowLongPtr(hCheckBoxVertexColor, GWL_STYLE, styleCheckBoxVertexColor);
+		}
+
 		// Restore size and position
 		const auto& settingsSize = settings.landscape_window.size;
 		const auto width = std::max(settingsSize.width, MIN_WIDTH);
@@ -347,51 +382,44 @@ namespace se::cs::dialog::landscape_edit_settings_window {
 	}
 
 	namespace ResizeConstants {
+		//Font 08 - Vanilla
+		constexpr auto STATIC_HEIGHT = 13;
+		//Font 10
+		//constexpr auto STATIC_HEIGHT = 16;
+		//Font 12
+
+		constexpr auto COMBO_HEIGHT = STATIC_HEIGHT + 8;
 		constexpr auto BASIC_PADDING = 2;
 		constexpr auto BIG_PADDING = 6;
 		constexpr auto WINDOW_EDGE_PADDING = 10;
+		constexpr auto STATIC_COMBO_OFFSET = (COMBO_HEIGHT - STATIC_HEIGHT) / 2;
 
-		constexpr auto SECTIONS_MIN_WIDTH = 396;
-		constexpr auto HEIGHT_SECTION_HEIGHT = 80;
-		constexpr auto VERTEX_COLOR_SECTION_HEIGHT = 147;
+		constexpr auto CUSTOM_COLOR_WIDTH = 40;
+		constexpr auto CUSTOM_COLOR_HEIGHT = CUSTOM_COLOR_WIDTH / 2;
+		constexpr auto CUSTOM_COLOR_SECTION_WIDTH = CUSTOM_COLOR_WIDTH * 8 + BIG_PADDING * 8;
+		constexpr auto COLOR_PREVIEW_HEIGHT = COMBO_HEIGHT * 2 + BASIC_PADDING;
 
-		constexpr auto BUTTON_HEIGHT = 23;
-		constexpr auto BUTTON_WIDTH = 80;
+		constexpr auto HEIGHT_SECTION_HEIGHT = BIG_PADDING * 4 + COMBO_HEIGHT * 2 + BASIC_PADDING;
+		constexpr auto VERTEX_COLOR_SECTION_HEIGHT = COMBO_HEIGHT * 5 + BASIC_PADDING * 2 + BIG_PADDING * 4 + CUSTOM_COLOR_HEIGHT * 2;
+		constexpr auto BOTTOM_SECTION_HEIGHT = COMBO_HEIGHT + WINDOW_EDGE_PADDING * 2;
 
-		constexpr auto HEIGHT_STATIC_WIDTH = 64;
-		constexpr auto HEIGHT_STATIC_HEIGHT = 16;
+		constexpr auto BUTTON_WIDTH = 90;
+		constexpr auto EDIT_FIELD_WIDTH = 40;
+		constexpr auto EDIT_COLORS_CHECKBOX_WIDTH = 90;
+		constexpr auto SHOW_EDIT_RADIUS_CHECKBOX_WIDTH = 130;
+		constexpr auto FLATTEN_VERTICES_CHECKBOX_WIDTH = 120;
+		constexpr auto SOFTEN_VERTICES_CHECKBOX_WIDTH = 120;
 
-		constexpr auto HEIGHT_EDIT_WIDTH = 68;
-		constexpr auto HEIGHT_EDIT_HEIGHT = 20;
+		constexpr auto PREVIEW_TEXTURE_NAME_STATIC_WIDTH = 150;
+		constexpr auto PREVIEW_TEXTURE_BOX = 256;
+		constexpr auto PREVIEW_TEXTURE_FRAME_BOX = PREVIEW_TEXTURE_BOX + STATIC_COMBO_OFFSET;
 
-		constexpr auto HEIGHT_CHECKBOX_WIDTH = 93;
-		constexpr auto HEIGHT_CHECKBOX_HEIGHT = 13;
+		constexpr auto RGB_WIDTH = EDIT_FIELD_WIDTH / 2;
+		constexpr auto VERTEX_EDIT_WIDTH = EDIT_FIELD_WIDTH;
+		constexpr auto SPIN_WIDTH = EDIT_FIELD_WIDTH / 2;
 
-		// Extra padding needed to keep the controls within the window
-		constexpr auto BOTTOM_GHOST_HEIGHT = 99;
-
-		constexpr auto PREVIEW_TEXTURE_WIDTH = 110;
-		constexpr auto PREVIEW_TEXTURE_NAME_WIDTH = 186;
-		constexpr auto PREVIEW_TEXTURE_NAME_HEIGHT = 14;
-
-		constexpr auto STATIC_WIDTH = 12;
-		constexpr auto STATIC_HEIGHT = 16;
-		constexpr auto STATIC_EDIT_OFFSET = 4;
-
-		constexpr auto VERTEX_EDIT_WIDTH = 26;
-		constexpr auto VERTEX_EDIT_HEIGHT = 20;
-
-		constexpr auto SPIN_WIDTH = 18;
-		constexpr auto SPIN_HEIGHT = 20;
-
-		constexpr auto STATIC_EDIT_SPIN_OFFSET = 24;
-
-		constexpr auto COLOR_PREVIEW_WIDTH = 58;
-		constexpr auto COLOR_PREVIEW_HEIGHT = 42;
-
-		constexpr auto CUSTOM_COLOR_WIDTH = 20;
-		constexpr auto CUSTOM_COLOR_HEIGHT = 15;
-		constexpr auto CUSTOM_COLOR_PADDING = 22;
+		constexpr auto COLOR_PREVIEW_GROUP_OFFSET = RGB_WIDTH + BASIC_PADDING + VERTEX_EDIT_WIDTH + SPIN_WIDTH + BIG_PADDING;
+		constexpr auto CURRENT_COLOR_SECTION_WIDTH = COLOR_PREVIEW_GROUP_OFFSET + BUTTON_WIDTH;
 	}
 
 	void ResizeCustomColorStatic(HWND hParent, int iDlgStatic, int& x, int y) {
@@ -399,22 +427,23 @@ namespace se::cs::dialog::landscape_edit_settings_window {
 
 		auto hDlgStatic = GetDlgItem(hParent, iDlgStatic);
 		MoveWindow(hDlgStatic, x, y, CUSTOM_COLOR_WIDTH, CUSTOM_COLOR_HEIGHT, FALSE);
-		x += CUSTOM_COLOR_WIDTH + CUSTOM_COLOR_PADDING;
+
+		x += CUSTOM_COLOR_WIDTH + BIG_PADDING;
 	}
 
 	void ResizeStaticEditSpin(HWND hParent, int iDlgStatic, int iDlgEdit, int iDlgSpin, int x, int& y) {
 		using namespace ResizeConstants;
 
 		auto hDlgStatic = GetDlgItem(hParent, iDlgStatic);
-		MoveWindow(hDlgStatic, x, y + STATIC_EDIT_OFFSET, STATIC_WIDTH, STATIC_HEIGHT, FALSE);
+		MoveWindow(hDlgStatic, x, y + STATIC_COMBO_OFFSET, RGB_WIDTH, STATIC_HEIGHT, FALSE);
 
 		auto hDlgEdit = GetDlgItem(hParent, iDlgEdit);
-		MoveWindow(hDlgEdit, x + STATIC_WIDTH + 4, y, VERTEX_EDIT_WIDTH, VERTEX_EDIT_HEIGHT, FALSE);
+		MoveWindow(hDlgEdit, x + BASIC_PADDING + RGB_WIDTH, y, VERTEX_EDIT_WIDTH, COMBO_HEIGHT, FALSE);
 
 		auto hDlgSpin = GetDlgItem(hParent, iDlgSpin);
-		MoveWindow(hDlgSpin, x + STATIC_WIDTH + VERTEX_EDIT_WIDTH + 2, y, SPIN_WIDTH, SPIN_HEIGHT, FALSE);
+		MoveWindow(hDlgSpin, x + RGB_WIDTH + VERTEX_EDIT_WIDTH, y, SPIN_WIDTH, COMBO_HEIGHT, FALSE);
 
-		y += STATIC_EDIT_SPIN_OFFSET;
+		y += COMBO_HEIGHT + BASIC_PADDING;
 	}
 
 #define ResizeStaticEditSpinHelper(hParent, primaryOrSecondary, color, x, y) ResizeStaticEditSpin(hParent, CONTROL_ID_##primaryOrSecondary##_COLOR_##color##_STATIC, CONTROL_ID_##primaryOrSecondary##_COLOR_##color##_EDIT, CONTROL_ID_##primaryOrSecondary##_COLOR_##color##_SPIN, x, y)
@@ -423,7 +452,7 @@ namespace se::cs::dialog::landscape_edit_settings_window {
 		using namespace ResizeConstants;
 
 		const auto showPreviewImagePadding = IsDlgButtonChecked(hWnd, CONTROL_ID_SHOW_PREVIEW_TEXTURE_BUTTON) ? 270 : 0;
-	
+
 		const auto clientWidth = LOWORD(lParam);
 		const auto clientHeight = HIWORD(lParam);
 		const auto sectionWidth = clientWidth - WINDOW_EDGE_PADDING * 2 - showPreviewImagePadding;
@@ -435,123 +464,135 @@ namespace se::cs::dialog::landscape_edit_settings_window {
 			auto currentY = WINDOW_EDGE_PADDING;
 
 			auto heightGroupbox = GetDlgItem(hWnd, CONTROL_ID_HEIGHT_GROUPBOX);
-			MoveWindow(heightGroupbox, currentX, currentY, sectionWidth, HEIGHT_SECTION_HEIGHT, FALSE);
-			currentY += 18;
-			currentX += 20;
+			MoveWindow(heightGroupbox, currentX, currentY - BIG_PADDING, sectionWidth, HEIGHT_SECTION_HEIGHT, FALSE);
+
+			currentX += BIG_PADDING;
+			currentY += BIG_PADDING * 2;
 
 			auto editRadiusStatic = GetDlgItem(hWnd, CONTROL_ID_EDIT_RADIUS_STATIC);
-			MoveWindow(editRadiusStatic, currentX, currentY + 4, HEIGHT_STATIC_WIDTH, HEIGHT_STATIC_HEIGHT, FALSE);
-			currentX += 69;
+			MoveWindow(editRadiusStatic, currentX, currentY + STATIC_COMBO_OFFSET, BUTTON_WIDTH, STATIC_HEIGHT, FALSE);
+
+			currentX += BASIC_PADDING * 2 + BUTTON_WIDTH;
 
 			auto editRadiusEdit = GetDlgItem(hWnd, CONTROL_ID_EDIT_RADIUS_EDIT);
-			MoveWindow(editRadiusEdit, currentX, currentY, HEIGHT_EDIT_WIDTH, HEIGHT_EDIT_HEIGHT, FALSE);
-			currentX += 88;
+			MoveWindow(editRadiusEdit, currentX, currentY, EDIT_FIELD_WIDTH, COMBO_HEIGHT, FALSE);
+
+			currentX += BIG_PADDING + EDIT_FIELD_WIDTH;
 
 			auto flattenVerticesCheckbox = GetDlgItem(hWnd, CONTROL_ID_FLATTEN_VERTICES_CHECKBOX);
-			MoveWindow(flattenVerticesCheckbox, currentX, currentY + 5, HEIGHT_CHECKBOX_WIDTH, HEIGHT_CHECKBOX_HEIGHT, FALSE);
-			currentX += 104;
+			MoveWindow(flattenVerticesCheckbox, currentX, currentY + STATIC_COMBO_OFFSET, FLATTEN_VERTICES_CHECKBOX_WIDTH, STATIC_HEIGHT, FALSE);
 
 			auto softenVerticesCheckbox = GetDlgItem(hWnd, CONTROL_ID_SOFTEN_VERTICES_CHECKBOX);
-			MoveWindow(softenVerticesCheckbox, currentX, currentY + 5, HEIGHT_CHECKBOX_WIDTH, HEIGHT_CHECKBOX_HEIGHT, FALSE);
+			MoveWindow(softenVerticesCheckbox, currentX + FLATTEN_VERTICES_CHECKBOX_WIDTH, currentY + STATIC_COMBO_OFFSET, SOFTEN_VERTICES_CHECKBOX_WIDTH, STATIC_HEIGHT, FALSE);
 
-			currentX = WINDOW_EDGE_PADDING + 20;
-			currentY += 31;
+			currentX -= BASIC_PADDING * 2 + BIG_PADDING + BUTTON_WIDTH + EDIT_FIELD_WIDTH;
+			currentY += COMBO_HEIGHT + BASIC_PADDING;
 
-			auto editFalloffStatic = GetDlgItem(hWnd, CONTROL_ID_EDIT_FALLOFF_STATIC);
-			MoveWindow(editFalloffStatic, currentX, currentY + 3, HEIGHT_STATIC_WIDTH, HEIGHT_STATIC_HEIGHT, FALSE);
-			currentX += 68;
+			auto editFallofEdit = GetDlgItem(hWnd, CONTROL_ID_EDIT_FALLOFF_EDIT);
+			MoveWindow(editFallofEdit, currentX + BASIC_PADDING * 2 + BUTTON_WIDTH, currentY, EDIT_FIELD_WIDTH, COMBO_HEIGHT, FALSE);
 
-			auto editFalloffEdit = GetDlgItem(hWnd, CONTROL_ID_EDIT_FALLOFF_EDIT);
-			MoveWindow(editFalloffEdit, currentX, currentY, HEIGHT_EDIT_WIDTH, HEIGHT_EDIT_HEIGHT, FALSE);
-			currentX += 133;
+			currentY += STATIC_COMBO_OFFSET;
 
-			auto showEditRadius = GetDlgItem(hWnd, CONTROL_ID_SHOW_EDIT_RADIUS_CHECKBOX);
-			MoveWindow(showEditRadius, currentX, currentY + 4, HEIGHT_CHECKBOX_WIDTH + 10, HEIGHT_CHECKBOX_HEIGHT, FALSE);
+			auto editFallofStatic = GetDlgItem(hWnd, CONTROL_ID_EDIT_FALLOFF_STATIC);
+			MoveWindow(editFallofStatic, currentX, currentY, BUTTON_WIDTH, STATIC_HEIGHT, FALSE);
+
+			currentX += BASIC_PADDING * 2 + BIG_PADDING + BUTTON_WIDTH + EDIT_FIELD_WIDTH + (FLATTEN_VERTICES_CHECKBOX_WIDTH + SOFTEN_VERTICES_CHECKBOX_WIDTH - SHOW_EDIT_RADIUS_CHECKBOX_WIDTH) / 2;
+
+			auto showEditRadiusCheckbox = GetDlgItem(hWnd, CONTROL_ID_SHOW_EDIT_RADIUS_CHECKBOX);
+			MoveWindow(showEditRadiusCheckbox, currentX, currentY, SHOW_EDIT_RADIUS_CHECKBOX_WIDTH, STATIC_HEIGHT, FALSE);
 		}
 
 		// Texture Section
 		{
 			auto currentX = WINDOW_EDGE_PADDING;
-			auto currentY = WINDOW_EDGE_PADDING + HEIGHT_SECTION_HEIGHT + BASIC_PADDING * 2;
-			const auto TEXTURE_SECTION_HEIGHT = clientHeight - BOTTOM_GHOST_HEIGHT - VERTEX_COLOR_SECTION_HEIGHT - WINDOW_EDGE_PADDING - BUTTON_HEIGHT - BASIC_PADDING * 2;
+			auto currentY = WINDOW_EDGE_PADDING + HEIGHT_SECTION_HEIGHT;
+			const auto TEXTURE_SECTION_HEIGHT = clientHeight - HEIGHT_SECTION_HEIGHT - VERTEX_COLOR_SECTION_HEIGHT - BOTTOM_SECTION_HEIGHT - BIG_PADDING * 3;
 
 			auto textureGroupbox = GetDlgItem(hWnd, CONTROL_ID_TEXTURE_GROUPBOX);
 			MoveWindow(textureGroupbox, currentX, currentY, sectionWidth, TEXTURE_SECTION_HEIGHT, FALSE);
 
-			currentX += BASIC_PADDING * 4;
-			currentY += 16;
+			currentX += WINDOW_EDGE_PADDING;
 
-			auto TEXTURE_LIST_WIDTH = sectionWidth - WINDOW_EDGE_PADDING - BASIC_PADDING * 3;//clientWidth - WINDOW_EDGE_PADDING - PREVIEW_TEXTURE_WIDTH;
-			const auto TEXTURE_LIST_HEIGHT = TEXTURE_SECTION_HEIGHT - BUTTON_HEIGHT - BASIC_PADDING * 10 - 1;
+			auto TEXTURE_LIST_WIDTH = sectionWidth - WINDOW_EDGE_PADDING * 2;
+			const auto TEXTURE_LIST_HEIGHT = TEXTURE_SECTION_HEIGHT - COMBO_HEIGHT * 2 - BIG_PADDING * 2 - BASIC_PADDING;
+
+			//Texture prewiew section offset
+			currentX += TEXTURE_LIST_WIDTH + WINDOW_EDGE_PADDING * 2;
+
+			auto selectedTextureStatic = GetDlgItem(hWnd, CONTROL_ID_SELECTED_TEXTURE_STATIC);
+			MoveWindow(selectedTextureStatic, currentX, currentY, PREVIEW_TEXTURE_NAME_STATIC_WIDTH, STATIC_HEIGHT, FALSE);
+
+			currentY += STATIC_HEIGHT + BIG_PADDING;
+
+			auto previewTextureImage = GetDlgItem(hWnd, CONTROL_ID_PREVIEW_TEXTURE_BUTTON);
+			MoveWindow(previewTextureImage, currentX + BASIC_PADDING, currentY + BASIC_PADDING, PREVIEW_TEXTURE_BOX, PREVIEW_TEXTURE_BOX, FALSE);
+
+			auto previewTextureFrameStatic = GetDlgItem(hWnd, CONTROL_ID_PREVIEW_TEXTURE_FRAME_STATIC);
+			MoveWindow(previewTextureFrameStatic, currentX, currentY, PREVIEW_TEXTURE_FRAME_BOX, PREVIEW_TEXTURE_FRAME_BOX, FALSE);
+
+			currentX -= TEXTURE_LIST_WIDTH + WINDOW_EDGE_PADDING * 2;
+			currentY -= STATIC_HEIGHT + BIG_PADDING;
+			//Texture prewiew section offset end
+
+			currentY += COMBO_HEIGHT;
 
 			auto textureList = GetDlgItem(hWnd, CONTROL_ID_TEXTURE_LIST);
 			MoveWindow(textureList, currentX, currentY, TEXTURE_LIST_WIDTH, TEXTURE_LIST_HEIGHT, FALSE);
-			currentX += TEXTURE_LIST_WIDTH;
 
-			auto selectedTextureStatic = GetDlgItem(hWnd, CONTROL_ID_SELECTED_TEXTURE_STATIC);
-			MoveWindow(selectedTextureStatic, currentX + 9, currentY - 54, 100, 12, FALSE);
-			currentY += BASIC_PADDING + 25 + 4;
-
-			auto previewTextureImage = GetDlgItem(hWnd, CONTROL_ID_PREVIEW_TEXTURE_BUTTON);
-			MoveWindow(previewTextureImage, currentX + 20, currentY - 68, 256, 256, FALSE);
-
-			auto previewTextureFrameStatic = GetDlgItem(hWnd, CONTROL_ID_PREVIEW_TEXTURE_FRAME_STATIC);
-			MoveWindow(previewTextureFrameStatic, currentX + 18, currentY - 69, 260, 259, FALSE);
-
-			currentX -= TEXTURE_LIST_WIDTH;
-			currentY -= BASIC_PADDING + 25 + 4 + 1;
-			currentY += TEXTURE_LIST_HEIGHT;
+			currentY += TEXTURE_LIST_HEIGHT + BIG_PADDING;
 
 			auto addTextureButton = GetDlgItem(hWnd, CONTROL_ID_ADD_TEXTURE_BUTTON);
-			MoveWindow(addTextureButton, currentX + 17, currentY + BASIC_PADDING, BUTTON_WIDTH, BUTTON_HEIGHT, FALSE);
+			MoveWindow(addTextureButton, currentX, currentY, BUTTON_WIDTH, COMBO_HEIGHT, FALSE);
 
 			auto previewTextureNameStatic = GetDlgItem(hWnd, CONTROL_ID_PREVIEW_TEXTURE_NAME_STATIC);
-			MoveWindow(previewTextureNameStatic, currentX + 110, currentY + 8, PREVIEW_TEXTURE_NAME_WIDTH, PREVIEW_TEXTURE_NAME_HEIGHT, FALSE);
-				
+			MoveWindow(previewTextureNameStatic, currentX + BUTTON_WIDTH + BASIC_PADDING, currentY, CUSTOM_COLOR_SECTION_WIDTH + BIG_PADDING - BUTTON_WIDTH * 2 - BASIC_PADDING * 2, COMBO_HEIGHT, FALSE);
+
+			currentX += CUSTOM_COLOR_SECTION_WIDTH + BIG_PADDING - BUTTON_WIDTH;
+
 			auto showPreviewTextureButton = GetDlgItem(hWnd, CONTROL_ID_SHOW_PREVIEW_TEXTURE_BUTTON);
-			MoveWindow(showPreviewTextureButton, currentX + 301, currentY + BASIC_PADDING, BUTTON_WIDTH, BUTTON_HEIGHT, FALSE);
+			MoveWindow(showPreviewTextureButton, currentX, currentY, BUTTON_WIDTH, COMBO_HEIGHT, FALSE);
 		}
 
 		// Vertex Color Section
 		{
 			auto currentX = WINDOW_EDGE_PADDING;
-			auto currentY = clientHeight - WINDOW_EDGE_PADDING - BUTTON_HEIGHT - 10 - VERTEX_COLOR_SECTION_HEIGHT + BASIC_PADDING * 2;
+			auto currentY = clientHeight - VERTEX_COLOR_SECTION_HEIGHT - BOTTOM_SECTION_HEIGHT;
 
 			auto vertexColorGroupbox = GetDlgItem(hWnd, CONTROL_ID_VERTEX_COLOR_GROUPBOX);
 			MoveWindow(vertexColorGroupbox, currentX, currentY, sectionWidth, VERTEX_COLOR_SECTION_HEIGHT, FALSE);
 
-			currentX += 9;
-			currentY += 21;
+			currentX += WINDOW_EDGE_PADDING;
+
+			auto editColorsButton = GetDlgItem(hWnd, CONTROL_ID_EDIT_COLORS_CHECKBOX);
+			MoveWindow(editColorsButton, currentX + CUSTOM_COLOR_SECTION_WIDTH - EDIT_COLORS_CHECKBOX_WIDTH, currentY + STATIC_COMBO_OFFSET * 2 + COMBO_HEIGHT / 2, EDIT_COLORS_CHECKBOX_WIDTH, STATIC_HEIGHT, FALSE);
+
+			currentY += COMBO_HEIGHT * 2;
 
 			auto primaryColorPreviewStatic = GetDlgItem(hWnd, CONTROL_ID_PRIMARY_COLOR_PREVIEW_STATIC);
-			MoveWindow(primaryColorPreviewStatic, currentX + 76, currentY, COLOR_PREVIEW_WIDTH, COLOR_PREVIEW_HEIGHT, FALSE);
+			MoveWindow(primaryColorPreviewStatic, currentX + COLOR_PREVIEW_GROUP_OFFSET, currentY, BUTTON_WIDTH, COLOR_PREVIEW_HEIGHT, FALSE);
 
 			ResizeStaticEditSpinHelper(hWnd, PRIMARY, RED, currentX, currentY);
 			ResizeStaticEditSpinHelper(hWnd, PRIMARY, GREEN, currentX, currentY);
 			ResizeStaticEditSpinHelper(hWnd, PRIMARY, BLUE, currentX, currentY);
 
 			auto primaryColorSelectColorButton = GetDlgItem(hWnd, CONTROL_ID_PRIMARY_COLOR_SELECT_COLOR_BUTTON);
-			MoveWindow(primaryColorSelectColorButton, currentX + 65, currentY - 24, BUTTON_WIDTH, BUTTON_HEIGHT, FALSE);
+			MoveWindow(primaryColorSelectColorButton, currentX + COLOR_PREVIEW_GROUP_OFFSET, currentY - COMBO_HEIGHT - BASIC_PADDING, BUTTON_WIDTH, COMBO_HEIGHT, FALSE);
 
-			currentX += 160;
-			currentY = clientHeight - WINDOW_EDGE_PADDING - BUTTON_HEIGHT - 11 - VERTEX_COLOR_SECTION_HEIGHT + BASIC_PADDING * 2;
-			currentY += 21;
+			currentX += CUSTOM_COLOR_SECTION_WIDTH / 2 + (CUSTOM_COLOR_SECTION_WIDTH / 2 - CURRENT_COLOR_SECTION_WIDTH);
+			currentY = clientHeight - VERTEX_COLOR_SECTION_HEIGHT - BOTTOM_SECTION_HEIGHT + COMBO_HEIGHT * 2;
 
 			auto secondaryColorPreviewStatic = GetDlgItem(hWnd, CONTROL_ID_SECONDARY_COLOR_PREVIEW_STATIC);
-			MoveWindow(secondaryColorPreviewStatic, currentX + 76, currentY, COLOR_PREVIEW_WIDTH, COLOR_PREVIEW_HEIGHT, FALSE);
+			MoveWindow(secondaryColorPreviewStatic, currentX + COLOR_PREVIEW_GROUP_OFFSET, currentY, BUTTON_WIDTH, COLOR_PREVIEW_HEIGHT, FALSE);
 
 			ResizeStaticEditSpinHelper(hWnd, SECONDARY, RED, currentX, currentY);
 			ResizeStaticEditSpinHelper(hWnd, SECONDARY, GREEN, currentX, currentY);
 			ResizeStaticEditSpinHelper(hWnd, SECONDARY, BLUE, currentX, currentY);
 
 			auto secondaryColorSelectColorButton = GetDlgItem(hWnd, CONTROL_ID_SECONDARY_COLOR_SELECT_COLOR_BUTTON);
-			MoveWindow(secondaryColorSelectColorButton, currentX + 65, currentY - 24, BUTTON_WIDTH, BUTTON_HEIGHT, FALSE);
+			MoveWindow(secondaryColorSelectColorButton, currentX + COLOR_PREVIEW_GROUP_OFFSET, currentY - COMBO_HEIGHT - BASIC_PADDING, BUTTON_WIDTH, COMBO_HEIGHT, FALSE);
 
-			auto editColorsButton = GetDlgItem(hWnd, CONTROL_ID_EDIT_COLORS_CHECKBOX);
-			MoveWindow(editColorsButton, currentX + 153, currentY - 67, 72, 13, FALSE);
-
-			currentX = WINDOW_EDGE_PADDING + 37;
-			currentY += 11;
+			currentX = WINDOW_EDGE_PADDING * 2 + BIG_PADDING;
+			currentY += BIG_PADDING;
 
 			ResizeCustomColorStatic(hWnd, CONTROL_ID_CUSTOM_COLOR_ONE_STATIC, currentX, currentY);
 			ResizeCustomColorStatic(hWnd, CONTROL_ID_CUSTOM_COLOR_TWO_STATIC, currentX, currentY);
@@ -562,8 +603,8 @@ namespace se::cs::dialog::landscape_edit_settings_window {
 			ResizeCustomColorStatic(hWnd, CONTROL_ID_CUSTOM_COLOR_SEVEN_STATIC, currentX, currentY);
 			ResizeCustomColorStatic(hWnd, CONTROL_ID_CUSTOM_COLOR_EIGHT_STATIC, currentX, currentY);
 
-			currentX = WINDOW_EDGE_PADDING + 37;
-			currentY += 6 + 15;
+			currentX = WINDOW_EDGE_PADDING * 2 + BIG_PADDING;
+			currentY += CUSTOM_COLOR_HEIGHT + BIG_PADDING;
 
 			ResizeCustomColorStatic(hWnd, CONTROL_ID_CUSTOM_COLOR_NINE_STATIC, currentX, currentY);
 			ResizeCustomColorStatic(hWnd, CONTROL_ID_CUSTOM_COLOR_TEN_STATIC, currentX, currentY);
@@ -573,9 +614,15 @@ namespace se::cs::dialog::landscape_edit_settings_window {
 			ResizeCustomColorStatic(hWnd, CONTROL_ID_CUSTOM_COLOR_FOURTEEN_STATIC, currentX, currentY);
 			ResizeCustomColorStatic(hWnd, CONTROL_ID_CUSTOM_COLOR_FIFTEEN_STATIC, currentX, currentY);
 			ResizeCustomColorStatic(hWnd, CONTROL_ID_CUSTOM_COLOR_SIXTEEN_STATIC, currentX, currentY);
+		}
+
+		// Bottom Section
+		{
+			auto currentX = WINDOW_EDGE_PADDING * 2 + BIG_PADDING + (CUSTOM_COLOR_SECTION_WIDTH - BIG_PADDING) / 2 - BUTTON_WIDTH;
+			auto currentY = clientHeight - BOTTOM_SECTION_HEIGHT + WINDOW_EDGE_PADDING;
 
 			auto exitEditingButton = GetDlgItem(hWnd, CONTROL_ID_EXIT_EDITING_BUTTON);
-			MoveWindow(exitEditingButton, 127, currentY + 31, 164, BUTTON_HEIGHT, FALSE);
+			MoveWindow(exitEditingButton, currentX, currentY, BUTTON_WIDTH * 2, COMBO_HEIGHT, FALSE);
 		}
 
 		RedrawWindow(hWnd, NULL, NULL, RDW_ERASE | RDW_FRAME | RDW_ERASENOW | RDW_INVALIDATE | RDW_ALLCHILDREN);


### PR DESCRIPTION
Galrom's Landscape Edit Window - the use of specific numbers in the layout of UI elements has been changed to the use of resize constants.

Cons: slightly different UI layout at Vertex Color section, in comparison with vanilla CS interface.

Preview: https://postimg.cc/ft3WvzKX