### PR TITLE
fixed documentation bug (in autobuilder and `autocomplete/definitions`)

### DIFF
--- a/autocomplete/builders/emmy.lua
+++ b/autocomplete/builders/emmy.lua
@@ -83,22 +83,21 @@ end
 
 --- @param types string[]
 local function insertNil(types)
-	local hasNil = false
-	for _, type in ipairs(types) do
+	for i, type in ipairs(types) do
 		if type == "nil" then
-			hasNil = true
-		elseif type:startswith("fun(") then
+			return
+		end
+		if type:startswith("fun(") then
 			-- If the type ends with "|fun(): someReturnType", don't append nil
 			-- at the end. That won't make the argument optional, but will
 			-- change the type of the function's return value
-			table.insert(types, #types, "nil")
-			hasNil = true
-			break
+			-- Instead, we'll insert `nil` right before `fun(...):...`, so that
+			-- the full type will look like `...|nil|fun(...):...|...`
+			table.insert(types, i, "nil")
+			return
 		end
 	end
-	if (not hasNil) then
-		table.insert(types, "nil")
-	end
+	table.insert(types, "nil")
 end
 
 local function getAllPossibleVariationsOfType(type, package)

--- a/autocomplete/definitions/namedTypes/mwseMCMSlider/convertToLabelValue/DistanceSlider.lua
+++ b/autocomplete/definitions/namedTypes/mwseMCMSlider/convertToLabelValue/DistanceSlider.lua
@@ -2,7 +2,7 @@ mwse.mcm.createSlider{
     parent = myPage,
     label = "My distance slider",
     variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-    convertToValueLabel = function(self, variableValue)
+    convertToLabelValue = function(self, variableValue)
         local feet = variableValue / 22.1
 	    local meters = 0.3048 * feet
         if self.decimalPlaces == 0 then

--- a/autocomplete/definitions/namedTypes/mwseMCMSlider/convertToLabelValue/SkillSlider.lua
+++ b/autocomplete/definitions/namedTypes/mwseMCMSlider/convertToLabelValue/SkillSlider.lua
@@ -2,7 +2,7 @@ mwse.mcm.createSlider{
     parent = myPage,
     label = "My skill slider",
     variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-    convertToValueLabel = function(self, variableValue)
+    convertToLabelValue = function(self, variableValue)
         local skillName = tes3.getSkillName(math.round(variableValue))
         if skillName then 
             return skillName

--- a/autocomplete/definitions/namedTypes/mwseMCMSlider/new.lua
+++ b/autocomplete/definitions/namedTypes/mwseMCMSlider/new.lua
@@ -23,6 +23,7 @@ return {
 			{ name = "childIndent", type = "integer", optional = true, description = "The left padding size in pixels. Used on all the child components." },
 			{ name = "paddingBottom", type = "integer", optional = true, default = 4, description = "The bottom border size in pixels. Only used if the `childSpacing` is unset on the parent component." },
 			{ name = "childSpacing", type = "integer", optional = true, description = "The bottom border size in pixels. Used on all the child components." },
+			{ name = "convertToLabelValue", type = "fun(self: mwseMCMSlider, variableValue: number): number|string", optional = true, description = "Define a custom formatting function for displaying variable values." },
 			{ name = "postCreate", type = "fun(self: mwseMCMSlider)", optional = true, description = "Can define a custom formatting function to make adjustments to any element saved in `self.elements`." },
 			{ name = "class", type = "string", optional = true },
 			{ name = "componentType", type = "string", optional = true },

--- a/docs/source/apis/mwse.mcm.md
+++ b/docs/source/apis/mwse.mcm.md
@@ -724,7 +724,7 @@ local slider = mwse.mcm.createSlider(parent, { label = ..., variable = ..., defa
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -754,7 +754,7 @@ local slider = mwse.mcm.createSlider(parent, { label = ..., variable = ..., defa
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName

--- a/docs/source/types/mwseMCMCategory.md
+++ b/docs/source/types/mwseMCMCategory.md
@@ -864,7 +864,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -894,7 +894,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName

--- a/docs/source/types/mwseMCMDecimalSlider.md
+++ b/docs/source/types/mwseMCMDecimalSlider.md
@@ -406,7 +406,7 @@ local labelValue = myObject:convertToLabelValue(variableValue)
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -436,7 +436,7 @@ local labelValue = myObject:convertToLabelValue(variableValue)
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName

--- a/docs/source/types/mwseMCMExclusionsPage.md
+++ b/docs/source/types/mwseMCMExclusionsPage.md
@@ -1055,7 +1055,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -1085,7 +1085,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName

--- a/docs/source/types/mwseMCMFilterPage.md
+++ b/docs/source/types/mwseMCMFilterPage.md
@@ -1016,7 +1016,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -1046,7 +1046,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName

--- a/docs/source/types/mwseMCMMouseOverPage.md
+++ b/docs/source/types/mwseMCMMouseOverPage.md
@@ -912,7 +912,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -942,7 +942,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName

--- a/docs/source/types/mwseMCMPage.md
+++ b/docs/source/types/mwseMCMPage.md
@@ -899,7 +899,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -929,7 +929,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName

--- a/docs/source/types/mwseMCMPercentageSlider.md
+++ b/docs/source/types/mwseMCMPercentageSlider.md
@@ -406,7 +406,7 @@ local labelValue = myObject:convertToLabelValue(variableValue)
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -436,7 +436,7 @@ local labelValue = myObject:convertToLabelValue(variableValue)
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName

--- a/docs/source/types/mwseMCMSideBarPage.md
+++ b/docs/source/types/mwseMCMSideBarPage.md
@@ -977,7 +977,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -1007,7 +1007,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName

--- a/docs/source/types/mwseMCMSideBySideBlock.md
+++ b/docs/source/types/mwseMCMSideBySideBlock.md
@@ -864,7 +864,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -894,7 +894,7 @@ local slider = myObject:createSlider({ label = ..., variable = ..., defaultSetti
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName

--- a/docs/source/types/mwseMCMSlider.md
+++ b/docs/source/types/mwseMCMSlider.md
@@ -406,7 +406,7 @@ local labelValue = myObject:convertToLabelValue(variableValue)
 	    parent = myPage,
 	    label = "My distance slider",
 	    variable = mwse.mcm.createTableVariable{id = "distance", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local feet = variableValue / 22.1
 		    local meters = 0.3048 * feet
 	        if self.decimalPlaces == 0 then
@@ -436,7 +436,7 @@ local labelValue = myObject:convertToLabelValue(variableValue)
 	    parent = myPage,
 	    label = "My skill slider",
 	    variable = mwse.mcm.createTableVariable{id = "skillId", config = myConfig},
-	    convertToValueLabel = function(self, variableValue)
+	    convertToLabelValue = function(self, variableValue)
 	        local skillName = tes3.getSkillName(math.round(variableValue))
 	        if skillName then 
 	            return skillName
@@ -697,7 +697,7 @@ myObject:makeComponent(parentBlock)
 Creates a new Slider.
 
 ```lua
-local slider = myObject:new({ label = ..., variable = ..., defaultSetting = ..., min = ..., max = ..., step = ..., jump = ..., decimalPlaces = ..., description = ..., callback = ..., inGameOnly = ..., restartRequired = ..., restartRequiredMessage = ..., indent = ..., childIndent = ..., paddingBottom = ..., childSpacing = ..., postCreate = ..., class = ..., componentType = ..., parentComponent = ... })
+local slider = myObject:new({ label = ..., variable = ..., defaultSetting = ..., min = ..., max = ..., step = ..., jump = ..., decimalPlaces = ..., description = ..., callback = ..., inGameOnly = ..., restartRequired = ..., restartRequiredMessage = ..., indent = ..., childIndent = ..., paddingBottom = ..., childSpacing = ..., convertToLabelValue = ..., postCreate = ..., class = ..., componentType = ..., parentComponent = ... })
 ```
 
 **Parameters**:
@@ -720,6 +720,7 @@ local slider = myObject:new({ label = ..., variable = ..., defaultSetting = ...,
 	* `childIndent` (integer): *Optional*. The left padding size in pixels. Used on all the child components.
 	* `paddingBottom` (integer): *Default*: `4`. The bottom border size in pixels. Only used if the `childSpacing` is unset on the parent component.
 	* `childSpacing` (integer): *Optional*. The bottom border size in pixels. Used on all the child components.
+	* `convertToLabelValue` (fun(self: [mwseMCMSlider](../types/mwseMCMSlider.md), variableValue: number): number, string): *Optional*. Define a custom formatting function for displaying variable values.
 	* `postCreate` (fun(self: [mwseMCMSlider](../types/mwseMCMSlider.md))): *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 	* `class` (string): *Optional*.
 	* `componentType` (string): *Optional*.

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseMCMCategory.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseMCMCategory.lua
@@ -233,7 +233,7 @@ function mwseMCMCategory:createCycleButton(data) end
 --- 
 --- `childSpacing`: integer? — *Optional*. The bottom border size in pixels. Used on all the child components.
 --- 
---- `convertToLabelValue`: fun(self: mwseMCMDecimalSlider, variableValue: number): number|nil|string — *Optional*. Define a custom formatting function for displaying variable values.
+--- `convertToLabelValue`: nil|fun(self: mwseMCMDecimalSlider, variableValue: number): number|string — *Optional*. Define a custom formatting function for displaying variable values.
 --- 
 --- `postCreate`: nil|fun(self: mwseMCMDecimalSlider) — *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 --- @return mwseMCMDecimalSlider slider No description yet available.
@@ -258,7 +258,7 @@ function mwseMCMCategory:createDecimalSlider(data) end
 --- @field childIndent integer? *Optional*. The left padding size in pixels. Used on all the child components.
 --- @field paddingBottom integer? *Default*: `4`. The bottom border size in pixels. Only used if the `childSpacing` is unset on the parent component.
 --- @field childSpacing integer? *Optional*. The bottom border size in pixels. Used on all the child components.
---- @field convertToLabelValue fun(self: mwseMCMDecimalSlider, variableValue: number): number|nil|string *Optional*. Define a custom formatting function for displaying variable values.
+--- @field convertToLabelValue nil|fun(self: mwseMCMDecimalSlider, variableValue: number): number|string *Optional*. Define a custom formatting function for displaying variable values.
 --- @field postCreate nil|fun(self: mwseMCMDecimalSlider) *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 
 --- Creates a new nested Dropdown.
@@ -642,7 +642,7 @@ function mwseMCMCategory:createParagraphField(data) end
 --- 
 --- `childSpacing`: integer? — *Optional*. The bottom border size in pixels. Used on all the child components.
 --- 
---- `convertToLabelValue`: fun(self: mwseMCMPercentageSlider, variableValue: number): number|nil|string — *Optional*. Define a custom formatting function for displaying variable values.
+--- `convertToLabelValue`: nil|fun(self: mwseMCMPercentageSlider, variableValue: number): number|string — *Optional*. Define a custom formatting function for displaying variable values.
 --- 
 --- `postCreate`: nil|fun(self: mwseMCMPercentageSlider) — *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 --- @return mwseMCMPercentageSlider slider No description yet available.
@@ -667,7 +667,7 @@ function mwseMCMCategory:createPercentageSlider(data) end
 --- @field childIndent integer? *Optional*. The left padding size in pixels. Used on all the child components.
 --- @field paddingBottom integer? *Default*: `4`. The bottom border size in pixels. Only used if the `childSpacing` is unset on the parent component.
 --- @field childSpacing integer? *Optional*. The bottom border size in pixels. Used on all the child components.
---- @field convertToLabelValue fun(self: mwseMCMPercentageSlider, variableValue: number): number|nil|string *Optional*. Define a custom formatting function for displaying variable values.
+--- @field convertToLabelValue nil|fun(self: mwseMCMPercentageSlider, variableValue: number): number|string *Optional*. Define a custom formatting function for displaying variable values.
 --- @field postCreate nil|fun(self: mwseMCMPercentageSlider) *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 
 --- Creates a new nested Side-by-side block.
@@ -744,7 +744,7 @@ function mwseMCMCategory:createSideBySideBlock(data) end
 --- 
 --- `childSpacing`: integer? — *Optional*. The bottom border size in pixels. Used on all the child components.
 --- 
---- `convertToLabelValue`: fun(self: mwseMCMSlider, variableValue: number): number|nil|string — *Optional*. Define a custom formatting function for displaying variable values.
+--- `convertToLabelValue`: nil|fun(self: mwseMCMSlider, variableValue: number): number|string — *Optional*. Define a custom formatting function for displaying variable values.
 --- 
 --- `postCreate`: nil|fun(self: mwseMCMSlider) — *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 --- @return mwseMCMDecimalSlider|mwseMCMPercentageSlider|mwseMCMSlider slider No description yet available.
@@ -769,7 +769,7 @@ function mwseMCMCategory:createSlider(data) end
 --- @field childIndent integer? *Optional*. The left padding size in pixels. Used on all the child components.
 --- @field paddingBottom integer? *Default*: `4`. The bottom border size in pixels. Only used if the `childSpacing` is unset on the parent component.
 --- @field childSpacing integer? *Optional*. The bottom border size in pixels. Used on all the child components.
---- @field convertToLabelValue fun(self: mwseMCMSlider, variableValue: number): number|nil|string *Optional*. Define a custom formatting function for displaying variable values.
+--- @field convertToLabelValue nil|fun(self: mwseMCMSlider, variableValue: number): number|string *Optional*. Define a custom formatting function for displaying variable values.
 --- @field postCreate nil|fun(self: mwseMCMSlider) *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 
 --- Creates UI element tree for all the given components by calling `component:create`.

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseMCMSlider.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseMCMSlider.lua
@@ -83,6 +83,8 @@ function mwseMCMSlider:makeComponent(parentBlock) end
 --- 
 --- `childSpacing`: integer? — *Optional*. The bottom border size in pixels. Used on all the child components.
 --- 
+--- `convertToLabelValue`: nil|fun(self: mwseMCMSlider, variableValue: number): number|string — *Optional*. Define a custom formatting function for displaying variable values.
+--- 
 --- `postCreate`: nil|fun(self: mwseMCMSlider) — *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 --- 
 --- `class`: string? — *Optional*. No description yet available.
@@ -112,6 +114,7 @@ function mwseMCMSlider:new(data) end
 --- @field childIndent integer? *Optional*. The left padding size in pixels. Used on all the child components.
 --- @field paddingBottom integer? *Default*: `4`. The bottom border size in pixels. Only used if the `childSpacing` is unset on the parent component.
 --- @field childSpacing integer? *Optional*. The bottom border size in pixels. Used on all the child components.
+--- @field convertToLabelValue nil|fun(self: mwseMCMSlider, variableValue: number): number|string *Optional*. Define a custom formatting function for displaying variable values.
 --- @field postCreate nil|fun(self: mwseMCMSlider) *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 --- @field class string? *Optional*. No description yet available.
 --- @field componentType string? *Optional*. No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/lib/mwse/mcm.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mwse/mcm.lua
@@ -300,7 +300,7 @@ function mwse.mcm.createCycleButton(parent, data) end
 --- 
 --- `childSpacing`: integer? — *Optional*. The bottom border size in pixels. Used on all the child components.
 --- 
---- `convertToLabelValue`: fun(self: mwseMCMDecimalSlider, variableValue: number): number|nil|string — *Optional*. Define a custom formatting function for displaying variable values.
+--- `convertToLabelValue`: nil|fun(self: mwseMCMDecimalSlider, variableValue: number): number|string — *Optional*. Define a custom formatting function for displaying variable values.
 --- 
 --- `postCreate`: nil|fun(self: mwseMCMDecimalSlider) — *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 --- @return mwseMCMDecimalSlider slider No description yet available.
@@ -325,7 +325,7 @@ function mwse.mcm.createDecimalSlider(parent, data) end
 --- @field childIndent integer? *Optional*. The left padding size in pixels. Used on all the child components.
 --- @field paddingBottom integer? *Default*: `4`. The bottom border size in pixels. Only used if the `childSpacing` is unset on the parent component.
 --- @field childSpacing integer? *Optional*. The bottom border size in pixels. Used on all the child components.
---- @field convertToLabelValue fun(self: mwseMCMDecimalSlider, variableValue: number): number|nil|string *Optional*. Define a custom formatting function for displaying variable values.
+--- @field convertToLabelValue nil|fun(self: mwseMCMDecimalSlider, variableValue: number): number|string *Optional*. Define a custom formatting function for displaying variable values.
 --- @field postCreate nil|fun(self: mwseMCMDecimalSlider) *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 
 --- Creates a new Dropdown inside given `parent` menu.
@@ -825,7 +825,7 @@ function mwse.mcm.createParagraphField(parent, data) end
 --- 
 --- `childSpacing`: integer? — *Optional*. The bottom border size in pixels. Used on all the child components.
 --- 
---- `convertToLabelValue`: fun(self: mwseMCMPercentageSlider, variableValue: number): number|nil|string — *Optional*. Define a custom formatting function for displaying variable values.
+--- `convertToLabelValue`: nil|fun(self: mwseMCMPercentageSlider, variableValue: number): number|string — *Optional*. Define a custom formatting function for displaying variable values.
 --- 
 --- `postCreate`: nil|fun(self: mwseMCMPercentageSlider) — *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 --- @return mwseMCMPercentageSlider slider No description yet available.
@@ -850,7 +850,7 @@ function mwse.mcm.createPercentageSlider(parent, data) end
 --- @field childIndent integer? *Optional*. The left padding size in pixels. Used on all the child components.
 --- @field paddingBottom integer? *Default*: `4`. The bottom border size in pixels. Only used if the `childSpacing` is unset on the parent component.
 --- @field childSpacing integer? *Optional*. The bottom border size in pixels. Used on all the child components.
---- @field convertToLabelValue fun(self: mwseMCMPercentageSlider, variableValue: number): number|nil|string *Optional*. Define a custom formatting function for displaying variable values.
+--- @field convertToLabelValue nil|fun(self: mwseMCMPercentageSlider, variableValue: number): number|string *Optional*. Define a custom formatting function for displaying variable values.
 --- @field postCreate nil|fun(self: mwseMCMPercentageSlider) *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 
 --- Creates a new PlayerData variable.
@@ -929,7 +929,7 @@ function mwse.mcm.createPlayerData(variable) end
 --- 
 --- `childSpacing`: integer? — *Optional*. The bottom border size in pixels. Used on all the child components.
 --- 
---- `convertToLabelValue`: fun(self: mwseMCMSlider, variableValue: number): number|nil|string — *Optional*. Define a custom formatting function for displaying variable values.
+--- `convertToLabelValue`: nil|fun(self: mwseMCMSlider, variableValue: number): number|string — *Optional*. Define a custom formatting function for displaying variable values.
 --- 
 --- `postCreate`: nil|fun(self: mwseMCMSlider) — *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 --- @return mwseMCMDecimalSlider|mwseMCMPercentageSlider|mwseMCMSlider slider No description yet available.
@@ -954,7 +954,7 @@ function mwse.mcm.createSlider(parent, data) end
 --- @field childIndent integer? *Optional*. The left padding size in pixels. Used on all the child components.
 --- @field paddingBottom integer? *Default*: `4`. The bottom border size in pixels. Only used if the `childSpacing` is unset on the parent component.
 --- @field childSpacing integer? *Optional*. The bottom border size in pixels. Used on all the child components.
---- @field convertToLabelValue fun(self: mwseMCMSlider, variableValue: number): number|nil|string *Optional*. Define a custom formatting function for displaying variable values.
+--- @field convertToLabelValue nil|fun(self: mwseMCMSlider, variableValue: number): number|string *Optional*. Define a custom formatting function for displaying variable values.
 --- @field postCreate nil|fun(self: mwseMCMSlider) *Optional*. Can define a custom formatting function to make adjustments to any element saved in `self.elements`.
 
 --- Creates a new TableVariable.


### PR DESCRIPTION
this PR fixes two bugs:
the first is pretty minor: there was a typo in the examples for `convertToLabelValue`. i wrote `convertToValueLabel` instead of `convertToLabelValue`. 😞 

the second is a bit more involved: the `emmy.lua` autobuilder was not properly handling optional parameters that are functions. i first noticed this problem with `convertToLabelValue`, since it has `optional = true`, but the generated `meta` file does not list the parameter as optional. the problem is that the type for `convertToLabelValue` is getting generated as
```lua
fun(self: mwseMCMDecimalSlider, variableValue: number): number|nil|string
```
when it should be 
```lua
nil|fun(self: mwseMCMDecimalSlider, variableValue: number): number|string
```

(i.e., the `nil` is getting added to the return value of the function, rather than to the parameter itself.) i fixed this bug by editing `emmy.lua`, changing

```lua
table.insert(types, #types, "nil")
```
to
```lua
table.insert(types, i, "nil")
```
(where `i` is the index where a function first appears.)
i documented the reasoning a bit more in the code


i think a more ideal solution would be to wrap the function in parentheses if it isn't the last type that's allowed, e.g.
```lua
(fun(self: mwseMCMDecimalSlider, variableValue: number): number|string)|nil
```
since this would also protect against cases where something other than `nil` gets added after a function type.
but i wasn't quite sure how to do this, and i don't think any currently defined mwse-lua functions would benefit from this change.
although, it might be good to keep an eye out for this, since it may come up in the future.
