### PR TITLE
DependencyManager: prevent the 'Plugin: "%s".' message from displaying

### DIFF
--- a/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyManager.lua
+++ b/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyManager.lua
@@ -110,7 +110,7 @@ function DependencyManager:checkDependencies()
             self.logger:warn("MWSE lua-mod: \"%s\".", luaMod)
         end
         self.logger:warn("No dependency checking will be performed.")
-        self.logger:warn("This can result from uncomplete mod installation or uninstallation.")
+        self.logger:warn("This can result from incomplete mod installation/uninstallation.")
 
         return true
     end

--- a/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyManager.lua
+++ b/misc/package/Data Files/MWSE/core/lib/dependencyManagement/DependencyManager.lua
@@ -103,10 +103,10 @@ function DependencyManager:checkDependencies()
         self.logger:warn("Metadata file (%s) found pointing to missing mod files:",
             self.metadata.package.name
         )
-        if not pluginExists then
+        if plugin and not pluginExists then
             self.logger:warn("Plugin: \"%s\".", plugin)
         end
-        if not luaModExists then
+        if luaMod and not luaModExists then
             self.logger:warn("MWSE lua-mod: \"%s\".", luaMod)
         end
         self.logger:warn("No dependency checking will be performed.")


### PR DESCRIPTION
very minor fix to `DependencyManager` that prevents a "missing plugin" warning from being displayed when there is no missing plugin.

This PR fixes the following bug: If a `metadata` file specifies a `plugin` and/or `lua-mod`, and one of them is missing, the `DependencyManager` will print a log message saying both the `plugin` and `lua-mod` are missing. This happens even if the `plugin` or `lua-mod` don't exist. For example:
```
[Animated Containers Rewritten.DependencyManager | main.lua:104 | WARN] Metadata file (Animated Containers Rewritten) found pointing to missing mod files:
[Animated Containers Rewritten.DependencyManager | main.lua:108 | WARN] Plugin: "%s".
[Animated Containers Rewritten.DependencyManager | main.lua:111 | WARN] MWSE lua-mod: "herbert100.animated containers".
[Animated Containers Rewritten.DependencyManager | main.lua:113 | WARN] No dependency checking will be performed.
[Animated Containers Rewritten.DependencyManager | main.lua:114 | WARN] This can result from uncomplete mod installation or uninstallation.
```
with the change, the following message is displayed instead:

```
[Animated Containers Rewritten.DependencyManager | main.lua:104 | WARN] Metadata file (Animated Containers Rewritten) found pointing to missing mod files:
[Animated Containers Rewritten.DependencyManager | main.lua:111 | WARN] MWSE lua-mod: "herbert100.animated containers".
[Animated Containers Rewritten.DependencyManager | main.lua:113 | WARN] No dependency checking will be performed.
[Animated Containers Rewritten.DependencyManager | main.lua:114 | WARN] This can result from incomplete mod installation/uninstallation.
```

This PR also changes "uncomplete" to "incomplete".
