### PR TITLE
Add `tes3.getKeyName(keyCode)` function

### DIFF
--- a/autocomplete/definitions/global/tes3/getKeyName.lua
+++ b/autocomplete/definitions/global/tes3/getKeyName.lua
@@ -1,0 +1,11 @@
+return {
+	type = "function",
+	description = "Gets the name of a corresponding `tes3.scanCode`, using the appropriate GMSTs. The `keyName` returned by this function is the same `keyName` \z
+		that would be used in the in-game Controls menu. \z
+		For example, `tes3.getKeyName(tes3.scanCode.b)` will return `\"B\"`, and `tes3.getKeyName(tes3.scanCode.rshift)` will return `\"Right Shift\"`.",
+	arguments = {{
+		name = "keyCode",
+		type = "tes3.scanCode",
+	}},
+	returns = {{ name = "keyName", type = "string", description = "A string representation of the given `keyCode`." }},
+}

--- a/autocomplete/definitions/global/tes3/getKeyName.lua
+++ b/autocomplete/definitions/global/tes3/getKeyName.lua
@@ -1,7 +1,8 @@
 return {
 	type = "function",
 	description = "Gets the name of a corresponding `tes3.scanCode`, using the appropriate GMSTs. The `keyName` returned by this function is the same `keyName` \z
-		that would be used in the in-game Controls menu. \z
+		that would be used in the in-game Controls menu.\n\n\z
+		\z
 		For example, `tes3.getKeyName(tes3.scanCode.b)` will return `\"B\"`, and `tes3.getKeyName(tes3.scanCode.rshift)` will return `\"Right Shift\"`.",
 	arguments = {{
 		name = "keyCode",

--- a/docs/source/apis/tes3.md
+++ b/docs/source/apis/tes3.md
@@ -2205,6 +2205,25 @@ local index = tes3.getJournalIndex({ id = ... })
 
 ***
 
+### `tes3.getKeyName`
+<div class="search_terms" style="display: none">getkeyname, keyname</div>
+
+Gets the name of a corresponding `tes3.scanCode`, using the appropriate GMSTs. The `keyName` returned by this function is the same `keyName` that would be used in the in-game Controls menu. For example, `tes3.getKeyName(tes3.scanCode.b)` will return `"B"`, and `tes3.getKeyName(tes3.scanCode.rshift)` will return `"Right Shift"`.
+
+```lua
+local keyName = tes3.getKeyName(keyCode)
+```
+
+**Parameters**:
+
+* `keyCode` ([tes3.scanCode](../references/scan-codes.md))
+
+**Returns**:
+
+* `keyName` (string): A string representation of the given `keyCode`.
+
+***
+
 ### `tes3.getKillCount`
 <div class="search_terms" style="display: none">getkillcount, killcount</div>
 

--- a/docs/source/apis/tes3.md
+++ b/docs/source/apis/tes3.md
@@ -2208,7 +2208,9 @@ local index = tes3.getJournalIndex({ id = ... })
 ### `tes3.getKeyName`
 <div class="search_terms" style="display: none">getkeyname, keyname</div>
 
-Gets the name of a corresponding `tes3.scanCode`, using the appropriate GMSTs. The `keyName` returned by this function is the same `keyName` that would be used in the in-game Controls menu. For example, `tes3.getKeyName(tes3.scanCode.b)` will return `"B"`, and `tes3.getKeyName(tes3.scanCode.rshift)` will return `"Right Shift"`.
+Gets the name of a corresponding `tes3.scanCode`, using the appropriate GMSTs. The `keyName` returned by this function is the same `keyName` that would be used in the in-game Controls menu.
+
+For example, `tes3.getKeyName(tes3.scanCode.b)` will return `"B"`, and `tes3.getKeyName(tes3.scanCode.rshift)` will return `"Right Shift"`.
 
 ```lua
 local keyName = tes3.getKeyName(keyCode)

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
@@ -26,11 +26,7 @@ KeyBinder.allowMouse = false
 --- @param keyCode integer|nil
 --- @return string|nil letter
 function KeyBinder:getLetter(keyCode)
-	local letter = table.find(tes3.scanCode, keyCode)
-	local returnString = tes3.scanCodeToNumber[keyCode] or letter
-	if returnString then
-		return string.upper(returnString)
-	end
+	return tes3.getKeyName(keyCode)
 end
 
 local mouseWheelDirectionName = {

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
@@ -26,6 +26,7 @@ KeyBinder.allowMouse = false
 --- @param keyCode integer|nil
 --- @return string|nil letter
 function KeyBinder:getLetter(keyCode)
+	if not keyCode then return end
 	return tes3.getKeyName(keyCode)
 end
 

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -1142,6 +1142,11 @@ function tes3.getJournalIndex(params) end
 --- @class tes3.getJournalIndex.params
 --- @field id tes3dialogue|string No description yet available.
 
+--- Gets the name of a corresponding `tes3.scanCode`, using the appropriate GMSTs. The `keyName` returned by this function is the same `keyName` that would be used in the in-game Controls menu. For example, `tes3.getKeyName(tes3.scanCode.b)` will return `"B"`, and `tes3.getKeyName(tes3.scanCode.rshift)` will return `"Right Shift"`.
+--- @param keyCode tes3.scanCode No description yet available.
+--- @return string keyName A string representation of the given `keyCode`.
+function tes3.getKeyName(keyCode) end
+
 --- Returns how many times the player killed an actor. If no actor is specified, total number of kills player commited will be returned.
 --- @param params tes3.getKillCount.params? This table accepts the following values:
 --- 

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -1142,7 +1142,9 @@ function tes3.getJournalIndex(params) end
 --- @class tes3.getJournalIndex.params
 --- @field id tes3dialogue|string No description yet available.
 
---- Gets the name of a corresponding `tes3.scanCode`, using the appropriate GMSTs. The `keyName` returned by this function is the same `keyName` that would be used in the in-game Controls menu. For example, `tes3.getKeyName(tes3.scanCode.b)` will return `"B"`, and `tes3.getKeyName(tes3.scanCode.rshift)` will return `"Right Shift"`.
+--- Gets the name of a corresponding `tes3.scanCode`, using the appropriate GMSTs. The `keyName` returned by this function is the same `keyName` that would be used in the in-game Controls menu.
+--- 
+--- For example, `tes3.getKeyName(tes3.scanCode.b)` will return `"B"`, and `tes3.getKeyName(tes3.scanCode.rshift)` will return `"Right Shift"`.
 --- @param keyCode tes3.scanCode No description yet available.
 --- @return string keyName A string representation of the given `keyCode`.
 function tes3.getKeyName(keyCode) end

--- a/misc/package/Data Files/MWSE/core/mwse/tes3/getKeyName/main.lua
+++ b/misc/package/Data Files/MWSE/core/mwse/tes3/getKeyName/main.lua
@@ -1,0 +1,12 @@
+---@param keyCode tes3.scanCode
+function tes3.getKeyName(keyCode)
+    -- get the index of the appropriate GMST setting
+    -- the `%02X` does hexadecimal formatting and gives numbers `< 16` a leading 0.
+    -- so, `11` -> "0A" and `16` -> "10"
+    local index = string.format("sKeyName_%02X", keyCode)
+	local gmst = tes3.gmst[index]
+    -- if the game setting exists, return its value
+	if gmst then
+		return tes3.findGMST(gmst).value
+	end
+end

--- a/misc/package/Data Files/MWSE/core/mwse/tes3/getKeyName/main.lua
+++ b/misc/package/Data Files/MWSE/core/mwse/tes3/getKeyName/main.lua
@@ -2,11 +2,12 @@
 function tes3.getKeyName(keyCode)
     -- get the index of the appropriate GMST setting
     -- the `%02X` does hexadecimal formatting and gives numbers `< 16` a leading 0.
-    -- so, `11` -> "0A" and `16` -> "10"
-    local index = string.format("sKeyName_%02X", keyCode)
-	local gmst = tes3.gmst[index]
+    --      so, `11` -> "0A" and `16` -> "10"
+    -- for example, if `keyCode == tes3.scanCode["2"] == 3`, then
+    --      `string.format("sKeyName_%02X", keyCode) == sKeyName_03`
+	local index = tes3.gmst[string.format("sKeyName_%02X", keyCode)]
     -- if the game setting exists, return its value
-	if gmst then
-		return tes3.findGMST(gmst).value
+	if index then
+		return tes3.findGMST(index).value
 	end
 end

--- a/misc/package/Data Files/MWSE/core/mwse/tes3/getKeyName/main.lua
+++ b/misc/package/Data Files/MWSE/core/mwse/tes3/getKeyName/main.lua
@@ -1,12 +1,10 @@
 ---@param keyCode tes3.scanCode
 function tes3.getKeyName(keyCode)
-    -- get the index of the appropriate GMST setting
-    -- the `%02X` does hexadecimal formatting and gives numbers `< 16` a leading 0.
-    --      so, `11` -> "0A" and `16` -> "10"
-    -- for example, if `keyCode == tes3.scanCode["2"] == 3`, then
-    --      `string.format("sKeyName_%02X", keyCode) == sKeyName_03`
+	-- This will get the index of the appropriate GMST setting.
+	-- The `%02X` performs hexadecimal formatting and makes sure numbers `< 16` have a leading 0. (e.g. `0A` instead of `A`.)
+	-- For an example of how this all works, `tes3.scanCode.h` (which has a value of `35`) will become `sKeyName_23`.
 	local index = tes3.gmst[string.format("sKeyName_%02X", keyCode)]
-    -- if the game setting exists, return its value
+	-- If the GMST exists, return its value.
 	if index then
 		return tes3.findGMST(index).value
 	end


### PR DESCRIPTION
## overview
- `tes3.getKeyName(keyCode)` will take in a `tes3.scanCode` and return its name, as defined by the relevant GMST. 
  - For example, `tes3.getKeyName(tes3.scanCode.p) == "P"`.
- I haven't made any documentation files yet, but would be happy to do so if people are interested in merging this PR.
- I also changed `mwseMCMKeyBinder:getLetter` to make it use `tes3.getKeyName`. This should make it more consistent with the in-game controls menu. (Although I'd be happy to revert this part if people would like.)

## implementation
This function works as follows:

0. The user-facing names for scan codes are specified in the `sKeyName_X` GMSTs, where `X` is a 0-padded hexadecimal number (i.e.,  `07` instead of `7`).
1. Given a `tes3.scanCode`, the `id` of the relevant GMST (taking 0-padding into account) is given by
```lua
string.format("sKeyName_%02X", keyCode)
```
2. So, we can get the name of a `tes3.scanCode` via
```lua
local id = string.format("sKeyName_%02X", keyCode)
local index = tes3.gmst[id]
if index then
    return tes3.findGMST(index).value
end
```
**Note:** If the user passed a valid `tes3.scanCode`, then the `index ~= nil` check will always succeed. (This is confirmed by the testing below.) The `index ~= nil` check only exists to ensure the `keyCode` parameter was valid.
## testing
I tested the output of this function against the `tes3.scanCode` table with the following code:
```lua
for k, v in pairs(tes3.scanCode) do
    local name = tes3.getKeyName(v)
    if not name then
        print(string.format("error!! name for (k, v) = (%q, %s) is nil", k, v))
    end
    if k:upper() ~= name then
        print(string.format("mismatch: %q ~= %q", k:upper(), name))
    end
end
```
### results
1. The `if not name then` condition was never satisfied.
2. The output of `tes3.getKeyName` didn't always exactly match `k:upper()`, but the only "failures" were things like  `"FORWARDSLASH" ~= "/"`,  `"TWO" ~= "2"`, and `"#" ~= "3"`.
   - The most concerning mismatches were things of the form `"#" ~= "3"`, but I think these mismatches would be unavoidable in any implementation, because the `tes3.scanCode` table isn't 1-1. For example, `tes3.scanCode["#"] == tes3.scanCode["3"]`.


<details><summary><b>Full testing output</b> (<i>click to expand</i>)</summary> <p>

```
mismatch: "APPS" ~= "Apps"
mismatch: "TILDE" ~= "Grave"
mismatch: "LESSTHAN" ~= ","
mismatch: "COLON" ~= ";"
mismatch: "EXCLAMATIONMARK" ~= "1"
mismatch: "BACKSLASH" ~= "\\"
mismatch: "QUOTEMARK" ~= "'"
mismatch: "PERCENT" ~= "5"
mismatch: ":" ~= ";"
mismatch: "RSHIFT" ~= "Right Shift"
mismatch: "<" ~= ","
mismatch: "GREATERTHAN" ~= "."
mismatch: "FIVE" ~= "5"
mismatch: "AT" ~= "2"
mismatch: "|" ~= "\\"
mismatch: "@" ~= "2"
mismatch: "CLOSECURLYBRACKET" ~= "]"
mismatch: "_" ~= "-"
mismatch: "#" ~= "3"
mismatch: "LSHIFT" ~= "Left Shift"
mismatch: "BACKTICK" ~= "Grave"
mismatch: "RIGHTSHIFT" ~= "Right Shift"
mismatch: "LEFTCTRL" ~= "Left Ctrl"
mismatch: "TAB" ~= "Tab"
mismatch: "QUESTIONMARK" ~= "/"
mismatch: "FORWARDSLASH" ~= "/"
mismatch: "RALT" ~= "Right Alt"
mismatch: ")" ~= "0"
mismatch: "FOUR" ~= "4"
mismatch: "NUMPAD5" ~= "Numpad 5"
mismatch: "CAPS" ~= "Caps Lock"
mismatch: "+" ~= "="
mismatch: "NUMPAD2" ~= "Numpad 2"
mismatch: "EIGHT" ~= "8"
mismatch: "LSUPER" ~= "Left Win"
mismatch: "LEFTSHIFT" ~= "Left Shift"
mismatch: "QUOTATIONMARK" ~= "'"
mismatch: "OPENBRACKET" ~= "9"
mismatch: "DIVIDE" ~= "Numpad /"
mismatch: "CLOSEPOINTYBRACKET" ~= "."
mismatch: "PAUSE" ~= "Pause"
mismatch: "ASTERISK" ~= "8"
mismatch: "SEMICOLON" ~= ";"
mismatch: "END" ~= "End"
mismatch: "QUOTE" ~= "'"
mismatch: "RIGHTCTRL" ~= "Right Ctrl"
mismatch: "NINE" ~= "9"
mismatch: "NUMPAD7" ~= "Numpad 7"
mismatch: "DOLLARSIGN" ~= "4"
mismatch: "NUMPAD4" ~= "Numpad 4"
mismatch: "MULTIPLY" ~= "Numpad *"
mismatch: "MENU" ~= "Apps"
mismatch: "EQUALS" ~= "="
mismatch: "RSUPER" ~= "Right Win"
mismatch: "SINGLEQUOTE" ~= "'"
mismatch: "LEFTALT" ~= "Left Alt"
mismatch: "BACKSPACE" ~= "Back Space"
mismatch: "CARET" ~= "6"
mismatch: "RWINDOWS" ~= "Right Win"
mismatch: "NUMPAD3" ~= "Numpad 3"
mismatch: "LEFTSUPER" ~= "Left Win"
mismatch: "KEYUP" ~= "Up"
mismatch: "LEFTWINDOWS" ~= "Left Win"
mismatch: "NUMPAD0" ~= "Numpad 0"
mismatch: ">" ~= "."
mismatch: "LWINDOWS" ~= "Left Win"
mismatch: "PAGEDOWN" ~= "Page Down"
mismatch: "PAGEUP" ~= "Page Up"
mismatch: "RETURN" ~= "Return"
mismatch: "{" ~= "["
mismatch: "?" ~= "/"
mismatch: "SPACE" ~= "SPACEBAR"
mismatch: "AMPERSAND" ~= "7"
mismatch: "DECIMAL" ~= "Decimal"
mismatch: "PRINTSCREEN" ~= "SysRq"
mismatch: "SUBTRACT" ~= "Numpad -"
mismatch: "DELETE" ~= "Delete"
mismatch: "INSERT" ~= "Insert"
mismatch: "}" ~= "]"
mismatch: "KEYRIGHT" ~= "Right"
mismatch: "KEYDOWN" ~= "Down"
mismatch: "KEYLEFT" ~= "Left"
mismatch: "HOME" ~= "Home"
mismatch: "NUMPAD1" ~= "Numpad 1"
mismatch: "`" ~= "Grave"
mismatch: "$" ~= "4"
mismatch: "NUMPAD9" ~= "Numpad 9"
mismatch: "ADD" ~= "Numpad +"
mismatch: "NUMPAD6" ~= "Numpad 6"
mismatch: "NUMPADENTER" ~= "Right Enter"
mismatch: "NUMPAD8" ~= "Numpad 8"
mismatch: "PERIOD" ~= "."
mismatch: "SCROLLLOCK" ~= "Scroll Lock"
mismatch: "THREE" ~= "3"
mismatch: "FULLSTOP" ~= "."
mismatch: "COMMA" ~= ","
mismatch: "UNDERSCORE" ~= "-"
mismatch: "NUMLOCK" ~= "Num Lock"
mismatch: "CAPSLOCK" ~= "Caps Lock"
mismatch: "DOUBLEQUOTE" ~= "'"
mismatch: "OPENCURLYBRACKET" ~= "["
mismatch: "RIGHTSUPER" ~= "Right Win"
mismatch: "&" ~= "7"
mismatch: "APPMENU" ~= "Apps"
mismatch: "OPENSQUAREBRACKET" ~= "["
mismatch: "RIGHTALT" ~= "Right Alt"
mismatch: "RIGHTWINDOWS" ~= "Right Win"
mismatch: "*" ~= "8"
mismatch: "LALT" ~= "Left Alt"
mismatch: "OPENPOINTYBRACKET" ~= ","
mismatch: "BANG" ~= "1"
mismatch: "SEVEN" ~= "7"
mismatch: "PIPE" ~= "\\"
mismatch: "HASH" ~= "3"
mismatch: "PLUS" ~= "="
mismatch: "(" ~= "9"
mismatch: "!" ~= "1"
mismatch: "HAT" ~= "6"
mismatch: "LCTRL" ~= "Left Ctrl"
mismatch: "DASH" ~= "-"
mismatch: "ONE" ~= "1"
mismatch: "ZERO" ~= "0"
mismatch: "^" ~= "6"
mismatch: "ENTER" ~= "Return"
mismatch: "SIX" ~= "6"
mismatch: "BACKSLASH" ~= "\\"
mismatch: "ESCAPE" ~= "ESC"
mismatch: "RCTRL" ~= "Right Ctrl"
mismatch: "TWO" ~= "2"
mismatch: "CLOSEBRACKET" ~= "0"
mismatch: "~" ~= "Grave"
mismatch: "CLOSESQUAREBRACKET" ~= "]"
```

</p></details>