### PR TITLE
docs fix: allow `MCMTableVariable.id` to be a `number`

### DIFF
--- a/autocomplete/definitions/global/mwse/mcm/createTableVariable.lua
+++ b/autocomplete/definitions/global/mwse/mcm/createTableVariable.lua
@@ -5,7 +5,7 @@ return {
 		name = "variable",
 		type = "table",
 		tableParams = {
-			{ name = "id", type = "string", description = "Key in the config file used to store the variable." },
+			{ name = "id", type = "string|number", description = "Key in the config file used to store the variable." },
 			{ name = "table", type = "table", description = "The table to save the data to." },
 			{ name = "defaultSetting", type = "unknown", optional = true, description = "If `id` does not exist in the table, it will be initialised to this value." },
 			{ name = "inGameOnly", type = "boolean", optional = true, default = false, description = "If true, the setting containing this variable will be disabled if the game is on main menu." },

--- a/autocomplete/definitions/namedTypes/mwseMCMTableVariable/id.lua
+++ b/autocomplete/definitions/namedTypes/mwseMCMTableVariable/id.lua
@@ -1,5 +1,5 @@
 return {
 	type = "value",
 	description = [[Key in the config file used to store the variable.]],
-	valuetype = "string",
+	valuetype = "string|number",
 }

--- a/autocomplete/definitions/namedTypes/mwseMCMTableVariable/new.lua
+++ b/autocomplete/definitions/namedTypes/mwseMCMTableVariable/new.lua
@@ -5,7 +5,7 @@ return {
 		name = "variable",
 		type = "table",
 		tableParams = {
-			{ name = "id", type = "string", description = "Key in the config file used to store the variable." },
+			{ name = "id", type = "string|number", description = "Key in the config file used to store the variable." },
 			{ name = "table", type = "table", description = "The table to save the data to." },
 			{ name = "defaultSetting", type = "unknown", optional = true, description = "If `id` does not exist in the table, it will be initialised to this value." },
 			{ name = "inGameOnly", type = "boolean", optional = true, default = false, description = "If true, the setting containing this variable will be disabled if the game is on main menu." },

--- a/docs/source/apis/mwse.mcm.md
+++ b/docs/source/apis/mwse.mcm.md
@@ -756,7 +756,7 @@ local variable = mwse.mcm.createTableVariable({ id = ..., table = ..., defaultSe
 **Parameters**:
 
 * `variable` (table)
-	* `id` (string): Key in the config file used to store the variable.
+	* `id` (string, number): Key in the config file used to store the variable.
 	* `table` (table): The table to save the data to.
 	* `defaultSetting` (unknown): *Optional*. If `id` does not exist in the table, it will be initialised to this value.
 	* `inGameOnly` (boolean): *Default*: `false`. If true, the setting containing this variable will be disabled if the game is on main menu.

--- a/docs/source/types/mwseMCMTableVariable.md
+++ b/docs/source/types/mwseMCMTableVariable.md
@@ -152,7 +152,7 @@ local variable = myObject:new({ id = ..., table = ..., defaultSetting = ..., inG
 **Parameters**:
 
 * `variable` (table)
-	* `id` (string): Key in the config file used to store the variable.
+	* `id` (string, number): Key in the config file used to store the variable.
 	* `table` (table): The table to save the data to.
 	* `defaultSetting` (unknown): *Optional*. If `id` does not exist in the table, it will be initialised to this value.
 	* `inGameOnly` (boolean): *Default*: `false`. If true, the setting containing this variable will be disabled if the game is on main menu.

--- a/docs/source/types/mwseMCMTableVariable.md
+++ b/docs/source/types/mwseMCMTableVariable.md
@@ -64,7 +64,7 @@ Key in the config file used to store the variable.
 
 **Returns**:
 
-* `result` (string)
+* `result` (string, number)
 
 ***
 

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseMCMTableVariable.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseMCMTableVariable.lua
@@ -14,7 +14,7 @@ mwseMCMTableVariable = {}
 --- Creates a new variable of this type.
 --- @param variable mwseMCMTableVariable.new.variable This table accepts the following values:
 --- 
---- `id`: string — Key in the config file used to store the variable.
+--- `id`: string|number — Key in the config file used to store the variable.
 --- 
 --- `table`: table — The table to save the data to.
 --- 
@@ -32,7 +32,7 @@ function mwseMCMTableVariable:new(variable) end
 
 ---Table parameter definitions for `mwseMCMTableVariable.new`.
 --- @class mwseMCMTableVariable.new.variable
---- @field id string Key in the config file used to store the variable.
+--- @field id string|number Key in the config file used to store the variable.
 --- @field table table The table to save the data to.
 --- @field defaultSetting unknown? *Optional*. If `id` does not exist in the table, it will be initialised to this value.
 --- @field inGameOnly boolean? *Default*: `false`. If true, the setting containing this variable will be disabled if the game is on main menu.

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseMCMTableVariable.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseMCMTableVariable.lua
@@ -7,7 +7,7 @@
 --- The TableVariable can be used to save multiple changes to a config file only when the menu is closed. Load the config file with `mwse.loadConfig()`, pass it to any TableVariables in your MCM, and then save it using the `template:saveOnClose()` function.
 --- @class mwseMCMTableVariable : mwseMCMVariable
 --- @field defaultSetting unknown If `id` does not exist in the table, it will be initialised to this value.
---- @field id string Key in the config file used to store the variable.
+--- @field id string|number Key in the config file used to store the variable.
 --- @field table table The table to save the data to.
 mwseMCMTableVariable = {}
 

--- a/misc/package/Data Files/MWSE/core/meta/lib/mwse/mcm.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mwse/mcm.lua
@@ -961,7 +961,7 @@ function mwse.mcm.createSlider(parent, data) end
 --- Creates a new TableVariable.
 --- @param variable mwse.mcm.createTableVariable.variable This table accepts the following values:
 --- 
---- `id`: string — Key in the config file used to store the variable.
+--- `id`: string|number — Key in the config file used to store the variable.
 --- 
 --- `table`: table — The table to save the data to.
 --- 
@@ -979,7 +979,7 @@ function mwse.mcm.createTableVariable(variable) end
 
 ---Table parameter definitions for `mwse.mcm.createTableVariable`.
 --- @class mwse.mcm.createTableVariable.variable
---- @field id string Key in the config file used to store the variable.
+--- @field id string|number Key in the config file used to store the variable.
 --- @field table table The table to save the data to.
 --- @field defaultSetting unknown? *Optional*. If `id` does not exist in the table, it will be initialised to this value.
 --- @field inGameOnly boolean? *Default*: `false`. If true, the setting containing this variable will be disabled if the game is on main menu.


### PR DESCRIPTION
the documentation says the `id` field of a `TableVariable` must be a `string`, but the `mcm` code allows for it to be a `number`

documentation has been rebuilt