### PR TITLE
MCM: Error out if using a MCM component before `modConfigReady`

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
@@ -6,6 +6,10 @@
 --- The warnings arise because each field set here is also 'set' in the annotations in the core\meta\ folder.
 --- @diagnostic disable: duplicate-set-field
 
+if not tes3.isInitialized() then
+	error("Trying to use an MCM Component before \"modConfigReady\" event triggered.")
+end
+
 --- @class mwseMCMComponent
 local Component = {}
 Component.componentType = "Component"

--- a/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
@@ -6,8 +6,11 @@
 --- The warnings arise because each field set here is also 'set' in the annotations in the core\meta\ folder.
 --- @diagnostic disable: duplicate-set-field
 
+-- MCM Components can't be used before "initialized" event as they read GMST values.
 if not tes3.isInitialized() then
-	error("Trying to use an MCM Component before \"modConfigReady\" event triggered.")
+	error(debug.traceback(
+		"Trying to use an MCM Component before \"modConfigReady\" event triggered!"
+	))
 end
 
 --- @class mwseMCMComponent


### PR DESCRIPTION
This makes the cause clearer than it currently is: #506. We already errored out in this case, but the logged error message mentioned line 18 in `mcm.components.Component.lua` which wasn't quite clear that the user shouldn't call this before "modConfigReady" triggered. 