### PR TITLE
minor bug-fix: `mkdocs` incorrectly generates documentation for arguments that are functions

### DIFF
--- a/autocomplete/builders/mkdocs.lua
+++ b/autocomplete/builders/mkdocs.lua
@@ -214,7 +214,7 @@ local function breakoutTypeLinks(type, nested)
 				paramStr = paramStr:trim()
 				-- name: "e", type: "mwseTimerCallbackData" or
 				-- name: "param2", type: nil
-				local name, type = paramStr:match("([%w]+)[:]?[%s]?(.*)")
+				local name, type = table.unpack(paramStr:split("%s?:%s?"))
 				p[i] = ("%s%s"):format(
 					name,
 					type and (": " .. breakoutTypeLinks(type, true)) or ""

--- a/docs/source/apis/mwse.mcm.md
+++ b/docs/source/apis/mwse.mcm.md
@@ -117,7 +117,7 @@ local variable = mwse.mcm.createConfigVariable({ id = ..., path = ..., defaultSe
 	* `numbersOnly` (boolean): *Default*: `false`. If true, only numbers will be allowed for this variable in TextFields.
 	* `restartRequired` (boolean): *Default*: `false`. If true, updating the setting containing this variable will notify the player to restart the game.
 	* `restartRequiredMessage` (string): *Optional*.  The default text is a localized version of: "The game must be restarted before this change will come into effect.".
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 
@@ -144,7 +144,7 @@ local variable = mwse.mcm.createCustom({ id = ..., getter = ..., setter = ..., i
 	* `numbersOnly` (boolean): *Default*: `false`. If true, only numbers will be allowed for this variable in TextFields.
 	* `restartRequired` (boolean): *Default*: `false`. If true, updating the setting containing this variable will notify the player to restart the game.
 	* `restartRequiredMessage` (string): *Optional*.  The default text is a localized version of: "The game must be restarted before this change will come into effect.".
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 
@@ -306,7 +306,7 @@ local variable = mwse.mcm.createGlobal({ id = ..., numbersOnly = ..., converter 
 * `variable` (table, string): If passing only a string, it will be used as variable's id.
 	* `id` (string): The id of the Morrowind Global.
 	* `numbersOnly` (boolean): *Default*: `false`. If true, only numbers will be allowed for this variable in TextFields.
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 
@@ -658,7 +658,7 @@ local variable = mwse.mcm.createPlayerData({ id = ..., path = ..., defaultSettin
 	* `defaultSetting` (unknown): *Optional*. If `id` does not exist in the `tes3.player.data` field, it will be initialized to this value. It's best to initialize this yourself though, as this will not create the value until you've entered the MCM.
 	* `restartRequired` (boolean): *Default*: `false`. If true, updating the setting containing this variable will notify the player to restart the game.
 	* `restartRequiredMessage` (string): *Optional*.  The default text is a localized version of: "The game must be restarted before this change will come into effect.".
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 
@@ -732,7 +732,7 @@ local variable = mwse.mcm.createTableVariable({ id = ..., table = ..., defaultSe
 	* `inGameOnly` (boolean): *Default*: `false`. If true, the setting containing this variable will be disabled if the game is on main menu.
 	* `restartRequired` (boolean): *Default*: `false`. If true, updating the setting containing this variable will notify the player to restart the game.
 	* `restartRequiredMessage` (string): *Optional*.  The default text is a localized version of: "The game must be restarted before this change will come into effect.".
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 
@@ -837,7 +837,7 @@ local variable = mwse.mcm.createVariable({ id = ..., inGameOnly = ..., numbersOn
 	* `numbersOnly` (boolean): *Default*: `false`. If true, only numbers will be allowed for this variable in TextFields.
 	* `restartRequired` (boolean): *Default*: `false`. If true, updating the setting containing this variable will notify the player to restart the game.
 	* `restartRequiredMessage` (string): *Optional*.  The default text is a localized version of: "The game must be restarted before this change will come into effect.".
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 

--- a/docs/source/apis/mwse.md
+++ b/docs/source/apis/mwse.md
@@ -222,7 +222,7 @@ local i18n = mwse.loadTranslations(mod)
 
 **Returns**:
 
-* `i18n` (fun(key: string, data: any?): string): The callable translation results.
+* `i18n` (fun(key: string, data: any): string): The callable translation results.
 
 ***
 

--- a/docs/source/apis/table.md
+++ b/docs/source/apis/table.md
@@ -30,7 +30,7 @@ local result = table.bininsert(t, value, comp)
 
 * `t` (table)
 * `value` (unknown)
-* `comp` (fun(a: , b: ): boolean): *Optional*.
+* `comp` (fun(a, b): boolean): *Optional*.
 
 **Returns**:
 
@@ -205,7 +205,7 @@ local result = table.filter(t, f, ...)
 **Parameters**:
 
 * `t` (table)
-* `f` (fun(k: unknown, v: unknown, nil))
+* `f` (fun(k: unknown, v: unknown, ...))
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:
@@ -230,7 +230,7 @@ local result = table.filterarray(arr, f, ...)
 **Parameters**:
 
 * `arr` (table)
-* `f` (fun(i: integer, v: unknown, nil))
+* `f` (fun(i: integer, v: unknown, ...))
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:
@@ -353,7 +353,7 @@ local result = table.map(t, f, ...)
 **Parameters**:
 
 * `t` (table)
-* `f` (fun(k: unknown, v: unknown, nil))
+* `f` (fun(k: unknown, v: unknown, ...))
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:

--- a/docs/source/types/mwseMCMConfigVariable.md
+++ b/docs/source/types/mwseMCMConfigVariable.md
@@ -42,7 +42,7 @@ This function is called when the value of the variable is changed. The function 
 
 **Returns**:
 
-* `result` (fun(newValue: ): unknown)
+* `result` (fun(newValue): unknown)
 
 ***
 
@@ -159,7 +159,7 @@ local variable = myObject:new({ id = ..., path = ..., defaultSetting = ..., inGa
 	* `numbersOnly` (boolean): *Default*: `false`. If true, only numbers will be allowed for this variable in TextFields.
 	* `restartRequired` (boolean): *Default*: `false`. If true, updating the setting containing this variable will notify the player to restart the game.
 	* `restartRequiredMessage` (string): *Optional*.  The default text is a localized version of: "The game must be restarted before this change will come into effect.".
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 

--- a/docs/source/types/mwseMCMCustomVariable.md
+++ b/docs/source/types/mwseMCMCustomVariable.md
@@ -40,7 +40,7 @@ This function is called when the value of the variable is changed. The function 
 
 **Returns**:
 
-* `result` (fun(newValue: ): unknown)
+* `result` (fun(newValue): unknown)
 
 ***
 
@@ -150,7 +150,7 @@ local variable = myObject:new({ id = ..., getter = ..., setter = ..., inGameOnly
 	* `numbersOnly` (boolean): *Default*: `false`. If true, only numbers will be allowed for this variable in TextFields.
 	* `restartRequired` (boolean): *Default*: `false`. If true, updating the setting containing this variable will notify the player to restart the game.
 	* `restartRequiredMessage` (string): *Optional*.  The default text is a localized version of: "The game must be restarted before this change will come into effect.".
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 

--- a/docs/source/types/mwseMCMGlobal.md
+++ b/docs/source/types/mwseMCMGlobal.md
@@ -40,7 +40,7 @@ This function is called when the value of the variable is changed. The function 
 
 **Returns**:
 
-* `result` (fun(newValue: ): unknown)
+* `result` (fun(newValue): unknown)
 
 ***
 
@@ -130,7 +130,7 @@ local variable = myObject:new({ id = ..., numbersOnly = ..., converter = ... })
 * `variable` (table, string): If passing only a string, it will be used as variable's id.
 	* `id` (string): The id of the Morrowind Global.
 	* `numbersOnly` (boolean): *Default*: `false`. If true, only numbers will be allowed for this variable in TextFields.
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 

--- a/docs/source/types/mwseMCMPlayerData.md
+++ b/docs/source/types/mwseMCMPlayerData.md
@@ -42,7 +42,7 @@ This function is called when the value of the variable is changed. The function 
 
 **Returns**:
 
-* `result` (fun(newValue: ): unknown)
+* `result` (fun(newValue): unknown)
 
 ***
 
@@ -157,7 +157,7 @@ local variable = myObject:new({ id = ..., path = ..., defaultSetting = ..., rest
 	* `defaultSetting` (unknown): *Optional*. If `id` does not exist in the `tes3.player.data` field, it will be initialized to this value. It's best to initialize this yourself though, as this will not create the value until you've entered the MCM.
 	* `restartRequired` (boolean): *Default*: `false`. If true, updating the setting containing this variable will notify the player to restart the game.
 	* `restartRequiredMessage` (string): *Optional*.  The default text is a localized version of: "The game must be restarted before this change will come into effect.".
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 

--- a/docs/source/types/mwseMCMSettingNewVariable.md
+++ b/docs/source/types/mwseMCMSettingNewVariable.md
@@ -36,7 +36,7 @@ The variable type to create. One of the following:
 
 **Returns**:
 
-* `result` (nil, fun(newValue: ): unknown?)
+* `result` (nil, fun(newValue): unknown?)
 
 ***
 

--- a/docs/source/types/mwseMCMTableVariable.md
+++ b/docs/source/types/mwseMCMTableVariable.md
@@ -42,7 +42,7 @@ This function is called when the value of the variable is changed. The function 
 
 **Returns**:
 
-* `result` (fun(newValue: ): unknown)
+* `result` (fun(newValue): unknown)
 
 ***
 
@@ -158,7 +158,7 @@ local variable = myObject:new({ id = ..., table = ..., defaultSetting = ..., inG
 	* `inGameOnly` (boolean): *Default*: `false`. If true, the setting containing this variable will be disabled if the game is on main menu.
 	* `restartRequired` (boolean): *Default*: `false`. If true, updating the setting containing this variable will notify the player to restart the game.
 	* `restartRequiredMessage` (string): *Optional*.  The default text is a localized version of: "The game must be restarted before this change will come into effect.".
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 

--- a/docs/source/types/mwseMCMVariable.md
+++ b/docs/source/types/mwseMCMVariable.md
@@ -41,7 +41,7 @@ This function is called when the value of the variable is changed. The function 
 
 **Returns**:
 
-* `result` (fun(newValue: ): unknown)
+* `result` (fun(newValue): unknown)
 
 ***
 
@@ -134,7 +134,7 @@ local variable = myObject:new({ id = ..., inGameOnly = ..., numbersOnly = ..., r
 	* `numbersOnly` (boolean): *Default*: `false`. If true, only numbers will be allowed for this variable in TextFields.
 	* `restartRequired` (boolean): *Default*: `false`. If true, updating the setting containing this variable will notify the player to restart the game.
 	* `restartRequiredMessage` (string): *Optional*.  The default text is a localized version of: "The game must be restarted before this change will come into effect.".
-	* `converter` (fun(newValue: ): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
+	* `converter` (fun(newValue): unknown): *Optional*. This function is called when the value of the variable is changed. The function can modify the new value before it is saved.
 
 **Returns**:
 


### PR DESCRIPTION
one line of code was changed: it has to do with how parameters are detected in the `mkdocs` autobuilder. documentation was also rebuilt

## description of problem
the problem is caused by `builders/mkdocs.lua:217`, which reads:
```lua
local name, type = paramStr:match("([%w]+)[:]?[%s]?(.*)")
```
the pattern for getting the `name` of a function argument, i.e. `([%w]+)`, only matches alphanumeric characters. this currently causes a problem for functions with variadic arguments, as seen in the newly created [`table.map` documentation](https://mwse.github.io/MWSE/apis/table/#tablemap). 

without the changes introduced in this PR, the documentation generated for the `f` parameter of `table.map` is:
```lua
f (fun(k: unknown, v: unknown, nil))
```
when it should read 
```lua
f (fun(k: unknown, v: unknown, ...))
```

another problem is that the second pattern, `(.*)` can sometimes match the empty string when the ":" character is ommitted, as seen in the current documentation for [`table.bininsert`](https://mwse.github.io/MWSE/apis/table/#tablebininsert). 
here, the problem is that the documentation for `comp` is `fun(a: , b: ): boolean` when it should be `fun(a, b): boolean`.


## proposed solution

i replaced line 217 with 
```lua
local name, type = table.unpack(paramStr:split("%s?:%s?"))
```
this allows variadic arguments to be matched by `name` (as now anything is allowed before the colon). it also allows parameter types to be optional (as `string.split` will return a list containing only one element, the entire string, if nothing could be split).

i rebuilt the docs with this change, and both `table.map` and `table.bininsert` were generated correctly. a few other miscellaneous files also got corrected by this change