### PR TITLE
fixed `load-priority` documentation bug

### DIFF
--- a/docs/source/guides/metadata.md
+++ b/docs/source/guides/metadata.md
@@ -55,14 +55,14 @@ The following fields are available:
     The following fields are available:
 
     * `lua-mod` - The path to the main.lua associated with this mod. For example, if your main.lua file is located in `"Data Files\MWSE\mods\g7\myMod\main.lua"`, then this field should be set to `"g7.myMod"`.
-    * `load-order` - The priority for when this mod is loaded. Lower numbers are loaded first.
+    * `load-priority` - The priority for when this mod is loaded. Lower numbers are loaded first.
     * `wait-until-initialize` - Whether to wait until the game has initialized before loading this mod.
 
     Example:
     ```toml
         [tools.mwse]
         lua-mod = "mer.myMod"
-        load-order = 100
+        load-priority = 100
         wait-until-initialize = true
     ```
 
@@ -239,7 +239,7 @@ version = "7.8.9"
 # MWSE specific information about this mod
 [tools.mwse]
 lua-mod = "mer.myMod"
-load-order = 100
+load-priority = 100
 wait-until-initialized = true
 
 # Dependencies are checked on `initialized` and warn the player if any are missing

--- a/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyManager.lua
+++ b/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyManager.lua
@@ -11,7 +11,7 @@ local util = require("dependencyManagement.util")
 
 ---@class MWSE.Metadata.Tools.MWSE
 ---@field lua-mod string The path to the main.lua associated with this mod
----@field load-order number The priority for when this mod is loaded. Lower numbers are loaded first.
+---@field load-priority number The priority for when this mod is loaded. Lower numbers are loaded first.
 ---@field wait-until-initialize boolean Whether to wait until the game has initialized before loading this mod.
 
 ---@class MWSE.Metadata.Tools


### PR DESCRIPTION
this is my attempt to fix a documentation bug that NullCascade mentioned on discord a week or so ago.

the metadata guide says to use `load-order`, but the `startLuaMods.lua` file only cares about a `load-priority` key. i updated the documentation to reflect this.