### PR TITLE
Documentation: warn about timers getting canceled before `loaded` event

### DIFF
--- a/autocomplete/definitions/global/timer.lua
+++ b/autocomplete/definitions/global/timer.lua
@@ -1,4 +1,8 @@
 return {
 	type = "lib",
-	description = "The timer library provides helper functions for creating delayed executors.",
+	description = [[The timer library provides helper functions for creating delayed executors.
+
+!!! warning "Timers get canceled when loading saves."
+	All active timers will be canceled right before the [`loaded`](../events/loaded.md) event triggers.
+]],
 }

--- a/autocomplete/definitions/global/timer/start.lua
+++ b/autocomplete/definitions/global/timer/start.lua
@@ -1,7 +1,9 @@
 return {
 	type = "function",
 	description = [[Creates a timer.
-
+!!! warning "Timers get canceled when loading saves."
+	All active timers will be canceled right before the [`loaded`](../events/loaded.md) event triggers.
+	
 !!! tip
 	It's recommended to study the [Object Lifetimes](../guides/object-lifetimes.md) guide. It describes how to safely use [tes3reference](../types/tes3reference.md) objects inside timer callbacks.]],
 	arguments = {{

--- a/docs/source/apis/timer.md
+++ b/docs/source/apis/timer.md
@@ -8,6 +8,10 @@
 
 The timer library provides helper functions for creating delayed executors.
 
+!!! warning "Timers get canceled when loading saves."
+	All active timers will be canceled right before the [`loaded`](../events/loaded.md) event triggers.
+
+
 ## Properties
 
 ### `timer.active`
@@ -149,7 +153,9 @@ timer.register(name, fn)
 <div class="search_terms" style="display: none">start</div>
 
 Creates a timer.
-
+!!! warning "Timers get canceled when loading saves."
+	All active timers will be canceled right before the [`loaded`](../events/loaded.md) event triggers.
+	
 !!! tip
 	It's recommended to study the [Object Lifetimes](../guides/object-lifetimes.md) guide. It describes how to safely use [tes3reference](../types/tes3reference.md) objects inside timer callbacks.
 

--- a/docs/source/guides/timers.md
+++ b/docs/source/guides/timers.md
@@ -2,6 +2,8 @@
 
 Timers are a way to keep track with the passage of time. They are volatile, meaning that they do not persist between saved games.
 
+!!! warning "Timers get canceled when loading saves."
+	All active timers will be canceled right before the [`loaded`](../events/loaded.md) event triggers.
 
 ## Creating a Basic Timer
 

--- a/misc/package/Data Files/MWSE/core/meta/lib/timer.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/timer.lua
@@ -3,6 +3,10 @@
 
 --- @meta
 --- The timer library provides helper functions for creating delayed executors.
+--- 
+--- !!! warning "Timers get canceled when loading saves."
+--- 	All active timers will be canceled right before the [`loaded`](../events/loaded.md) event triggers.
+--- 
 --- @class timerlib
 --- @field active any Constant to represent a timer that is actively running.
 --- @field expired any Constant to represent a timer that has completed.
@@ -32,7 +36,9 @@ function timer.delayOneFrame(callback, type) end
 function timer.register(name, fn) end
 
 --- Creates a timer.
---- 
+--- !!! warning "Timers get canceled when loading saves."
+--- 	All active timers will be canceled right before the [`loaded`](../events/loaded.md) event triggers.
+--- 	
 --- !!! tip
 --- 	It's recommended to study the [Object Lifetimes](../guides/object-lifetimes.md) guide. It describes how to safely use [tes3reference](../types/tes3reference.md) objects inside timer callbacks.
 ---


### PR DESCRIPTION
These warnings were added at the top of the `Timers` guide, the top of the `timer` API page, and in the description of the `timer.start` function.