### PR TITLE
minor documentation changes

### DIFF
--- a/autocomplete/definitions/global/json/decode.lua
+++ b/autocomplete/definitions/global/json/decode.lua
@@ -2,8 +2,8 @@ return {
 	type = "function",
 	description = [[Decode string into a table.
 
-!!! warning "json does not support `integer` indices"
-	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+!!! warning "json does not support `number` indices"
+	As a result, the `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
 	You should be mindful of this when using this function.
 ]],
 	link = "http://dkolf.de/src/dkjson-lua.fsl/wiki?name=Documentation",

--- a/autocomplete/definitions/global/json/decode.lua
+++ b/autocomplete/definitions/global/json/decode.lua
@@ -2,9 +2,8 @@ return {
 	type = "function",
 	description = [[Decode string into a table.
 
-!!! warning "json does not support `number` indices"
-	As a result, the `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
-	You should be mindful of this when using this function.
+!!! warning "json does not support mixed `string` and `number` indices"
+	If the encoded table had any `string` indices, then the `table` returned by this function will have no `number` indices. For example, `[1]` could have been converted to `["1"]` in the encoding process.
 ]],
 	link = "http://dkolf.de/src/dkjson-lua.fsl/wiki?name=Documentation",
 	arguments = {

--- a/autocomplete/definitions/global/json/decode.lua
+++ b/autocomplete/definitions/global/json/decode.lua
@@ -2,8 +2,9 @@ return {
 	type = "function",
 	description = [[Decode string into a table.
 
-!!! warning
-	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+!!! warning "json does not support `integer` indices"
+	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+	You should be mindful of this when using this function.
 ]],
 	link = "http://dkolf.de/src/dkjson-lua.fsl/wiki?name=Documentation",
 	arguments = {

--- a/autocomplete/definitions/global/json/encode.lua
+++ b/autocomplete/definitions/global/json/encode.lua
@@ -1,9 +1,9 @@
 return {
 	type = "function",
-	description = [[Create a string representing the object. Object can be a table, a string, a number, a boolean, nil, json.null or any object with a function __tojson in its metatable. A table can only use strings and numbers as keys and its values have to be valid objects as well. It raises an error for any invalid data types or reference cycles.
+	description = [[Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data struture that contains reference cycles.
 
-!!! warning
-	If the table being encoded has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading json files.
+!!! warning "json does not support `integer` indices"
+	This function will convert all `integer` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
 ]],
 	link = "http://dkolf.de/src/dkjson-lua.fsl/wiki?name=Documentation",
 	arguments = {

--- a/autocomplete/definitions/global/json/encode.lua
+++ b/autocomplete/definitions/global/json/encode.lua
@@ -2,8 +2,8 @@ return {
 	type = "function",
 	description = [[Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data struture that contains reference cycles.
 
-!!! warning "json does not support `integer` indices"
-	This function will convert all `integer` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
+!!! warning "json does not support `number` indices"
+	This function will convert all `number` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
 ]],
 	link = "http://dkolf.de/src/dkjson-lua.fsl/wiki?name=Documentation",
 	arguments = {

--- a/autocomplete/definitions/global/json/encode.lua
+++ b/autocomplete/definitions/global/json/encode.lua
@@ -3,7 +3,7 @@ return {
 	description = [[Create a string representing the object. Object can be a table, a string, a number, a boolean, nil, json.null or any object with a function __tojson in its metatable. A table can only use strings and numbers as keys and its values have to be valid objects as well. It raises an error for any invalid data types or reference cycles.
 
 !!! warning
-	If the table you are encoding as json has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+	If the table being encoded has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading json files.
 ]],
 	link = "http://dkolf.de/src/dkjson-lua.fsl/wiki?name=Documentation",
 	arguments = {

--- a/autocomplete/definitions/global/json/encode.lua
+++ b/autocomplete/definitions/global/json/encode.lua
@@ -1,9 +1,9 @@
 return {
 	type = "function",
-	description = [[Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data struture that contains reference cycles.
+	description = [[Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data structure that contains reference cycles.
 
-!!! warning "json does not support `number` indices"
-	This function will convert all `number` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
+!!! warning "json does not support mixed `string` and `number` indices"
+	If the encoded table has any `string` indices, then this function will convert all `number` indices to `string` indices. For example, `[1]` could be converted to `["1"]`. This should be taken into account when loading/decoding json files.
 ]],
 	link = "http://dkolf.de/src/dkjson-lua.fsl/wiki?name=Documentation",
 	arguments = {

--- a/autocomplete/definitions/global/json/loadfile.lua
+++ b/autocomplete/definitions/global/json/loadfile.lua
@@ -1,9 +1,9 @@
 return {
 	type = "function",
-	description = [[Loads the contents of a file through json.decode. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
+	description = [[Loads the contents of a file through `json.decode`. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
 
-!!! warning "json does not support `integer` indices"
-	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+!!! warning "json does not support `number` indices"
+	The `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
 	You should be mindful of this when using this function.
 	If you're using this to load a configuration file for your mod, it's recommended you use [`mwse.loadConfig`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 ]],

--- a/autocomplete/definitions/global/json/loadfile.lua
+++ b/autocomplete/definitions/global/json/loadfile.lua
@@ -1,10 +1,11 @@
 return {
 	type = "function",
-	description = [[Loads the contents of a file through json.decode. Files loaded from Data Files\\MWSE\\{fileName}.json.
+	description = [[Loads the contents of a file through json.decode. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
 
-!!! warning
-	All of the keys in the `table` returned by function will be `string`s. For example, if you're decoding an array-style table, then the first entry will be `["1"]` instead of `[1]`.
-	If you're using this function to load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
+!!! warning "json does not support `integer` indices"
+	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+	You should be mindful of this when using this function.
+	If you're using this to load a configuration file for your mod, it's recommended you use [`mwse.loadConfig`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 ]],
 	arguments = {
 		{ name = "fileName", type = "string" },

--- a/autocomplete/definitions/global/json/loadfile.lua
+++ b/autocomplete/definitions/global/json/loadfile.lua
@@ -2,9 +2,8 @@ return {
 	type = "function",
 	description = [[Loads the contents of a file through `json.decode`. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
 
-!!! warning "json does not support `number` indices"
-	The `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
-	You should be mindful of this when using this function.
+!!! warning "json does not support mixed `string` and `number` indices"
+	If the encoded table had any `string` indices, then the `table` returned by this function will have no `number` indices. For example, `[1]` could have been converted to `["1"]` in the encoding process.
 	If you're using this to load a configuration file for your mod, it's recommended you use [`mwse.loadConfig`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 ]],
 	arguments = {

--- a/autocomplete/definitions/global/json/loadfile.lua
+++ b/autocomplete/definitions/global/json/loadfile.lua
@@ -3,7 +3,8 @@ return {
 	description = [[Loads the contents of a file through json.decode. Files loaded from Data Files\\MWSE\\{fileName}.json.
 
 !!! warning
-	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered. If you need to save and load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) as that function will do this for you.
+	All of the keys in the `table` returned by function will be `string`s. For example, if you're decoding an array-style table, then the first entry will be `["1"]` instead of `[1]`.
+	If you're using this function to load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 ]],
 	arguments = {
 		{ name = "fileName", type = "string" },

--- a/autocomplete/definitions/global/json/savefile.lua
+++ b/autocomplete/definitions/global/json/savefile.lua
@@ -1,6 +1,6 @@
 return {
 	type = "function",
-	description = [[Saves a serializable table to Data Files\\MWSE\\{fileName}.json, using json.encode.]],
+	description = [[Saves a serializable table to Data Files\\MWSE\\{`fileName`}.json, using `json.encode`.]],
 	arguments = {
 		{ name = "fileName", type = "string" },
 		{ name = "object", type = "table" },

--- a/autocomplete/definitions/global/mwse/saveConfig.lua
+++ b/autocomplete/definitions/global/mwse/saveConfig.lua
@@ -4,6 +4,6 @@ return {
 	arguments = {
 		{ name = "fileName", type = "string", description = "Usually named after your mod." },
 		{ name = "config", type = "table", description = "The config table to save." },
-		{ name = "jsonOptions", type = "table", optional = true, description = "Used to optionally pass encoding options to the dkjson encoder." },
+		{ name = "jsonOptions", type = "table", optional = true, description = "Encoding options. These get passed to the `dkjson` encoder." },
 	},
 }

--- a/autocomplete/definitions/global/string/split.lua
+++ b/autocomplete/definitions/global/string/split.lua
@@ -2,7 +2,12 @@ return {
 	type = "function",
 	description = [[Returns an array-style table with a `string` split by a specified separator.
 The seperator is not part of the results. 
-By default the `sep == "%s"`, which will result in `str` getting split by whitespace characters (e.g. spaces and tabs).]],
+By default the `sep == "%s"`, which will result in `str` getting split by whitespace characters (e.g. spaces and tabs).
+
+!!! warning 
+	if `sep` is more than one character, then `str` will get split at each occurrence of any of the individual characters in `sep`.
+	For example, `string.split("1a2b3c4abc5", "abc")` will return `{"1", "2", "3", "4", "5"}` instead of `{"1a2b3c4", "5"}`.
+]],
 	arguments = {
 		{ name = "str", type = "string", description = "The string to split." },
 		{ name = "sep", type = "string", optional = true, default = [["%s"]], description = "The token to split the string by." },

--- a/autocomplete/definitions/global/table/filter.lua
+++ b/autocomplete/definitions/global/table/filter.lua
@@ -8,7 +8,7 @@ Any additional arguments will be passed to `f`. For example, `table.filter(t, f,
 ]],
 	arguments = {
 		{ name = "t", type = "table" },
-		{ name = "f", type = "fun(k: unknown, v: unknown, ...)", "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
+		{ name = "f", type = "fun(k: unknown, v: unknown, ...): boolean|unknown", "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
 		{ name = "...", type = "any", description = "Additional parameters to pass to `f`." },
 	},
 	returns = {

--- a/autocomplete/definitions/global/table/filter.lua
+++ b/autocomplete/definitions/global/table/filter.lua
@@ -8,7 +8,7 @@ Any additional arguments will be passed to `f`. For example, `table.filter(t, f,
 ]],
 	arguments = {
 		{ name = "t", type = "table" },
-		{ name = "f", type = "fun(k: unknown, v: unknown, ...): boolean|unknown", "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
+		{ name = "f", type = "fun(k: unknown, v: unknown, ...): boolean", "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
 		{ name = "...", type = "any", description = "Additional parameters to pass to `f`." },
 	},
 	returns = {

--- a/autocomplete/definitions/global/table/filterarray.lua
+++ b/autocomplete/definitions/global/table/filterarray.lua
@@ -7,7 +7,7 @@ Any additional arguments will be passed to `f`. For example, `table.filterarray(
 When an element gets filtered out, the index of subsequent items will be shifted down, so that the resulting table plays nicely with the `#` operator and the `ipairs` function.]],
 	arguments = {
 		{ name = "arr", type = "table" },
-		{ name = "f", type = "fun(i: integer, v: unknown, ...)", "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
+		{ name = "f", type = "fun(i: integer, v: unknown, ...): boolean|unknown", "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
 		{ name = "...", type = "any", description = "Additional parameters to pass to `f`." },
 	},
 	returns = {

--- a/autocomplete/definitions/global/table/filterarray.lua
+++ b/autocomplete/definitions/global/table/filterarray.lua
@@ -7,7 +7,7 @@ Any additional arguments will be passed to `f`. For example, `table.filterarray(
 When an element gets filtered out, the index of subsequent items will be shifted down, so that the resulting table plays nicely with the `#` operator and the `ipairs` function.]],
 	arguments = {
 		{ name = "arr", type = "table" },
-		{ name = "f", type = "fun(i: integer, v: unknown, ...): boolean|unknown", "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
+		{ name = "f", type = "fun(i: integer, v: unknown, ...): boolean", "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
 		{ name = "...", type = "any", description = "Additional parameters to pass to `f`." },
 	},
 	returns = {

--- a/autocomplete/definitions/global/table/map.lua
+++ b/autocomplete/definitions/global/table/map.lua
@@ -4,7 +4,7 @@ return {
 Any additional arguments will be passed to `f`. For example, `table.map(t, f, 10)` would call `f(k, v, 10)` on each value `v` of `t`.]],
 	arguments = {
 		{ name = "t", type = "table" },
-		{ name = "f", type = "fun(k: unknown, v: unknown, ...)", "The function to apply to each element of `t`." },
+		{ name = "f", type = "fun(k: unknown, v: unknown, ...): unknown", "The function to apply to each element of `t`." },
 		{ name = "...", type = "any", description = "Additional parameters to pass to `f`." },
 	},
 	returns = {

--- a/autocomplete/definitions/global/tes3/addSoulGem.lua
+++ b/autocomplete/definitions/global/tes3/addSoulGem.lua
@@ -10,7 +10,7 @@ return {
 	}},
 	examples = {
 		["customSoulGem"] = {
-			title = "Make the Dwemer Tube a Soul gem. Also, make sure Fargoth's soul alway ends up in it if the player has one avilable.",
+			title = "Make Dwemer Tubes be treated as Soul gems. Also, make sure Fargoth's soul always ends up in one if the player has one avilable.",
 		}
 	},
 	returns = {{ name = "wasAdded", type = "boolean" }},

--- a/autocomplete/definitions/global/tes3/getLuaModMetadata.lua
+++ b/autocomplete/definitions/global/tes3/getLuaModMetadata.lua
@@ -1,10 +1,11 @@
 return {
 	type = "function",
-	description = [[Fetches the contents of the [metadata file](https://mwse.github.io/MWSE/guides/metadata/) associated with a given lua mod key.]],
+	description = [[Fetches the contents of the [metadata file](https://mwse.github.io/MWSE/guides/metadata/) associated with a given lua mod key.
+The mod key should match the value of `lua-mod` specified in the `[tools.mwse]` section of the relevant metadata file.]],
 	arguments = {
 		{ name = "modKey", type = "string", description = "The key for the lua mod, which must match the file location and the metadata file's `[tools.mwse]` contents." },
 	},
 	returns = {
-		{ name = "metadata",type = "table|nil" },
+		{ name = "metadata", type = "MWSE.Metadata|nil" },
 	}
 }

--- a/autocomplete/definitions/global/tes3/payMerchant.lua
+++ b/autocomplete/definitions/global/tes3/payMerchant.lua
@@ -1,17 +1,19 @@
 return {
 	type = "function",
-	description = [[Pays a merchant gold. The money is transferred to their barter gold (non-inventory trading gold), and also updates the last barter timer, so that it works the same way a transaction affeects the barter gold reset cycle. This is useful for simulating paying for services. The function will return true if there was enough gold to complete the payment.
+	description = [[Pays a merchant a specified amount of gold and updates the merchant's "last barter timer". This should be used to simulate paying for services. You may also want to play a trade-related sound of your choice upon successful completion.
 
-A negative cost will allow payment from the merchant's barter gold to the player. You may also want to play a trade-related sound of your choice upon successful completion.]],
+If `cost` is positive, then that amount of gold will be removed from the player's inventory and added to the merchant's available barter gold.
+
+If `cost` is negative, then that amount of gold will be added to the player's inventory and removed from the merchant's available barter gold.]],
 	arguments = {{
 		name = "params",
 		type = "table",
 		tableParams = {
 			{ name = "merchant", type = "tes3mobileActor", description = "The merchant to pay." },
-			{ name = "cost", type = "number", description = "The amount of gold to transfer to the merchant. May be negative to transfer gold to the player." },
+			{ name = "cost", type = "number", description = "The amount of gold to pay the merchant. If negative, the merchant will pay the player." },
 		},
 	}},
 	returns = {
-		{ name = "success", type = "boolean", description = "True if the transaction completed. False if there was not enough gold." },
+		{ name = "success", type = "boolean", description = "`true` if the transaction completed. `false` if there was not enough gold." },
 	},
 }

--- a/docs/source/apis/json.md
+++ b/docs/source/apis/json.md
@@ -39,9 +39,8 @@ Current version of dkjson.
 
 Decode string into a table.
 
-!!! warning "json does not support `number` indices"
-	As a result, the `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
-	You should be mindful of this when using this function.
+!!! warning "json does not support mixed `string` and `number` indices"
+	If the encoded table had any `string` indices, then the `table` returned by this function will have no `number` indices. For example, `[1]` could have been converted to `["1"]` in the encoding process.
 
 
 ```lua
@@ -63,10 +62,10 @@ local result = json.decode(s, position, nullValue)
 ### `json.encode`
 <div class="search_terms" style="display: none">encode</div>
 
-Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data struture that contains reference cycles.
+Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data structure that contains reference cycles.
 
-!!! warning "json does not support `number` indices"
-	This function will convert all `number` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
+!!! warning "json does not support mixed `string` and `number` indices"
+	If the encoded table has any `string` indices, then this function will convert all `number` indices to `string` indices. For example, `[1]` could be converted to `["1"]`. This should be taken into account when loading/decoding json files.
 
 
 ```lua
@@ -89,9 +88,8 @@ local result = json.encode(object, state)
 
 Loads the contents of a file through `json.decode`. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
 
-!!! warning "json does not support `number` indices"
-	The `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
-	You should be mindful of this when using this function.
+!!! warning "json does not support mixed `string` and `number` indices"
+	If the encoded table had any `string` indices, then the `table` returned by this function will have no `number` indices. For example, `[1]` could have been converted to `["1"]` in the encoding process.
 	If you're using this to load a configuration file for your mod, it's recommended you use [`mwse.loadConfig`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 
 

--- a/docs/source/apis/json.md
+++ b/docs/source/apis/json.md
@@ -39,8 +39,9 @@ Current version of dkjson.
 
 Decode string into a table.
 
-!!! warning
-	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+!!! warning "json does not support `integer` indices"
+	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+	You should be mindful of this when using this function.
 
 
 ```lua
@@ -62,10 +63,10 @@ local result = json.decode(s, position, nullValue)
 ### `json.encode`
 <div class="search_terms" style="display: none">encode</div>
 
-Create a string representing the object. Object can be a table, a string, a number, a boolean, nil, json.null or any object with a function __tojson in its metatable. A table can only use strings and numbers as keys and its values have to be valid objects as well. It raises an error for any invalid data types or reference cycles.
+Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data struture that contains reference cycles.
 
-!!! warning
-	If the table being encoded has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading json files.
+!!! warning "json does not support `integer` indices"
+	This function will convert all `integer` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
 
 
 ```lua
@@ -86,11 +87,12 @@ local result = json.encode(object, state)
 ### `json.loadfile`
 <div class="search_terms" style="display: none">loadfile</div>
 
-Loads the contents of a file through json.decode. Files loaded from Data Files\\MWSE\\{fileName}.json.
+Loads the contents of a file through json.decode. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
 
-!!! warning
-	All of the keys in the `table` returned by function will be `string`s. For example, if you're decoding an array-style table, then the first entry will be `["1"]` instead of `[1]`.
-	If you're using this function to load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
+!!! warning "json does not support `integer` indices"
+	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+	You should be mindful of this when using this function.
+	If you're using this to load a configuration file for your mod, it's recommended you use [`mwse.loadConfig`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 
 
 ```lua

--- a/docs/source/apis/json.md
+++ b/docs/source/apis/json.md
@@ -65,7 +65,7 @@ local result = json.decode(s, position, nullValue)
 Create a string representing the object. Object can be a table, a string, a number, a boolean, nil, json.null or any object with a function __tojson in its metatable. A table can only use strings and numbers as keys and its values have to be valid objects as well. It raises an error for any invalid data types or reference cycles.
 
 !!! warning
-	If the table you are encoding as json has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+	If the table being encoded has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading json files.
 
 
 ```lua
@@ -89,7 +89,8 @@ local result = json.encode(object, state)
 Loads the contents of a file through json.decode. Files loaded from Data Files\\MWSE\\{fileName}.json.
 
 !!! warning
-	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered. If you need to save and load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) as that function will do this for you.
+	All of the keys in the `table` returned by function will be `string`s. For example, if you're decoding an array-style table, then the first entry will be `["1"]` instead of `[1]`.
+	If you're using this function to load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 
 
 ```lua

--- a/docs/source/apis/json.md
+++ b/docs/source/apis/json.md
@@ -39,8 +39,8 @@ Current version of dkjson.
 
 Decode string into a table.
 
-!!! warning "json does not support `integer` indices"
-	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+!!! warning "json does not support `number` indices"
+	As a result, the `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
 	You should be mindful of this when using this function.
 
 
@@ -65,8 +65,8 @@ local result = json.decode(s, position, nullValue)
 
 Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data struture that contains reference cycles.
 
-!!! warning "json does not support `integer` indices"
-	This function will convert all `integer` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
+!!! warning "json does not support `number` indices"
+	This function will convert all `number` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
 
 
 ```lua
@@ -87,10 +87,10 @@ local result = json.encode(object, state)
 ### `json.loadfile`
 <div class="search_terms" style="display: none">loadfile</div>
 
-Loads the contents of a file through json.decode. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
+Loads the contents of a file through `json.decode`. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
 
-!!! warning "json does not support `integer` indices"
-	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+!!! warning "json does not support `number` indices"
+	The `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
 	You should be mindful of this when using this function.
 	If you're using this to load a configuration file for your mod, it's recommended you use [`mwse.loadConfig`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 
@@ -131,7 +131,7 @@ local result = json.quotestring(s)
 ### `json.savefile`
 <div class="search_terms" style="display: none">savefile</div>
 
-Saves a serializable table to Data Files\\MWSE\\{fileName}.json, using json.encode.
+Saves a serializable table to Data Files\\MWSE\\{`fileName`}.json, using `json.encode`.
 
 ```lua
 json.savefile(fileName, object, config)

--- a/docs/source/apis/mwse.md
+++ b/docs/source/apis/mwse.md
@@ -356,7 +356,7 @@ mwse.saveConfig(fileName, config, jsonOptions)
 
 * `fileName` (string): Usually named after your mod.
 * `config` (table): The config table to save.
-* `jsonOptions` (table): *Optional*. Used to optionally pass encoding options to the dkjson encoder.
+* `jsonOptions` (table): *Optional*. Encoding options. These get passed to the `dkjson` encoder.
 
 ***
 

--- a/docs/source/apis/string.md
+++ b/docs/source/apis/string.md
@@ -133,6 +133,11 @@ Returns an array-style table with a `string` split by a specified separator.
 The seperator is not part of the results. 
 By default the `sep == "%s"`, which will result in `str` getting split by whitespace characters (e.g. spaces and tabs).
 
+!!! warning 
+	if `sep` is more than one character, then `str` will get split at each occurrence of any of the individual characters in `sep`.
+	For example, `string.split("1a2b3c4abc5", "abc")` will return `{"1", "2", "3", "4", "5"}` instead of `{"1a2b3c4", "5"}`.
+
+
 ```lua
 local split = string.split(str, sep)
 ```

--- a/docs/source/apis/table.md
+++ b/docs/source/apis/table.md
@@ -205,7 +205,7 @@ local result = table.filter(t, f, ...)
 **Parameters**:
 
 * `t` (table)
-* `f` (fun(k: unknown, v: unknown, ...))
+* `f` (fun(k: unknown, v: unknown, ...): boolean, unknown)
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:
@@ -230,7 +230,7 @@ local result = table.filterarray(arr, f, ...)
 **Parameters**:
 
 * `arr` (table)
-* `f` (fun(i: integer, v: unknown, ...))
+* `f` (fun(i: integer, v: unknown, ...): boolean, unknown)
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:
@@ -353,7 +353,7 @@ local result = table.map(t, f, ...)
 **Parameters**:
 
 * `t` (table)
-* `f` (fun(k: unknown, v: unknown, ...))
+* `f` (fun(k: unknown, v: unknown, ...): unknown)
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:

--- a/docs/source/apis/table.md
+++ b/docs/source/apis/table.md
@@ -205,7 +205,7 @@ local result = table.filter(t, f, ...)
 **Parameters**:
 
 * `t` (table)
-* `f` (fun(k: unknown, v: unknown, ...): boolean, unknown)
+* `f` (fun(k: unknown, v: unknown, ...): boolean)
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:
@@ -230,7 +230,7 @@ local result = table.filterarray(arr, f, ...)
 **Parameters**:
 
 * `arr` (table)
-* `f` (fun(i: integer, v: unknown, ...): boolean, unknown)
+* `f` (fun(i: integer, v: unknown, ...): boolean)
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:

--- a/docs/source/apis/tes3.md
+++ b/docs/source/apis/tes3.md
@@ -3609,9 +3609,11 @@ local onMainMenu = tes3.onMainMenu()
 ### `tes3.payMerchant`
 <div class="search_terms" style="display: none">paymerchant</div>
 
-Pays a merchant gold. The money is transferred to their barter gold (non-inventory trading gold), and also updates the last barter timer, so that it works the same way a transaction affeects the barter gold reset cycle. This is useful for simulating paying for services. The function will return true if there was enough gold to complete the payment.
+Pays a merchant a specified amount of gold and updates the merchant's "last barter timer". This should be used to simulate paying for services. You may also want to play a trade-related sound of your choice upon successful completion.
 
-A negative cost will allow payment from the merchant's barter gold to the player. You may also want to play a trade-related sound of your choice upon successful completion.
+If `cost` is positive, then that amount of gold will be removed from the player's inventory and added to the merchant's available barter gold.
+
+If `cost` is negative, then that amount of gold will be added to the player's inventory and removed from the merchant's available barter gold.
 
 ```lua
 local success = tes3.payMerchant({ merchant = ..., cost = ... })
@@ -3621,11 +3623,11 @@ local success = tes3.payMerchant({ merchant = ..., cost = ... })
 
 * `params` (table)
 	* `merchant` ([tes3mobileActor](../types/tes3mobileActor.md)): The merchant to pay.
-	* `cost` (number): The amount of gold to transfer to the merchant. May be negative to transfer gold to the player.
+	* `cost` (number): The amount of gold to pay the merchant. If negative, the merchant will pay the player.
 
 **Returns**:
 
-* `success` (boolean): True if the transaction completed. False if there was not enough gold.
+* `success` (boolean): `true` if the transaction completed. `false` if there was not enough gold.
 
 ***
 

--- a/docs/source/apis/tes3.md
+++ b/docs/source/apis/tes3.md
@@ -449,7 +449,7 @@ local wasAdded = tes3.addSoulGem({ item = ... })
 
 * `wasAdded` (boolean)
 
-??? example "Example: Make the Dwemer Tube a Soul gem. Also, make sure Fargoth's soul alway ends up in it if the player has one avilable."
+??? example "Example: Make Dwemer Tubes be treated as Soul gems. Also, make sure Fargoth's soul always ends up in one if the player has one avilable."
 
 	```lua
 	local function onInitialized()
@@ -2329,6 +2329,7 @@ local level = tes3.getLockLevel({ reference = ... })
 <div class="search_terms" style="display: none">getluamodmetadata, luamodmetadata</div>
 
 Fetches the contents of the [metadata file](https://mwse.github.io/MWSE/guides/metadata/) associated with a given lua mod key.
+The mod key should match the value of `lua-mod` specified in the `[tools.mwse]` section of the relevant metadata file.
 
 ```lua
 local metadata = tes3.getLuaModMetadata(modKey)
@@ -2340,7 +2341,7 @@ local metadata = tes3.getLuaModMetadata(modKey)
 
 **Returns**:
 
-* `metadata` (table, nil)
+* `metadata` (MWSE.Metadata, nil)
 
 ***
 

--- a/docs/source/guides/metadata.md
+++ b/docs/source/guides/metadata.md
@@ -210,7 +210,7 @@ The following dependencies are available:
 
 ## Versions
 
-The version strings in `[package]`, `[dependencies.mge-xe]` and `[dependencies.mods]` uses semver (Semantic Versioning) format. This consists of three numbers separated by periods, such as `1.2.3`. The first number is the `major` version, the second is the `minor` version, and the third is the `patch` version. You should increment the major version when you make a breaking change, the minor version when you add new features, and the patch version when you make bug fixes.
+The version strings in `[package]`, `[dependencies.mge-xe]`, and `[dependencies.mods]` follow the semver (Semantic Versioning) format, which consists of three numbers separated by periods. The syntax is `<MAJOR>`.`<MINOR>`.`<PATCH>`. For example, `1.2.3` means the major version is 1, the minor version is 2, and the patch version is 3. You should increment the major version when you make a breaking change, the minor version when you add new features, and the patch version when you make bug fixes.
 
 For more information on semver, see the [semver website](https://semver.org/).
 
@@ -220,7 +220,7 @@ When specifying a version for a mod or mge-xe dependency, use a comparison opera
 
 Available dependency operators are: `^`, `=`, `>=`, `<=`, `>`, `<`.
 
-Most operators are self explanatory, but the most useful one is the pessemistic operator: `^`. This will assert that the major version is the same, and the minor/patch versions are the same or higher than the target version. This is because a major version update indicates a breaking change. For example, if your target version is `^1.2.3`, then `1.2.3`, `1.3.3`, and `1.2.4` will be compatible, but `2.0.0`, `1.1.3`, and `1.2.2` will not.
+The  `=`, `>=`, `<=`, `>`, and `<` operators all function as expected. The pessemistic operator (`^`) works by using `=` on major versions and `<=` on minor and patch versions. For example, if your target version is `^1.2.3`, then `1.2.3`, `1.3.3`, and `1.2.4` will be compatible, but `2.0.0`, `1.1.3`, and `1.2.2` will not. The idea behind the `^` operator is that changes in major versions signify breaking changes, which can introduce incompatibilities. 
 
 ## Full Example
 

--- a/misc/package/Data Files/MWSE/core/meta/lib/json.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/json.lua
@@ -10,9 +10,8 @@ json = {}
 
 --- Decode string into a table.
 --- 
---- !!! warning "json does not support `number` indices"
---- 	As a result, the `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
---- 	You should be mindful of this when using this function.
+--- !!! warning "json does not support mixed `string` and `number` indices"
+--- 	If the encoded table had any `string` indices, then the `table` returned by this function will have no `number` indices. For example, `[1]` could have been converted to `["1"]` in the encoding process.
 --- 
 --- @param s string No description yet available.
 --- @param position number? *Default*: `1`. No description yet available.
@@ -20,10 +19,10 @@ json = {}
 --- @return table result No description yet available.
 function json.decode(s, position, nullValue) end
 
---- Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data struture that contains reference cycles.
+--- Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data structure that contains reference cycles.
 --- 
---- !!! warning "json does not support `number` indices"
---- 	This function will convert all `number` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
+--- !!! warning "json does not support mixed `string` and `number` indices"
+--- 	If the encoded table has any `string` indices, then this function will convert all `number` indices to `string` indices. For example, `[1]` could be converted to `["1"]`. This should be taken into account when loading/decoding json files.
 --- 
 --- @param object table No description yet available.
 --- @param state table? No description yet available.
@@ -32,9 +31,8 @@ function json.encode(object, state) end
 
 --- Loads the contents of a file through `json.decode`. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
 --- 
---- !!! warning "json does not support `number` indices"
---- 	The `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
---- 	You should be mindful of this when using this function.
+--- !!! warning "json does not support mixed `string` and `number` indices"
+--- 	If the encoded table had any `string` indices, then the `table` returned by this function will have no `number` indices. For example, `[1]` could have been converted to `["1"]` in the encoding process.
 --- 	If you're using this to load a configuration file for your mod, it's recommended you use [`mwse.loadConfig`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 --- 
 --- @param fileName string No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/lib/json.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/json.lua
@@ -10,8 +10,8 @@ json = {}
 
 --- Decode string into a table.
 --- 
---- !!! warning "json does not support `integer` indices"
---- 	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+--- !!! warning "json does not support `number` indices"
+--- 	As a result, the `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
 --- 	You should be mindful of this when using this function.
 --- 
 --- @param s string No description yet available.
@@ -22,18 +22,18 @@ function json.decode(s, position, nullValue) end
 
 --- Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data struture that contains reference cycles.
 --- 
---- !!! warning "json does not support `integer` indices"
---- 	This function will convert all `integer` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
+--- !!! warning "json does not support `number` indices"
+--- 	This function will convert all `number` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
 --- 
 --- @param object table No description yet available.
 --- @param state table? No description yet available.
 --- @return string result No description yet available.
 function json.encode(object, state) end
 
---- Loads the contents of a file through json.decode. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
+--- Loads the contents of a file through `json.decode`. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
 --- 
---- !!! warning "json does not support `integer` indices"
---- 	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+--- !!! warning "json does not support `number` indices"
+--- 	The `table` returned by this function won't have any `number` indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
 --- 	You should be mindful of this when using this function.
 --- 	If you're using this to load a configuration file for your mod, it's recommended you use [`mwse.loadConfig`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 --- 
@@ -46,7 +46,7 @@ function json.loadfile(fileName) end
 --- @return string result No description yet available.
 function json.quotestring(s) end
 
---- Saves a serializable table to Data Files\\MWSE\\{fileName}.json, using json.encode.
+--- Saves a serializable table to Data Files\\MWSE\\{`fileName`}.json, using `json.encode`.
 --- @param fileName string No description yet available.
 --- @param object table No description yet available.
 --- @param config table? *Optional*. No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/lib/json.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/json.lua
@@ -10,8 +10,9 @@ json = {}
 
 --- Decode string into a table.
 --- 
---- !!! warning
---- 	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+--- !!! warning "json does not support `integer` indices"
+--- 	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+--- 	You should be mindful of this when using this function.
 --- 
 --- @param s string No description yet available.
 --- @param position number? *Default*: `1`. No description yet available.
@@ -19,21 +20,22 @@ json = {}
 --- @return table result No description yet available.
 function json.decode(s, position, nullValue) end
 
---- Create a string representing the object. Object can be a table, a string, a number, a boolean, nil, json.null or any object with a function __tojson in its metatable. A table can only use strings and numbers as keys and its values have to be valid objects as well. It raises an error for any invalid data types or reference cycles.
+--- Create a string representing the object. Object can be a `table`, `string`, `number`, `boolean`, `nil`, `json.null`,  or any object with a `__tojson` function in its `metatable`. A `table` can only use strings and numbers as keys, and its values have to be valid objects as well. This function will raise an error if called on an invalid data type or on a data struture that contains reference cycles.
 --- 
---- !!! warning
---- 	If the table being encoded has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading json files.
+--- !!! warning "json does not support `integer` indices"
+--- 	This function will convert all `integer` indices to `string` indices. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading/decoding json files.
 --- 
 --- @param object table No description yet available.
 --- @param state table? No description yet available.
 --- @return string result No description yet available.
 function json.encode(object, state) end
 
---- Loads the contents of a file through json.decode. Files loaded from Data Files\\MWSE\\{fileName}.json.
+--- Loads the contents of a file through json.decode. Files loaded from "Data Files\\MWSE\\{`fileName`}.json".
 --- 
---- !!! warning
---- 	All of the keys in the `table` returned by function will be `string`s. For example, if you're decoding an array-style table, then the first entry will be `["1"]` instead of `[1]`.
---- 	If you're using this function to load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
+--- !!! warning "json does not support `integer` indices"
+--- 	As a result, the `table` returned by this function won't have any integer indices. (e.g., the first key of an array-style table will be decoded as `["1"]`, not as `[1`].)
+--- 	You should be mindful of this when using this function.
+--- 	If you're using this to load a configuration file for your mod, it's recommended you use [`mwse.loadConfig`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 --- 
 --- @param fileName string No description yet available.
 --- @return table result No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/lib/json.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/json.lua
@@ -22,7 +22,7 @@ function json.decode(s, position, nullValue) end
 --- Create a string representing the object. Object can be a table, a string, a number, a boolean, nil, json.null or any object with a function __tojson in its metatable. A table can only use strings and numbers as keys and its values have to be valid objects as well. It raises an error for any invalid data types or reference cycles.
 --- 
 --- !!! warning
---- 	If the table you are encoding as json has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered.
+--- 	If the table being encoded has both string and integer indices, this action will convert all the integer indices to strings. For example, `[1]` is converted to `["1"]`. This should be taken into account when loading json files.
 --- 
 --- @param object table No description yet available.
 --- @param state table? No description yet available.
@@ -32,7 +32,8 @@ function json.encode(object, state) end
 --- Loads the contents of a file through json.decode. Files loaded from Data Files\\MWSE\\{fileName}.json.
 --- 
 --- !!! warning
---- 	If the table encoded as json had both string and integer indices, this process converted all the integer indices to strings. For example, `[1]` was converted to `["1"]`. So, when loading mixed tables from json, this needs to be considered. If you need to save and load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) as that function will do this for you.
+--- 	All of the keys in the `table` returned by function will be `string`s. For example, if you're decoding an array-style table, then the first entry will be `["1"]` instead of `[1]`.
+--- 	If you're using this function to load your mod's configuration file, consider using [`mwse.loadConfig()`](https://mwse.github.io/MWSE/apis/mwse/#mwseloadconfig) instead.
 --- 
 --- @param fileName string No description yet available.
 --- @return table result No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/lib/mwse.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mwse.lua
@@ -102,7 +102,7 @@ function mwse.registerModConfig(name, package) end
 --- Saves a config table to Data Files\\MWSE\\config\\{fileName}.json. The config is converted to JSON during saving.
 --- @param fileName string Usually named after your mod.
 --- @param config table The config table to save.
---- @param jsonOptions table? *Optional*. Used to optionally pass encoding options to the dkjson encoder.
+--- @param jsonOptions table? *Optional*. Encoding options. These get passed to the `dkjson` encoder.
 function mwse.saveConfig(fileName, config, jsonOptions) end
 
 --- Converts an uppercase, 4-character string into a TES3 object type.

--- a/misc/package/Data Files/MWSE/core/meta/lib/string.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/string.lua
@@ -69,6 +69,11 @@ function string.multifind(s, patterns, index, plain) end
 --- Returns an array-style table with a `string` split by a specified separator.
 --- The seperator is not part of the results. 
 --- By default the `sep == "%s"`, which will result in `str` getting split by whitespace characters (e.g. spaces and tabs).
+--- 
+--- !!! warning 
+--- 	if `sep` is more than one character, then `str` will get split at each occurrence of any of the individual characters in `sep`.
+--- 	For example, `string.split("1a2b3c4abc5", "abc")` will return `{"1", "2", "3", "4", "5"}` instead of `{"1a2b3c4", "5"}`.
+--- 
 --- @param str string The string to split.
 --- @param sep string? *Default*: `"%s"`. The token to split the string by.
 --- @return string[] split No description yet available.

--- a/misc/package/Data Files/MWSE/core/meta/lib/table.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/table.lua
@@ -85,7 +85,7 @@ function table.empty(t, deepCheck) end
 ---  	Do not use this function on array-style tables, as it will not shift indices down after filtering out elements. Instead, you should use `table.filterarray` on array-style tables.
 --- 
 --- @param t table No description yet available.
---- @param f fun(k: unknown, v: unknown, ...): boolean|unknown No description yet available.
+--- @param f fun(k: unknown, v: unknown, ...): boolean No description yet available.
 --- @param ... any Additional parameters to pass to `f`.
 --- @return table result The result of using `f` to filter out elements of `t`.
 function table.filter(t, f, ...) end
@@ -96,7 +96,7 @@ function table.filter(t, f, ...) end
 --- 
 --- When an element gets filtered out, the index of subsequent items will be shifted down, so that the resulting table plays nicely with the `#` operator and the `ipairs` function.
 --- @param arr table No description yet available.
---- @param f fun(i: integer, v: unknown, ...): boolean|unknown No description yet available.
+--- @param f fun(i: integer, v: unknown, ...): boolean No description yet available.
 --- @param ... any Additional parameters to pass to `f`.
 --- @return table result The result of using `f` to filter out elements of `t`.
 function table.filterarray(arr, f, ...) end

--- a/misc/package/Data Files/MWSE/core/meta/lib/table.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/table.lua
@@ -85,7 +85,7 @@ function table.empty(t, deepCheck) end
 ---  	Do not use this function on array-style tables, as it will not shift indices down after filtering out elements. Instead, you should use `table.filterarray` on array-style tables.
 --- 
 --- @param t table No description yet available.
---- @param f fun(k: unknown, v: unknown, ...) No description yet available.
+--- @param f fun(k: unknown, v: unknown, ...): boolean|unknown No description yet available.
 --- @param ... any Additional parameters to pass to `f`.
 --- @return table result The result of using `f` to filter out elements of `t`.
 function table.filter(t, f, ...) end
@@ -96,7 +96,7 @@ function table.filter(t, f, ...) end
 --- 
 --- When an element gets filtered out, the index of subsequent items will be shifted down, so that the resulting table plays nicely with the `#` operator and the `ipairs` function.
 --- @param arr table No description yet available.
---- @param f fun(i: integer, v: unknown, ...) No description yet available.
+--- @param f fun(i: integer, v: unknown, ...): boolean|unknown No description yet available.
 --- @param ... any Additional parameters to pass to `f`.
 --- @return table result The result of using `f` to filter out elements of `t`.
 function table.filterarray(arr, f, ...) end
@@ -135,7 +135,7 @@ function table.keys(t, sort) end
 --- Creates a new table consisting of key value pairs `k, f(k, v)`, where `k, v` is a pair in `t`.
 --- Any additional arguments will be passed to `f`. For example, `table.map(t, f, 10)` would call `f(k, v, 10)` on each value `v` of `t`.
 --- @param t table No description yet available.
---- @param f fun(k: unknown, v: unknown, ...) No description yet available.
+--- @param f fun(k: unknown, v: unknown, ...): unknown No description yet available.
 --- @param ... any Additional parameters to pass to `f`.
 --- @return table result The result of applying `f` to each value in `t`.
 function table.map(t, f, ...) end

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -1701,21 +1701,23 @@ function tes3.newGame() end
 --- @return boolean onMainMenu No description yet available.
 function tes3.onMainMenu() end
 
---- Pays a merchant gold. The money is transferred to their barter gold (non-inventory trading gold), and also updates the last barter timer, so that it works the same way a transaction affeects the barter gold reset cycle. This is useful for simulating paying for services. The function will return true if there was enough gold to complete the payment.
+--- Pays a merchant a specified amount of gold and updates the merchant's "last barter timer". This should be used to simulate paying for services. You may also want to play a trade-related sound of your choice upon successful completion.
 --- 
---- A negative cost will allow payment from the merchant's barter gold to the player. You may also want to play a trade-related sound of your choice upon successful completion.
+--- If `cost` is positive, then that amount of gold will be removed from the player's inventory and added to the merchant's available barter gold.
+--- 
+--- If `cost` is negative, then that amount of gold will be added to the player's inventory and removed from the merchant's available barter gold.
 --- @param params tes3.payMerchant.params This table accepts the following values:
 --- 
 --- `merchant`: tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer — The merchant to pay.
 --- 
---- `cost`: number — The amount of gold to transfer to the merchant. May be negative to transfer gold to the player.
---- @return boolean success True if the transaction completed. False if there was not enough gold.
+--- `cost`: number — The amount of gold to pay the merchant. If negative, the merchant will pay the player.
+--- @return boolean success `true` if the transaction completed. `false` if there was not enough gold.
 function tes3.payMerchant(params) end
 
 ---Table parameter definitions for `tes3.payMerchant`.
 --- @class tes3.payMerchant.params
 --- @field merchant tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer The merchant to pay.
---- @field cost number The amount of gold to transfer to the merchant. May be negative to transfer gold to the player.
+--- @field cost number The amount of gold to pay the merchant. If negative, the merchant will pay the player.
 
 --- Attempts a persuasion attempt on an actor, potentially adjusting their disposition. Returns true if the attempt was a success.
 --- @param params tes3.persuade.params This table accepts the following values:

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -1192,8 +1192,9 @@ function tes3.getLockLevel(params) end
 --- @field reference tes3reference|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer|string No description yet available.
 
 --- Fetches the contents of the [metadata file](https://mwse.github.io/MWSE/guides/metadata/) associated with a given lua mod key.
+--- The mod key should match the value of `lua-mod` specified in the `[tools.mwse]` section of the relevant metadata file.
 --- @param modKey string The key for the lua mod, which must match the file location and the metadata file's `[tools.mwse]` contents.
---- @return table|nil metadata No description yet available.
+--- @return MWSE.Metadata|nil metadata No description yet available.
 function tes3.getLuaModMetadata(modKey) end
 
 --- Fetches the core game Magic Effect object for a given ID. Can return custom magic effects added with `tes3.addMagicEffect`.


### PR DESCRIPTION
i reworded the documentation in a few places, added some more detail here and there, and fixed/tweaked the function parameters/return types for some functions.

i'd be happy to undo some changes (or revise them) if people would like

the documentation was also rebuilt

### notes:
* i changed the return type of `tes3.getLuaModMetadata` to be `MWSE.Metadata`. however, this is only defined in `core/lib/dependencyManagement/DependencyManager.lua`, so there's no link to it in the generated `mkdocs` documentation. but it's still useful for code completion in visual studio.
  * i can add the `MWSE.Metadata` class to the `autocomplete` folder if people think that would be appropriate

