### PR TITLE
add `ModConfigClosed` event

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -30,12 +30,17 @@ mwse.mcm.i18n = mwse.loadTranslations("mcm")
 --- @param e tes3uiEventData
 local function onClickModName(e)
 	-- If we have a current mod, fire its close event.
-	if (currentModConfig and currentModConfig.onClose) then
-		local status, error = pcall(currentModConfig.onClose, modConfigContainer)
-		if (status == false) then
-			mwse.log("Error in mod config close callback: %s\n%s", error, debug.traceback())
+	if currentModConfig then
+		if currentModConfig.onClose then
+			local status, error = pcall(currentModConfig.onClose, modConfigContainer)
+			if (status == false) then
+				mwse.log("Error in mod config close callback: %s\n%s", error, debug.traceback())
+			end
 		end
+		-- do it after `onClose` gets called
+		event.trigger("ModConfigClosed", {modName = currentModConfig.name})
 	end
+	
 
 	-- Update the current mod package.
 	currentModConfig = configMods[e.source.text]
@@ -73,11 +78,15 @@ local function onClickCloseButton(e)
 	event.unregister("keyDown", onClickCloseButton, { filter = tes3.scanCode.escape })
 
 	-- If we have a current mod, fire its close event.
-	if (currentModConfig and currentModConfig.onClose) then
-		local status, error = pcall(currentModConfig.onClose, modConfigContainer)
-		if (status == false) then
-			mwse.log("Error in mod config close callback: %s\n%s", error, debug.traceback())
+	if currentModConfig then
+		if currentModConfig.onClose then
+			local status, error = pcall(currentModConfig.onClose, modConfigContainer)
+			if (status == false) then
+				mwse.log("Error in mod config close callback: %s\n%s", error, debug.traceback())
+			end
 		end
+		-- do it after `onClose` gets called
+		event.trigger("ModConfigClosed", {modName = currentModConfig.name})
 	end
 
 	-- Destroy the mod config menu.


### PR DESCRIPTION
this event fires whenever a mods MCM closes (both when clicking on a new MCM and when the MCM itself closes. it has the `modName` in the event payload, so it's possible to filter the event based on which mod got closed. (currently this cannot be done using the `filter` keyword option, but i'd like to add that if people are interested).

this can be useful for:
- detecting when another mod changed its config (if it doesn't publicly expose its config)
- detecting when your own mod had some of its config settings changed.


if people are interested in adding this, i can make the documentation and add the `filter` functionality.