### PR TITLE
Add `Dropdown:convertToLabelValue`

### DIFF
--- a/autocomplete/definitions/namedTypes/mwseMCMDropdown/convertToLabelValue.lua
+++ b/autocomplete/definitions/namedTypes/mwseMCMDropdown/convertToLabelValue.lua
@@ -1,0 +1,15 @@
+return {
+	type = "method",
+	description = [[This function specifies how values stored in the `variable` field should correspond to values displayed by this setting.
+The default behavior is to return the `label` of the [`mwseMCMDropdownOption`](./mwseMCMDropdownOption.md) with a given `variableValue`.]],
+	arguments = {{ 
+		name = "variableValue", 
+		type = "unknown", 
+		description = "The value of a [`mwseMCMDropdownOption`](./mwseMCMDropdownOption.md) stored in `self.options`." 
+	}},
+	returns = {{
+		name = "labelValue", 
+		type = "string",
+		description = "The label of the corresponding [`mwseMCMDropdownOption`](./mwseMCMDropdownOption.md)." 
+	}},
+}

--- a/docs/source/types/mwseMCMDropdown.md
+++ b/docs/source/types/mwseMCMDropdown.md
@@ -371,6 +371,7 @@ local result = myObject:checkDisabled()
 <div class="search_terms" style="display: none">converttolabelvalue</div>
 
 This function specifies how values stored in the `variable` field should correspond to values displayed by this setting.
+The default behavior is to return the `label` of the [`mwseMCMDropdownOption`](./mwseMCMDropdownOption.md) with a given `variableValue`.
 
 ```lua
 local labelValue = myObject:convertToLabelValue(variableValue)
@@ -378,11 +379,11 @@ local labelValue = myObject:convertToLabelValue(variableValue)
 
 **Parameters**:
 
-* `variableValue` (number)
+* `variableValue` (unknown): The value of a [`mwseMCMDropdownOption`](./mwseMCMDropdownOption.md) stored in `self.options`.
 
 **Returns**:
 
-* `labelValue` (number, string)
+* `labelValue` (string): The label of the corresponding [`mwseMCMDropdownOption`](./mwseMCMDropdownOption.md).
 
 ***
 

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
@@ -131,4 +131,13 @@ function Dropdown:createOuterContainer(parentBlock)
 	self.elements.outerContainer.paddingRight = self.indent -- * 2
 end
 
+function Dropdown:convertToLabelValue(variableValue)
+	-- Find the matching option and return its label.
+	for _, option in ipairs(self.options) do
+		if variableValue == option.value then
+			return option.label
+		end
+	end
+end
+
 return Dropdown

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseMCMDropdown.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseMCMDropdown.lua
@@ -13,6 +13,12 @@
 --- @field pressedColor number[] The color used when the dropdown is being pressed. By default set to `tes3ui.getPalette(tes3.palette.normalPressedColor)`.
 mwseMCMDropdown = {}
 
+--- This function specifies how values stored in the `variable` field should correspond to values displayed by this setting.
+--- The default behavior is to return the `label` of the [`mwseMCMDropdownOption`](./mwseMCMDropdownOption.md) with a given `variableValue`.
+--- @param variableValue unknown The value of a [`mwseMCMDropdownOption`](./mwseMCMDropdownOption.md) stored in `self.options`.
+--- @return string labelValue The label of the corresponding [`mwseMCMDropdownOption`](./mwseMCMDropdownOption.md).
+function mwseMCMDropdown:convertToLabelValue(variableValue) end
+
 --- Creates the expanded dropdown UI element parent dropdownParent and the text select entries inside for each option of the dropdown. If the dropdown is expanded, then calling this method will close the dropdown.
 function mwseMCMDropdown:createDropdown() end
 


### PR DESCRIPTION
Previously, `Dropdown` inherited the default implementation of `convertToLabelValue`. This basically resulted in `option.value` being returned instead of `option.label`. This change seeks to remedy that.

This change makes `Dropdown:convertToLabelValue(variableValue)` find the first `option` with `option.value == variableValue`, and then it returns `option.label`.