### PR TITLE
fixed documentation: `trapDisarm`, `lockpick` events; `tes3skill` object

### DIFF
--- a/autocomplete/definitions/events/standard/lockPick.lua
+++ b/autocomplete/definitions/events/standard/lockPick.lua
@@ -30,8 +30,7 @@ return {
 		},
 		["chance"] = {
 			type = "number",
-			readOnly = true,
-			description = "The chance the lockpick will be successful.",
+			description = "The chance the lockpick attempt will be successful. May be modified. If set to a value `<= 0`, the attempt will fail and the \"Lock too complex\" message will be displayed.",
 		},
 		["lockPresent"] = {
 			type = "boolean",

--- a/autocomplete/definitions/events/standard/trapDisarm.lua
+++ b/autocomplete/definitions/events/standard/trapDisarm.lua
@@ -30,8 +30,7 @@ return {
 		},
 		["chance"] = {
 			type = "number",
-			readOnly = true,
-			description = "The chance the trap disarm will be successful.",
+			description = "The chance that the probe attempt will be successful. May be modified. If set to a value `<= 0`, the attempt will fail and the \"Trap too complex\" message will be displayed.",
 		},
 		["trapPresent"] = {
 			type = "boolean",

--- a/autocomplete/definitions/namedTypes/tes3skill/id.lua
+++ b/autocomplete/definitions/namedTypes/tes3skill/id.lua
@@ -1,0 +1,6 @@
+return {
+	type = "value",
+	description = "The unique identifier for this skill.",
+	valuetype = "tes3.skill",
+	readOnly = true,
+}

--- a/docs/source/events/lockPick.md
+++ b/docs/source/events/lockPick.md
@@ -23,7 +23,7 @@ event.register(tes3.event.lockPick, lockPickCallback)
 
 ## Event Data
 
-* `chance` (number): *Read-only*. The chance the lockpick will be successful.
+* `chance` (number): The chance the lockpick attempt will be successful. May be modified. If set to a value `<= 0`, the attempt will fail and the "Lock too complex" message will be displayed.
 * `lockData` ([tes3lockNode](../types/tes3lockNode.md)): *Read-only*. The lock data of the reference.
 * `lockPresent` (boolean): *Read-only*. Indicates if a lock is present on the reference.
 * `picker` ([tes3mobileNPC](../types/tes3mobileNPC.md)): *Read-only*. The Mobile NPC doing the disarming.

--- a/docs/source/events/trapDisarm.md
+++ b/docs/source/events/trapDisarm.md
@@ -23,7 +23,7 @@ event.register(tes3.event.trapDisarm, trapDisarmCallback)
 
 ## Event Data
 
-* `chance` (number): *Read-only*. The chance the trap disarm will be successful.
+* `chance` (number): The chance that the probe attempt will be successful. May be modified. If set to a value `<= 0`, the attempt will fail and the "Trap too complex" message will be displayed.
 * `disarmer` ([tes3mobileNPC](../types/tes3mobileNPC.md)): *Read-only*. The Mobile NPC doing the disarming.
 * `lockData` ([tes3lockNode](../types/tes3lockNode.md)): *Read-only*. The lock data of the reference.
 * `reference` ([tes3reference](../types/tes3reference.md)): *Read-only*. The reference that triggered the event (container, door, etc.).

--- a/docs/source/types/tes3skill.md
+++ b/docs/source/types/tes3skill.md
@@ -91,11 +91,11 @@ Loads from disk and returns the description of the skill.
 ### `id`
 <div class="search_terms" style="display: none">id</div>
 
-*Read-only*. The unique identifier for the object.
+*Read-only*. The unique identifier for this skill.
 
 **Returns**:
 
-* `result` (string)
+* `result` ([tes3.skill](../references/skills.md))
 
 ***
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3skill.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3skill.lua
@@ -8,5 +8,6 @@
 --- @field attribute tes3.attribute *Read-only*. Skill's governing attribute. Maps to [`tes3.attribute`](https://mwse.github.io/MWSE/references/attributes/) constants.
 --- @field description string Loads from disk and returns the description of the skill.
 --- @field iconPath string *Read-only*. The path to the icon for the skill.
+--- @field id tes3.skill *Read-only*. The unique identifier for this skill.
 --- @field name string *Read-only*. The player-facing name of the skill.
 --- @field specialization tes3.specialization The specialization in which the skill belongs. Maps to values in the [`tes3.specialization`](https://mwse.github.io/MWSE/references/specializations/) table.

--- a/misc/package/Data Files/MWSE/core/meta/event/lockPick.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/lockPick.lua
@@ -6,7 +6,7 @@
 --- @class lockPickEventData
 --- @field block boolean If set to `true`, vanilla logic will be suppressed. Returning `false` will set this to `true`.
 --- @field claim boolean If set to `true`, any lower-priority event callbacks will be skipped. Returning `false` will set this to `true`.
---- @field chance number *Read-only*. The chance the lockpick will be successful.
+--- @field chance number The chance the lockpick attempt will be successful. May be modified. If set to a value `<= 0`, the attempt will fail and the "Lock too complex" message will be displayed.
 --- @field lockData tes3lockNode *Read-only*. The lock data of the reference.
 --- @field lockPresent boolean *Read-only*. Indicates if a lock is present on the reference.
 --- @field picker tes3mobileNPC|tes3mobilePlayer *Read-only*. The Mobile NPC doing the disarming.

--- a/misc/package/Data Files/MWSE/core/meta/event/trapDisarm.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/trapDisarm.lua
@@ -6,7 +6,7 @@
 --- @class trapDisarmEventData
 --- @field block boolean If set to `true`, vanilla logic will be suppressed. Returning `false` will set this to `true`.
 --- @field claim boolean If set to `true`, any lower-priority event callbacks will be skipped. Returning `false` will set this to `true`.
---- @field chance number *Read-only*. The chance the trap disarm will be successful.
+--- @field chance number The chance that the probe attempt will be successful. May be modified. If set to a value `<= 0`, the attempt will fail and the "Trap too complex" message will be displayed.
 --- @field disarmer tes3mobileNPC|tes3mobilePlayer *Read-only*. The Mobile NPC doing the disarming.
 --- @field lockData tes3lockNode *Read-only*. The lock data of the reference.
 --- @field reference tes3reference *Read-only*. The reference that triggered the event (container, door, etc.).


### PR DESCRIPTION
Here's a summary of the things being fixed:
1. The `trapDisarm` and `lockPick` events incorrectly say the `chance` parameter is "Read only". This is evidenced by lines  `747` and `807` of the `TES3Reference.cpp` file (within the `attemptUnlockDisarm` function). I also did some testing in-game and was able to update the chances using these events.
2. The `id` field of the `tes3skill` object incorrectly lists that `id` is a `string`, when it should be a `tes3.skill`.

Documentation has been rebuilt.