### PR TITLE
minor typo fix in documentation for `uiSkillTooltip` event

### DIFF
--- a/autocomplete/definitions/events/standard/uiSkillTooltip.lua
+++ b/autocomplete/definitions/events/standard/uiSkillTooltip.lua
@@ -12,9 +12,9 @@ Note that tooltips may have different width depending on which menu they were cr
 			description = "The newly created tooltip element. Due to timeouts and target changes, it may be destroyed at any time.",
 		},
 		["skill"] = {
-			type = "tes3skill",
+			type = "tes3.skill",
 			readOnly = true,
-			description = "The skill being examined.",
+			description = "The id of the skill being examined.",
 		},
 		["type"] = {
 			type = "integer",

--- a/docs/source/events/uiSkillTooltip.md
+++ b/docs/source/events/uiSkillTooltip.md
@@ -23,7 +23,7 @@ event.register(tes3.event.uiSkillTooltip, uiSkillTooltipCallback)
 
 ## Event Data
 
-* `skill` ([tes3skill](../types/tes3skill.md)): *Read-only*. The skill being examined.
+* `skill` ([tes3.skill](../references/skills.md)): *Read-only*. The id of the skill being examined.
 * `tooltip` ([tes3uiElement](../types/tes3uiElement.md)): *Read-only*. The newly created tooltip element. Due to timeouts and target changes, it may be destroyed at any time.
 * `type` (integer): *Read-only*. 1 where the tooltip is being created by MenuStat, and includes progress to the next skill level up, and 0 for every other instance including tes3ui.createTooltipMenu().
 

--- a/misc/package/Data Files/MWSE/core/meta/event/uiSkillTooltip.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/uiSkillTooltip.lua
@@ -8,6 +8,6 @@
 --- 	
 --- @class uiSkillTooltipEventData
 --- @field claim boolean If set to `true`, any lower-priority event callbacks will be skipped. Returning `false` will set this to `true`.
---- @field skill tes3skill *Read-only*. The skill being examined.
+--- @field skill tes3.skill *Read-only*. The id of the skill being examined.
 --- @field tooltip tes3uiElement *Read-only*. The newly created tooltip element. Due to timeouts and target changes, it may be destroyed at any time.
 --- @field type integer *Read-only*. 1 where the tooltip is being created by MenuStat, and includes progress to the next skill level up, and 0 for every other instance including tes3ui.createTooltipMenu().


### PR DESCRIPTION
the documentation says the `skill` parameter is a `tes3skill` when it should be a value in the `tes3.skill` enum table. this fixes that (and updates the description of the `skill` parameter to reflect this)

docs have been rebuilt