### PR TITLE
Reduce usage of `getComponent` in `SideBarPage.lua`

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/SideBarPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/SideBarPage.lua
@@ -9,6 +9,10 @@
 
 local Parent = require("mcm.components.pages.Page")
 
+local Info = require("mcm.components.infos.Info")
+local MouseOverInfo = require("mcm.components.infos.MouseOverInfo")
+local MouseOverPage = require("mcm.components.pages.MouseOverPage")
+
 --- @class mwseMCMSideBarPage
 --- @field sidebarComponents mwseMCMComponent[] *Deprecated*
 local SideBarPage = Parent:new()
@@ -19,7 +23,7 @@ SideBarPage.triggerOff = "MCM:MouseLeave"
 --- @return mwseMCMSideBarPage page
 function SideBarPage:new(data)
 	local t = Parent:new(data) --[[@as mwseMCMSideBarPage]]
-	t.sidebar = self:getComponent({ class = "MouseOverPage" }) --[[@as mwseMCMMouseOverPage]]
+	t.sidebar = MouseOverPage:new({ parentComponent = self})
 
 	setmetatable(t, self)
 	self.__index = self
@@ -56,20 +60,19 @@ function SideBarPage:createRightColumn(parentBlock)
 		-- or description
 	elseif self.description then
 		-- By default, sidebar is a mouseOver description pane
-		local sidebarInfo = self:getComponent({
+		local sidebarInfo = Info:new({
 			-- label = self.label,
 			text = self.description,
-			class = "Info",
-		}) --[[@as mwseMCMInfo]]
+			parentComponent = self
+		})
 		sidebarInfo:create(defaultView)
 	end
 
-	-- mouseover shows descriptions of settings
-	local mouseOver = self:getComponent({
-		-- label = self.label,
+	-- MouseOverInfo shows descriptions of settings.
+	local mouseOver = MouseOverInfo:new({
 		text = self.description or "",
-		class = "MouseOverInfo",
-	}) --[[@as mwseMCMMouseOverInfo]]
+		parentComponent = self
+	})
 	mouseOver:create(mouseoverView)
 	mouseOver.elements.outerContainer.visible = false
 	self.elements.mouseOver = mouseOver


### PR DESCRIPTION
## Summary
In three different parts of the `SideBarPage.lua` file, the `Component:getComponent` function was used to create a new instance of a class. This PR replaces each call to `Component:getComponent` with the constructor of the relevant class.

## Description

Each of those calls to `getComponent(self, data)` would ultimately result in the following lines of code being executed:
```lua
data.parentComponent = self

... -- complicated logic to fetch `componentClass`

return componentClass:new(data)
```

Since `componentClass` is already known ahead of time, it's possible to replace `getComponent(self, data)` with `componentClass:new(data)`. The only other difference is that instead of writing `data.class = className`, we write `data.parentComponent = self`.

Here are some consequences of these changes:
- In my opinion, the code is now easier to follow, since more of the logic is happening inside `SideBarPage.lua`, without needing to use the `getComponent` method that was defined in a separate file.
- It does not result in a net increase in lines of code (ignoring the three import statements that were added).
- After these changes, `getComponent` is only used in two places: `Category.lua` and `Template.lua`.
    - In both uses, `getComponent` just makes sure that a `component` is actually an instance of `mwseMCMComponent`, i.e. it's only performing data sanitation.
    - In my opinion, this makes it more clear what the intended use-case of `getComponent` is.

## Comments

If this both PR and #533 get merged, then it may be worth deleting `getComponent` altogether, and just replacing each call to `getComponent` with a call to `fileUtils.getComponentClass`. (The Lua code-dump indicates that no mods are using `Component:getComponent`.)