### PR TITLE
added CRLF conversions for .lua and .md files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -35,6 +35,10 @@
 *.h++ text
 *.hh text
 
+# marking lua and md files as text, with crlf set to true so that documentation can be built on other operating systems
+*.lua text eol=crlf
+*.md text eol=crlf
+
 # Compiled Object files
 *.slo binary
 *.lo binary


### PR DESCRIPTION
i changed `.gitattributes` to enable CRLF conversion for `.md` and `.lua` files. without this, git freaks out when rebuilding docs on non-windows operating systems.