### PR TITLE
Make mcm icon visible when hovering over mod label

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -402,22 +402,20 @@ local function onClickModConfigButton()
 				image.width = 16
 				image.paddingTop = 3
 			end
-			modNameButton:register(tes3.uiEvent.mouseOver, function (e)
-				imageButton:triggerEvent(tes3.uiEvent.mouseOver)
+
+			-- Forward mouseOver and mouseLeave events to the `imageButton`
+			-- This is so that the favorites icon lights up whenever hovering over the mod label.
+
+			---@param e tes3uiEventData
+			local function forwardToImageButton(e)
+				imageButton:triggerEvent(e)
 				e.source:forwardEvent(e)
-			end)
-			modNameButton:register(tes3.uiEvent.mouseLeave, function (e)
-				imageButton:triggerEvent(tes3.uiEvent.mouseLeave)
-				e.source:forwardEvent(e)
-			end)
-			entryBlock:register(tes3.uiEvent.mouseOver, function (e)
-				imageButton:triggerEvent(tes3.uiEvent.mouseOver)
-				e.source:forwardEvent(e)
-			end)
-			entryBlock:register(tes3.uiEvent.mouseLeave, function (e)
-				imageButton:triggerEvent(tes3.uiEvent.mouseLeave)
-				e.source:forwardEvent(e)
-			end)
+			end
+
+			modNameButton:register(tes3.uiEvent.mouseOver, forwardToImageButton)
+			modNameButton:register(tes3.uiEvent.mouseLeave, forwardToImageButton)
+			entryBlock:register(tes3.uiEvent.mouseOver, forwardToImageButton)
+			entryBlock:register(tes3.uiEvent.mouseLeave, forwardToImageButton)
 		end
 
 		-- Create container for mod content. This will be deleted whenever the pane is reloaded.

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -56,7 +56,7 @@ end
 mwse.mcm = require("mcm.mcm")
 mwse.mcm.i18n = mwse.loadTranslations("mcm")
 
--- credit to Pherim for the default icons
+-- credit to Pherim and MelchiorDahrk for the default icons
 local favoriteIcons = {
 	id = "UnFavoriteButton",
 	idle = "textures/mwse/menu_modconfig_favorite.tga",

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -297,7 +297,9 @@ local function onClickModConfigButton()
 	tes3.worldController.menuClickSound:play()
 
 	local menu = tes3ui.findMenu("MWSE:ModConfigMenu")
-	if (not menu) then
+	if menu then
+		menu.visible = true
+	else
 		-- Create the main menu frame.
 		menu = tes3ui.createMenu({ id = "MWSE:ModConfigMenu", dragFrame = true })
 		menu.text = mwse.mcm.i18n("Mod Configuration")
@@ -377,6 +379,7 @@ local function onClickModConfigButton()
 
 			local modNameButton = entryBlock:createTextSelect({ id = "ModEntry", text = package.name })
 			modNameButton:register("mouseClick", onClickModName)
+			
 			modNameButton.wrapText = true
 			modNameButton.widthProportional = 0.95
 			modNameButton.borderRight = 16
@@ -399,6 +402,22 @@ local function onClickModConfigButton()
 				image.width = 16
 				image.paddingTop = 3
 			end
+			modNameButton:register(tes3.uiEvent.mouseOver, function (e)
+				imageButton:triggerEvent(tes3.uiEvent.mouseOver)
+				e.source:forwardEvent(e)
+			end)
+			modNameButton:register(tes3.uiEvent.mouseLeave, function (e)
+				imageButton:triggerEvent(tes3.uiEvent.mouseLeave)
+				e.source:forwardEvent(e)
+			end)
+			entryBlock:register(tes3.uiEvent.mouseOver, function (e)
+				imageButton:triggerEvent(tes3.uiEvent.mouseOver)
+				e.source:forwardEvent(e)
+			end)
+			entryBlock:register(tes3.uiEvent.mouseLeave, function (e)
+				imageButton:triggerEvent(tes3.uiEvent.mouseLeave)
+				e.source:forwardEvent(e)
+			end)
 		end
 
 		-- Create container for mod content. This will be deleted whenever the pane is reloaded.
@@ -450,8 +469,7 @@ local function onClickModConfigButton()
 				end
 			end
 		end
-	else
-		menu.visible = true
+		
 	end
 
 	-- Hide main menu.

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -58,18 +58,17 @@ mwse.mcm.i18n = mwse.loadTranslations("mcm")
 
 -- credit to Pherim for the default icons
 local favoriteIcons = {
-	idle = "textures/mwse/menu_modconfig_favorite_idle.dds",
-	-- hover over a favorite to remove it
-	over = "textures/mwse/menu_modconfig_favorite_over.dds",
-	pressed = "textures/mwse/menu_modconfig_favorite_pressed.dds",
-	-- id = "FavoriteButton"
+	id = "UnFavoriteButton",
+	idle = "textures/mwse/menu_modconfig_favorite.tga",
+	over = "textures/mwse/menu_modconfig_favorite_unset.tga",
+	pressed = "textures/mwse/menu_modconfig_favorite_unset.tga",
 }
 
 local nonFavoriteIcons = {
-	idle = "textures/mwse/menu_modconfig_nonfavorite_idle.dds",
-	-- hover over a favorite to remove it
-	over = "textures/mwse/menu_modconfig_nonfavorite_over.dds",
-	pressed = "textures/mwse/menu_modconfig_nonfavorite_pressed.dds",
+	id = "FavoriteButton",
+	idle = "textures/mwse/menu_modconfig_favorite.tga",
+	over = "textures/mwse/menu_modconfig_favorite_set.tga",
+	pressed = "textures/mwse/menu_modconfig_favorite_set.tga",
 }
 
 --- Checks to see if a mod is favorited.
@@ -297,9 +296,7 @@ local function onClickModConfigButton()
 	tes3.worldController.menuClickSound:play()
 
 	local menu = tes3ui.findMenu("MWSE:ModConfigMenu")
-	if menu then
-		menu.visible = true
-	else
+	if (not menu) then
 		-- Create the main menu frame.
 		menu = tes3ui.createMenu({ id = "MWSE:ModConfigMenu", dragFrame = true })
 		menu.text = mwse.mcm.i18n("Mod Configuration")
@@ -373,19 +370,17 @@ local function onClickModConfigButton()
 			entryBlock.flowDirection = tes3.flowDirection.leftToRight
 			entryBlock.autoHeight = true
 			entryBlock.autoWidth = true
-
 			entryBlock.widthProportional = 1.0
 			entryBlock.childAlignY = 0.5
 
 			local modNameButton = entryBlock:createTextSelect({ id = "ModEntry", text = package.name })
 			modNameButton:register("mouseClick", onClickModName)
-			
 			modNameButton.wrapText = true
 			modNameButton.widthProportional = 0.95
 			modNameButton.borderRight = 16
 			modNameButton.heightProportional = 1
 
-			local iconTable = isFavorite(package.name) and favoriteIcons or nonFavoriteIcons
+			local iconTable = isFavorite and favoriteIcons or nonFavoriteIcons
 
 			local imageButton = entryBlock:createImageButton(iconTable)
 			updateFavoriteImageButton(imageButton, isFavorite(package.name))
@@ -393,6 +388,8 @@ local function onClickModConfigButton()
 			imageButton.absolutePosAlignX = .97
 			-- imageButton.absolutePosAlignY = 1.0
 			imageButton.absolutePosAlignY = 0.5
+			imageButton.consumeMouseEvents = true
+			imageButton.visible = isFavorite(package.name)
 
 			imageButton:register(tes3.uiEvent.mouseClick, onClickFavoriteButton)
 			---@param image tes3uiElement
@@ -403,19 +400,14 @@ local function onClickModConfigButton()
 				image.paddingTop = 3
 			end
 
-			-- Forward mouseOver and mouseLeave events to the `imageButton`
-			-- This is so that the favorites icon lights up whenever hovering over the mod label.
-
-			---@param e tes3uiEventData
-			local function forwardToImageButton(e)
-				imageButton:triggerEvent(e)
-				e.source:forwardEvent(e)
-			end
-
-			modNameButton:register(tes3.uiEvent.mouseOver, forwardToImageButton)
-			modNameButton:register(tes3.uiEvent.mouseLeave, forwardToImageButton)
-			entryBlock:register(tes3.uiEvent.mouseOver, forwardToImageButton)
-			entryBlock:register(tes3.uiEvent.mouseLeave, forwardToImageButton)
+			local onHover = function() imageButton.visible = true end
+			local onLeave = function() imageButton.visible = isFavorite(package.name) end
+			entryBlock:registerAfter(tes3.uiEvent.mouseOver, onHover)
+			entryBlock:registerAfter(tes3.uiEvent.mouseLeave, onLeave)
+			modNameButton:registerAfter(tes3.uiEvent.mouseOver, onHover)
+			modNameButton:registerAfter(tes3.uiEvent.mouseLeave, onLeave)
+			imageButton:registerAfter(tes3.uiEvent.mouseOver, onHover)
+			imageButton:registerAfter(tes3.uiEvent.mouseLeave, onLeave)
 		end
 
 		-- Create container for mod content. This will be deleted whenever the pane is reloaded.
@@ -467,7 +459,8 @@ local function onClickModConfigButton()
 				end
 			end
 		end
-		
+	else
+		menu.visible = true
 	end
 
 	-- Hide main menu.


### PR DESCRIPTION
I did some rudimentary testing and everything seems to work fine, but a bit more testing may be required. The changes were fairly minimal.

- This was implemented by triggering making the `mouseOver` and `mouseLeave` events for the `modNameButton` and `modEntryBlock` trigger the corresponding events for the `imageButton`.
- I had to register events to both `modNameButton` and `modEntryBlock` so that the icon would show when hovering over the mod label and when hovering over the whitespace in between the mod label and the favorites icon.