### PR TITLE
fixed bug where the MCM could try to access GMSTs before the game initialized

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
@@ -11,12 +11,29 @@ local Component = {}
 Component.componentType = "Component"
 Component.paddingBottom = 4
 Component.indent = 12
-Component.sOK = tes3.findGMST(tes3.gmst.sOK).value --[[@as string]]
-Component.sCancel = tes3.findGMST(tes3.gmst.sCancel).value --[[@as string]]
-Component.sYes = tes3.findGMST(tes3.gmst.sYes).value --[[@as string]]
-Component.sNo = tes3.findGMST(tes3.gmst.sNo).value --[[@as string]]
-Component.sOn = tes3.findGMST(tes3.gmst.sOn).value --[[@as string]]
-Component.sOff = tes3.findGMST(tes3.gmst.sOff).value --[[@as string]]
+
+do -- set GMST values
+
+	-- the GMSTs aren't available until the game initializes, so we'll set them here and
+	-- then update them later once the GMSTs are available. it shouldn't really matter what
+	-- they're set to before the game initializes, so long as it's a string
+
+	Component.sOK = "OK" 			---@type string
+	Component.sCancel = "Cancel" 	---@type string
+	Component.sYes = "Yes" 			---@type string
+	Component.sNo = "No" 			---@type string
+	Component.sOn = "On" 			---@type string
+	Component.sOff = "Off" 			---@type string
+
+	event.register("initialized", function (e)
+		Component.sOK = tes3.findGMST(tes3.gmst.sOK).value 			--[[@as string]]
+		Component.sCancel = tes3.findGMST(tes3.gmst.sCancel).value 	--[[@as string]]
+		Component.sYes = tes3.findGMST(tes3.gmst.sYes).value 		--[[@as string]]
+		Component.sNo = tes3.findGMST(tes3.gmst.sNo).value 			--[[@as string]]
+		Component.sOn = tes3.findGMST(tes3.gmst.sOn).value 			--[[@as string]]
+		Component.sOff = tes3.findGMST(tes3.gmst.sOff).value 		--[[@as string]]
+	end, {doOnce=true, priority=1000000})
+end
 
 -- CONTROL METHODS
 

--- a/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
@@ -25,14 +25,22 @@ do -- set GMST values
 	Component.sOn = "On" 			---@type string
 	Component.sOff = "Off" 			---@type string
 
-	event.register("initialized", function (e)
+	local function setGMSTS()
 		Component.sOK = tes3.findGMST(tes3.gmst.sOK).value 			--[[@as string]]
 		Component.sCancel = tes3.findGMST(tes3.gmst.sCancel).value 	--[[@as string]]
 		Component.sYes = tes3.findGMST(tes3.gmst.sYes).value 		--[[@as string]]
 		Component.sNo = tes3.findGMST(tes3.gmst.sNo).value 			--[[@as string]]
 		Component.sOn = tes3.findGMST(tes3.gmst.sOn).value 			--[[@as string]]
 		Component.sOff = tes3.findGMST(tes3.gmst.sOff).value 		--[[@as string]]
-	end, {doOnce=true, priority=1000000})
+	end
+	
+	-- already initialized? set the GMSTs now
+	if tes3.isInitialized() then
+		setGMSTS()
+	else
+		-- havent initialized yet? make sure we set the GMSTS when we initialize
+		event.register("initialized", setGMSTS, {doOnce=true, priority=10000})
+	end
 end
 
 -- CONTROL METHODS


### PR DESCRIPTION
Fixed a bug that would cause the MCM code to try to access GMSTs before the game initialized. This could happen if a component was created before the "initialized" event fired.

This is fixed by:
1. When the file is first launched, the stored GMST values are defined using the default English values. They could probably set to anything at this point (so long as it's a string).
2. Next, we check if the game has already been initialized. If it has, we update the fields using the relevant GMST settings. If the game hasn't initialized, we register a function to the `initialized` event that will update the GMSTs once the game initializes.

This change also makes it possible for MCMs to be created without using the `ModConfigReady` event. (MCMs created this way seem to work fine.)
