### PR TITLE
Fix bugs/inconsistencies in `mwse_safeObjectHandle.lua`

### DIFF
--- a/misc/package/Data Files/MWSE/core/lib/mwse_safeObjectHandle.lua
+++ b/misc/package/Data Files/MWSE/core/lib/mwse_safeObjectHandle.lua
@@ -48,7 +48,7 @@ end
 
 function handleMetatable.__index(handle, key)
 	-- Try to look things up in the `SafeHandle` class.
-	local val = rawget(SafeHandle, key)
+	local val = SafeHandle[key]
 	if val ~= nil then return val end
 
 	-- Try to look things up in the stored object, if it still exists.


### PR DESCRIPTION
There were a couple bugs/inconsistencies in the `mwse_safeObjectHandle.lua` file that have been cleaned up in this PR.

Things that were fixed/changed:
1. Previously, every `safeHandle` instance got its own copy of the `getObject` and `valid` functions. 
    -This PR ensures that there is only one copy of the `getObject` and `valid` functions, and that `handle` objects look up those functions via the `__index` metamethod.
2. Previously, the `__index` metamethod began with the line `if rawget(self, key) then`. However, the `__index` metamethod is triggered precisely when `rawget(self, key) == nil`. So, this check has been removed.
3. There was an `__eq` metamethod defined for safe handles. However, in practice, this metamethod will never be triggered. This is because `Lua` only calls the `__eq` metamethod on objects of the same type, and `getObject()` has type `userdata` while `handle` has type `table`.
4. The `__tojson` metamethod tried to reroute to the stored object's `__tojson` metamethod, but instead would call `object:__tojson()`. However, it is not the case that the `__tojson` metamethod is always equal to `object.__tojson`.
    - The previous implementation of `__tojson` was also inconsistent with the previous implementation of `__tostring`: the `__tostring` metamethod would call the stored object's `__tostring` metamethod instead of trying to index the stored object's `__tostring` field.

There were also a couple stylistic changes made, with the attempt of making the file easier to read:
1. In a few different places in the file, I replaced `rawget(handle, "_object")` with `handle:getObject()`, since `handle:getObject()` is defined as `rawget(handle, "_object")`. 
2. Before this PR, the result of `handle:getObject()` was assigned to a variable called `reference`. But there are no restrictions on the types of things that can be placed inside a `SafeObjectHandle`. So, I changed the name of the `reference` variable to be `object`. 
3. The variable name `this` was used to store the various `SafeObjectHandle` functionalities. I renamed this variable to be `SafeHandle` since I felt that was a bit more descriptive.

Additionally, I renamed the `safeHandle:valid()` method to `safeHandle:isValid()`. (But the old version was preserved for backwards compatibility.)