### PR TITLE
added `getAllRegisteredModNames` and `setHidden` to `mwse/mcm/main.lua`

### DIFF
--- a/autocomplete/definitions/global/mwse/mcm/getAllRegisteredModNames.lua
+++ b/autocomplete/definitions/global/mwse/mcm/getAllRegisteredModNames.lua
@@ -1,0 +1,10 @@
+return {
+	type = "function",
+	description = [[Returns a list containing the names of all mods that have been registered to the MCM.]],
+	arguments = {
+		{ name = "sort", type = "boolean|function|nil", optional = true, description = "If true, the returned table will be sorted. If a function is passed, the table will be sorted using the given function." },
+	},
+	returns = {
+		{ name = "modNames", type = "table", description = "An array containing the names of all mods that have been registered to the MCM." },
+	},
+}

--- a/autocomplete/definitions/global/mwse/mcm/setHidden.lua
+++ b/autocomplete/definitions/global/mwse/mcm/setHidden.lua
@@ -1,0 +1,8 @@
+return {
+	type = "function",
+	description = [[This function will hide or unhide a mod in the MCM. The MCM must be closed and reopened for changes to take effect.]],
+	arguments = {
+		{ name = "modName", type = "string", description = "The name of the mod to hide or unhide." },
+		{ name = "hidden", type = "boolean|nil", optional = true, description = "Whether to hide or unhide the mod. If `true`, the mod will be hidden. If `false`, the mod will be unhidden (i.e. shown). Default: `true`." },
+	},
+}

--- a/docs/source/apis/mwse.mcm.md
+++ b/docs/source/apis/mwse.mcm.md
@@ -838,6 +838,21 @@ local button = mwse.mcm.createYesNoButton(parent, { label = ..., description = .
 
 ***
 
+### `mwse.mcm.getAllRegisteredModNames`
+<div class="search_terms" style="display: none">getAllRegisteredMods</div>
+
+Returns a list containing the names of all mods that have been registered to the MCM.
+
+**Parameters**:
+
+* `sort` (boolean, function, nil): *Optional*. If true, the returned table will be sorted. If a function is passed, the table will be sorted using the given function.
+
+**Returns**:
+
+* `modNames` (table): An array containing the names of all mods that have been registered to the MCM.
+
+***
+
 ### `mwse.mcm.register`
 <div class="search_terms" style="display: none">register</div>
 
@@ -852,6 +867,18 @@ mwse.mcm.register(template)
 **Parameters**:
 
 * `template` ([mwseMCMTemplate](../types/mwseMCMTemplate.md))
+
+***
+
+### `mwse.mcm.setHidden`
+<div class="search_terms" style="display: none">setHidden</div>
+
+This function will hide or unhide a mod in the MCM. The MCM must be closed and reopened for changes to take effect.
+
+**Parameters**:
+
+* `modName` (string): The name of the mod to hide or unhide.
+* `hidden` (boolean|nil): *Optional*. If true, the mod will be hidden. If false, the mod will be unhidden (i.e. shown). Default: true.
 
 ***
 

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -26,6 +26,16 @@ local modConfigContainer = nil
 mwse.mcm = require("mcm.mcm")
 mwse.mcm.i18n = mwse.loadTranslations("mcm")
 
+
+function mwse.mcm.getAllRegisteredModNames(sort) return table.keys(configMods, sort) end
+
+function mwse.mcm.setHidden(modName, hidden)
+	if configMods[modName] then
+		if hidden == nil then hidden = true end
+		configMods[modName].hidden = hidden
+	end
+end
+
 --- Callback for when a mod name has been clicked in the left pane.
 --- @param e tes3uiEventData
 local function onClickModName(e)


### PR DESCRIPTION
two functions were added:
* `getAllRegisteredModNames`: this one just calls `table.keys` on `configMods`.
* `setHidden`: this one takes in a `modName` and a boolean (`hidden`). it checks if a mod with the given `modName` exists, and then toggles its `hidden` flag if it does. the `hidden` functionality was already implemented in the MCM, this just gives people another way to access it.

i also added documentation for both functions (both via luacats and in the mwse.mcm.md file)