### PR TITLE
added support for multiple key prefixes in the `mwseKeyCombo` display string

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
@@ -107,9 +107,9 @@ function KeyBinder:getComboString(keyCombo)
 	local hasCtrl = (keyCombo.isControlDown and keyCode ~= tes3.scanCode.lCtrl
 	                                        and keyCode ~= tes3.scanCode.rCtrl)
 	local prefixes = {}
-	if hasShift then table.insert(prefixes,"Shift") end
-	if hasAlt then table.insert(prefixes,"Alt") end
-	if hasCtrl then table.insert(prefixes,"Ctrl") end
+	if hasShift then table.insert(prefixes, "Shift") end
+	if hasAlt then table.insert(prefixes, "Alt") end
+	if hasCtrl then table.insert(prefixes, "Ctrl") end
 	table.insert(prefixes, comboText)
 	return table.concat(prefixes, " - ")
 end

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
@@ -106,9 +106,12 @@ function KeyBinder:getComboString(keyCombo)
 	                                       and keyCode ~= tes3.scanCode.rShift)
 	local hasCtrl = (keyCombo.isControlDown and keyCode ~= tes3.scanCode.lCtrl
 	                                        and keyCode ~= tes3.scanCode.rCtrl)
-	local prefix = (hasAlt and "Alt - " or hasShift and "Shift - " or hasCtrl and "Ctrl - " or "")
-
-	return (prefix .. comboText)
+	local prefixes = {}
+	if hasShift then table.insert(prefixes,"Shift") end
+	if hasAlt then table.insert(prefixes,"Alt") end
+	if hasCtrl then table.insert(prefixes,"Ctrl") end
+	table.insert(prefixes, comboText)
+	return table.concat(prefixes, " - ")
 end
 
 


### PR DESCRIPTION
as it is now, `mwseCombo` supports multiple prefixes being used, but the UI only displays one. (so if a keybind has shift and alt held, only "Alt - key" will be shown.) this small change allows multiple prefixes to be shown (e.g. "Shift - Alt- key".)

only a few select lines of code were changed