### PR TITLE
Hotfix for log spam caused by latest commit

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
@@ -87,7 +87,7 @@ end
 function Component:registerMouseOverElements(mouseOverList)
 	for _, element in ipairs(mouseOverList or {}) do
 		element:register("mouseOver", function(e)
-			event.trigger("MCM:MouseOver", self)
+			event.trigger("MCM:MouseOver", {component = self})
 			e.source:forwardEvent(e)
 		end)
 		element:register("mouseLeave", function(e)

--- a/misc/package/Data Files/MWSE/core/mcm/components/infos/MouseOverInfo.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/infos/MouseOverInfo.lua
@@ -30,9 +30,9 @@ end
 function MouseOverInfo:makeComponent(parentBlock)
 	Parent.makeComponent(self, parentBlock)
 
-	--- @param component mwseMCMMouseOverInfo
-	local function updateInfo(component)
-		self:updateInfo(component)
+	--- @param e {component: mwseMCMMouseOverInfo}
+	local function updateInfo(e)
+		self:updateInfo(e.component)
 	end
 
 	-- Register events

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/SideBarPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/SideBarPage.lua
@@ -78,8 +78,9 @@ function SideBarPage:createRightColumn(parentBlock)
 	self.elements.mouseOver = mouseOver
 
 	--- event to hide default and show mouseover
-	--- @param component mwseMCMComponent
-	local function doMouseOver(component)
+	--- @param e {component: mwseMCMComponent}
+	local function doMouseOver(e)
+		local component = e.component
 		-- This results in `component:getMouseOverText()` getting called twice
 		-- per mouseover update. Not sure of a nice way around that.
 		-- This should be fine for most implementations of `convertToLabelValue`.


### PR DESCRIPTION
The most recent commit caused a bunch of log spam:
```
'getMouseOverText' (a nil value)
stack traceback:
    .\Data Files\MWSE\core\lib\event.lua:328: in function 'getMouseOverText'
    ...a Files\MWSE\core\mcm\components\infos\mouseoverinfo.lua:24: in function 'updateInfo'
    ...a Files\MWSE\core\mcm\components\infos\mouseoverinfo.lua:35: in function <...a Files\MWSE\core\mcm\components\infos\mouseoverinfo.lua:34>
```
This was happening because the `MCM:MouseOver` event was structured so that the `eventData` was either a `mwseMCMComponent`, or an empty `table`. This clashes with the `eventData` structure of every event. 
And it led to problems here because the `MouseOverInfo:updateInfo` method was being called on the `eventData` (which sometimes doubled as a `component`. In particular, the `nil` check in that function would always pass, because it was being called on an `eventData` table.

This PR fixes this by changing the structure of the `eventData` to be a table of the form `{component = component}`.

This is a hot-fix though, since I haven't updated documentation yet, and it may not be the best solution to the problem.

The Lua nexus says only one mod is using `MCM:MouseOver`, and that mod is Seph's Hud Customizer, which is using it to highlight certain UI elements. But that mod includes `nil` checks so it should be compatible with the new event structure. (It just won't do anything until the mod is updated.)