### PR TITLE
Add support for `__call` metamethod to `event.register`

### DIFF
--- a/misc/package/Data Files/MWSE/core/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/lib/event.lua
@@ -67,19 +67,29 @@ local function remapFilter(options, showWarnings)
 	options.filter = filter.id:lower()
 end
 
+local function isCallbackValid(callback)
+	local callbackType = type(callback)
+	if callbackType == "function" then return true end
+	if callbackType ~= "table" then return false end
+
+	local callbackMeta = getmetatable(callback)
+	if callbackMeta and callbackMeta.__call then return true end
+
+	return false
+end
+
 function this.register(eventType, callback, options)
 	-- Validate event type.
 	if (type(eventType) ~= "string" or eventType == "") then
 		return error("event.register: Event type must be a valid string.")
 	end
 
-	-- Validate callback.
-	if (type(callback) ~= "function") then
+	if not isCallbackValid(callback) then
 		return error("event.register: Event callback must be a function.")
 	end
 
 	-- Make sure options is an empty table if nothing else.
-	local options = options or {}
+	options = options or {}
 
 	-- If 'doOnce' was set, wrap with a call to unregister.
 	if options.doOnce then

--- a/misc/package/Data Files/MWSE/core/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/lib/event.lua
@@ -70,10 +70,13 @@ end
 local function isCallbackValid(callback)
 	local callbackType = type(callback)
 	if callbackType == "function" then return true end
-	if callbackType ~= "table" then return false end
-
-	local callbackMeta = getmetatable(callback)
-	if callbackMeta and callbackMeta.__call then return true end
+	-- If it's a table, check if it has a `__call` metamethod.
+	if callbackType == "table" then
+		local callbackMeta = getmetatable(callback)
+		if callbackMeta and callbackMeta.__call then 
+			return true
+		end
+	end
 
 	return false
 end
@@ -130,8 +133,9 @@ function this.unregister(eventType, callback, options)
 	end
 
 	-- Validate callback.
-	if (type(callback) ~= "function") then
-		return error("event.unregister: Event callback must be a valid function.")
+
+	if not isCallbackValid(callback) then
+		return error("event.unregister: Event callback must be a function.")
 	end
 
 	-- Make sure options is an empty table if nothing else.
@@ -160,8 +164,8 @@ function this.isRegistered(eventType, callback, options)
 	end
 
 	-- Validate callback.
-	if (type(callback) ~= "function") then
-		return error("event.isRegistered: Event callback must be a valid function.")
+	if not isCallbackValid(callback) then
+		return error("event.isRegistered: Event callback must be a function.")
 	end
 
 	-- Make sure options is an empty table if nothing else.

--- a/misc/package/Data Files/MWSE/core/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/lib/event.lua
@@ -71,11 +71,9 @@ local function isCallbackValid(callback)
 	local callbackType = type(callback)
 	if callbackType == "function" then return true end
 	-- If it's a table, check if it has a `__call` metamethod.
-	if callbackType == "table" then
-		local callbackMeta = getmetatable(callback)
-		if callbackMeta and callbackMeta.__call then 
-			return true
-		end
+	local callbackMeta = getmetatable(callback)
+	if callbackMeta and callbackMeta.__call then 
+		return true
 	end
 
 	return false


### PR DESCRIPTION
`event.register` will allow tables to be registered as callbacks, provided they have a `__call` metamethod. An error is still thrown if trying to register a table without a `__call` metamethod.