### PR TITLE
Support `mwse.mcm.createtemplate`

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/fileUtils.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/fileUtils.lua
@@ -30,6 +30,7 @@ for filePath, dir, fileName in lfs.walkdir("data files\\mwse\\core\\mcm\\compone
 	componentPaths[className] = luaPath
 end
 -- Add backwards compatibility by redirecting old component names to new ones.
+componentPaths.template = componentPaths.Template
 componentPaths.HyperLink = componentPaths.Hyperlink
 componentPaths.SidebarPage = componentPaths.SideBarPage
 


### PR DESCRIPTION
Previously, the `create` methods were case-insensitive.

The lua code dump suggests that only two mods ever made use of this functionality: "Brutal Backstabbing" and "Better Sorting Names". And both those mods only utilized the case-insensitivity to call `mwse.mcm.createtemplate` instead of `mwse.mcm.createTemplate`. This change adds backwards compatibility for those mods.

This is done by saying that the path of the `template` class is equal to the path of the `Template` class. This results in a `createtemplate` function being generated. (This is similar to how `createHyperLink` is supported by piggybacking off of `createHyperlink`.)