### PR TITLE
Bug fix: show `Dropdown.description` when hovering over options

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
@@ -71,6 +71,10 @@ function Dropdown:createDropdown()
 		end
 		self.elements.dropdown = dropdown
 		dropdown:getTopLevelMenu():updateLayout()
+		
+		-- Show the setting description when picking an option
+		self:registerMouseOverElements(dropdown.children)
+		self:registerMouseOverElements({dropdown})
 
 		-- Destroy dropdown
 	else
@@ -109,6 +113,8 @@ function Dropdown:makeComponent(parentBlock)
 
 	local textBox = border:createTextSelect({ text = "---" })
 	self.elements.textBox = textBox
+	-- Show the setting description when hovering over the text box.
+	table.insert(self.mouseOvers, textBox)
 
 	textBox.color = tes3ui.getPalette(tes3.palette.disabledColor)
 	textBox.widget.idle = self.idleColor


### PR DESCRIPTION
Before this fix, the description of a `mwseMCMDropdown` would only be shown when hovering over its label. When hovering over the `thinBorder` that houses the currently selected option, the description of the parent component would be shown, instead of the description of the `Dropdown` element.

This change makes the description be shown when hovering over the `thinBorder` element. It also allows the description to be shown when selecting an option (when the dropdown menu is active).