### PR TITLE
Add `supportsActivate` property

### DIFF
--- a/MWSE/TES3Item.cpp
+++ b/MWSE/TES3Item.cpp
@@ -2,6 +2,7 @@
 
 #include "TES3Actor.h"
 #include "TES3ItemData.h"
+#include "TES3Light.h"
 #include "TES3Misc.h"
 
 #include "CodePatchUtil.h"
@@ -59,6 +60,9 @@ namespace TES3 {
 	}
 
 	bool Item::getCanCarry() const {
+		if (objectType == TES3::ObjectType::Light) {
+			return static_cast<const TES3::Light*>(this)->getCanCarry();
+		}
 		return true;
 	}
 

--- a/MWSE/TES3Item.cpp
+++ b/MWSE/TES3Item.cpp
@@ -58,6 +58,10 @@ namespace TES3 {
 		return value;
 	}
 
+	bool Item::getCanCarry() const {
+		return true;
+	}
+
 	sol::table Item::getStolenList_lua(sol::this_state ts) {
 		auto stolenList = getStolenList();
 		if (!stolenList) {

--- a/MWSE/TES3Item.h
+++ b/MWSE/TES3Item.h
@@ -15,6 +15,7 @@ namespace TES3 {
 		bool promptsEquipmentReevaluation() const;
 
 		int getBaseBarterValue(ItemData* itemData = nullptr, bool useSoulValue = true, bool useDurability = true) const;
+		bool getCanCarry() const;
 
 		sol::table getStolenList_lua(sol::this_state ts);
 

--- a/MWSE/TES3Object.cpp
+++ b/MWSE/TES3Object.cpp
@@ -109,12 +109,18 @@ namespace TES3 {
 		// Make sure we aren't dealing with references.
 		BaseObject* object = getBaseObject();
 
-		if (object->isItem_lua()) {
-			return true;
+		if (object->isItem()) {
+			return static_cast<const TES3::Item*>(this)->getCanCarry();
 		}
 
-		if (object->isActor()) {
-			return !TES3::WorldController::get()->getMobilePlayer()->getFlagInCombat();
+		if (object->objectType == ObjectType::NPC || object->objectType == ObjectType::Creature) {
+			const auto macp = WorldController::get() ? WorldController::get()->getMobilePlayer() : nullptr;
+			if (macp) {
+				return macp->getFlagInCombat();
+			}
+			else {
+				return true;
+			}
 		}
 
 		switch (object->objectType) {
@@ -173,22 +179,6 @@ namespace TES3 {
 		default:
 			return false;
 		}
-	}
-
-	// In addition to object type checks in isItem, this method also checks canCarry flag on lights.
-	bool BaseObject::isItem_lua() const {
-		if (!isItem()) {
-			return false;
-		}
-
-		if (objectType == TES3::ObjectType::Light) {
-			if (static_cast<const TES3::Light*>(this)->getCanCarry()) {
-				return true;
-			}
-			return false;
-		}
-
-		return true;
 	}
 
 	bool BaseObject::isWeaponOrAmmo() const {

--- a/MWSE/TES3Object.cpp
+++ b/MWSE/TES3Object.cpp
@@ -106,14 +106,19 @@ namespace TES3 {
 	}
 
 	bool BaseObject::supportsActivate() const {
-		// Make sure we aren't dealing with references.
-		BaseObject* object = getBaseObject();
-
-		if (object->isItem()) {
-			return static_cast<const TES3::Item*>(this)->getCanCarry();
+		auto asObject = static_cast<const Object*>(this);
+		if (asObject && asObject->getIsLocationMarker()) {
+			return false;
 		}
 
-		if (object->objectType == ObjectType::NPC || object->objectType == ObjectType::Creature) {
+		// Make sure we aren't dealing with references.
+		BaseObject* asBase = getBaseObject();
+
+		if (asBase->isItem()) {
+			return static_cast<const Item*>(this)->getCanCarry();
+		}
+
+		if (asBase->objectType == ObjectType::NPC || asBase->objectType == ObjectType::Creature) {
 			const auto macp = WorldController::get() ? WorldController::get()->getMobilePlayer() : nullptr;
 			if (macp) {
 				return macp->getFlagInCombat();
@@ -123,7 +128,7 @@ namespace TES3 {
 			}
 		}
 
-		switch (object->objectType) {
+		switch (asBase->objectType) {
 		case TES3::ObjectType::Activator:
 		case TES3::ObjectType::Container:
 		case TES3::ObjectType::Door:
@@ -131,8 +136,6 @@ namespace TES3 {
 		default:
 			return false;
 		}
-
-		return false;
 	}
 
 	BaseObject* BaseObject::getBaseObject() const {

--- a/MWSE/TES3Object.cpp
+++ b/MWSE/TES3Object.cpp
@@ -105,7 +105,7 @@ namespace TES3 {
 		return BaseObject_writeFileHeader(this, file);
 	}
 
-	bool BaseObject::canActivate() const {
+	bool BaseObject::supportsActivate() const {
 		// Make sure we aren't dealing with references.
 		BaseObject* object = getBaseObject();
 
@@ -177,16 +177,18 @@ namespace TES3 {
 
 	// In addition to object type checks in isItem, this method also checks canCarry flag on lights.
 	bool BaseObject::isItem_lua() const {
-		if (isItem()) {
-			if (objectType == TES3::ObjectType::Light) {
-				if (static_cast<const TES3::Light*>(this)->getCanCarry()) {
-					return true;
-				}
-				return false;
-			}
-			return true;
+		if (!isItem()) {
+			return false;
 		}
-		return false;
+
+		if (objectType == TES3::ObjectType::Light) {
+			if (static_cast<const TES3::Light*>(this)->getCanCarry()) {
+				return true;
+			}
+			return false;
+		}
+
+		return true;
 	}
 
 	bool BaseObject::isWeaponOrAmmo() const {

--- a/MWSE/TES3Object.cpp
+++ b/MWSE/TES3Object.cpp
@@ -105,6 +105,30 @@ namespace TES3 {
 		return BaseObject_writeFileHeader(this, file);
 	}
 
+	bool BaseObject::canActivate() const {
+		// Make sure we aren't dealing with references.
+		BaseObject* object = getBaseObject();
+
+		if (object->isItem_lua()) {
+			return true;
+		}
+
+		if (object->isActor()) {
+			return !TES3::WorldController::get()->getMobilePlayer()->getFlagInCombat();
+		}
+
+		switch (object->objectType) {
+		case TES3::ObjectType::Activator:
+		case TES3::ObjectType::Container:
+		case TES3::ObjectType::Door:
+			return true;
+		default:
+			return false;
+		}
+
+		return false;
+	}
+
 	BaseObject* BaseObject::getBaseObject() const {
 		BaseObject* object = const_cast<BaseObject*>(this);
 
@@ -149,6 +173,20 @@ namespace TES3 {
 		default:
 			return false;
 		}
+	}
+
+	// In addition to object type checks in isItem, this method also checks canCarry flag on lights.
+	bool BaseObject::isItem_lua() const {
+		if (isItem()) {
+			if (objectType == TES3::ObjectType::Light) {
+				if (static_cast<const TES3::Light*>(this)->getCanCarry()) {
+					return true;
+				}
+				return false;
+			}
+			return true;
+		}
+		return false;
 	}
 
 	bool BaseObject::isWeaponOrAmmo() const {

--- a/MWSE/TES3Object.cpp
+++ b/MWSE/TES3Object.cpp
@@ -110,6 +110,9 @@ namespace TES3 {
 		BaseObject* object = getBaseObject();
 
 		if (object->isItem()) {
+			if (object->objectType == TES3::ObjectType::Light) {
+				return static_cast<const TES3::Light*>(this)->getCanCarry();
+			}
 			return static_cast<const TES3::Item*>(this)->getCanCarry();
 		}
 

--- a/MWSE/TES3Object.cpp
+++ b/MWSE/TES3Object.cpp
@@ -110,9 +110,6 @@ namespace TES3 {
 		BaseObject* object = getBaseObject();
 
 		if (object->isItem()) {
-			if (object->objectType == TES3::ObjectType::Light) {
-				return static_cast<const TES3::Light*>(this)->getCanCarry();
-			}
 			return static_cast<const TES3::Item*>(this)->getCanCarry();
 		}
 

--- a/MWSE/TES3Object.h
+++ b/MWSE/TES3Object.h
@@ -249,10 +249,13 @@ namespace TES3 {
 		// Custom functions.
 		//
 
+		bool canActivate() const;
+
 		BaseObject* getBaseObject() const;
 
 		bool isActor() const;
 		bool isItem() const;
+		bool isItem_lua() const;
 		bool isWeaponOrAmmo() const;
 		const char* getSourceFilename() const;
 

--- a/MWSE/TES3Object.h
+++ b/MWSE/TES3Object.h
@@ -249,7 +249,7 @@ namespace TES3 {
 		// Custom functions.
 		//
 
-		bool canActivate() const;
+		bool supportsActivate() const;
 
 		BaseObject* getBaseObject() const;
 

--- a/MWSE/TES3Object.h
+++ b/MWSE/TES3Object.h
@@ -255,7 +255,6 @@ namespace TES3 {
 
 		bool isActor() const;
 		bool isItem() const;
-		bool isItem_lua() const;
 		bool isWeaponOrAmmo() const;
 		const char* getSourceFilename() const;
 

--- a/MWSE/TES3ObjectLua.h
+++ b/MWSE/TES3ObjectLua.h
@@ -21,7 +21,6 @@ namespace mwse::lua {
 		usertypeDefinition["__tojson"] = &TES3::BaseObject::toJson;
 
 		// Functions exposed as properties.
-		usertypeDefinition["canActivate"] = sol::readonly_property(&TES3::BaseObject::canActivate);
 		usertypeDefinition["id"] = sol::readonly_property(&TES3::BaseObject::getObjectID);
 		usertypeDefinition["isItem"] = sol::readonly_property(&TES3::BaseObject::isItem_lua);
 		usertypeDefinition["sourceMod"] = sol::readonly_property(&TES3::BaseObject::getSourceFilename);
@@ -31,6 +30,7 @@ namespace mwse::lua {
 		usertypeDefinition["persistent"] = sol::property(&TES3::BaseObject::getPersistent, &TES3::BaseObject::setPersistent);
 		usertypeDefinition["blocked"] = sol::property(&TES3::BaseObject::getBlocked, &TES3::BaseObject::setBlocked);
 		usertypeDefinition["sourceless"] = sol::property(&TES3::BaseObject::getSourceless, &TES3::BaseObject::setSourceless);
+		usertypeDefinition["supportsActivate"] = sol::readonly_property(&TES3::BaseObject::supportsActivate);
 		usertypeDefinition["supportsLuaData"] = sol::property(&TES3::BaseObject::getSupportsLuaData);
 	}
 

--- a/MWSE/TES3ObjectLua.h
+++ b/MWSE/TES3ObjectLua.h
@@ -21,7 +21,9 @@ namespace mwse::lua {
 		usertypeDefinition["__tojson"] = &TES3::BaseObject::toJson;
 
 		// Functions exposed as properties.
+		usertypeDefinition["canActivate"] = sol::readonly_property(&TES3::BaseObject::canActivate);
 		usertypeDefinition["id"] = sol::readonly_property(&TES3::BaseObject::getObjectID);
+		usertypeDefinition["isItem"] = sol::readonly_property(&TES3::BaseObject::isItem_lua);
 		usertypeDefinition["sourceMod"] = sol::readonly_property(&TES3::BaseObject::getSourceFilename);
 		usertypeDefinition["modified"] = sol::property(&TES3::BaseObject::getObjectModified, &TES3::BaseObject::setObjectModified);
 		usertypeDefinition["disabled"] = sol::readonly_property(&TES3::BaseObject::getDisabled);

--- a/MWSE/TES3ObjectLua.h
+++ b/MWSE/TES3ObjectLua.h
@@ -22,7 +22,6 @@ namespace mwse::lua {
 
 		// Functions exposed as properties.
 		usertypeDefinition["id"] = sol::readonly_property(&TES3::BaseObject::getObjectID);
-		usertypeDefinition["isItem"] = sol::readonly_property(&TES3::BaseObject::isItem_lua);
 		usertypeDefinition["sourceMod"] = sol::readonly_property(&TES3::BaseObject::getSourceFilename);
 		usertypeDefinition["modified"] = sol::property(&TES3::BaseObject::getObjectModified, &TES3::BaseObject::setObjectModified);
 		usertypeDefinition["disabled"] = sol::readonly_property(&TES3::BaseObject::getDisabled);

--- a/autocomplete/definitions/namedTypes/tes3baseObject/isItem.lua
+++ b/autocomplete/definitions/namedTypes/tes3baseObject/isItem.lua
@@ -1,5 +1,0 @@
-return {
-	type = "value",
-	description = [[If true, the object is an item. This property is false for non-carriable lights.]],
-	valuetype = "boolean",
-}

--- a/autocomplete/definitions/namedTypes/tes3baseObject/isItem.lua
+++ b/autocomplete/definitions/namedTypes/tes3baseObject/isItem.lua
@@ -1,0 +1,5 @@
+return {
+	type = "value",
+	description = [[If true, the object is an item. This property is false for non-carriable lights.]],
+	valuetype = "boolean",
+}

--- a/autocomplete/definitions/namedTypes/tes3baseObject/supportsActivate.lua
+++ b/autocomplete/definitions/namedTypes/tes3baseObject/supportsActivate.lua
@@ -1,0 +1,7 @@
+return {
+	type = "value",
+	description = [[If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.]],
+	valuetype = "boolean",
+}

--- a/docs/source/types/tes3activator.md
+++ b/docs/source/types/tes3activator.md
@@ -66,17 +66,6 @@ The bounding box for the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3activator.md
+++ b/docs/source/types/tes3activator.md
@@ -66,6 +66,17 @@ The bounding box for the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -250,6 +261,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3actor.md
+++ b/docs/source/types/tes3actor.md
@@ -136,17 +136,6 @@ The bounding box for the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3actor.md
+++ b/docs/source/types/tes3actor.md
@@ -136,6 +136,17 @@ The bounding box for the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -287,6 +298,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3alchemy.md
+++ b/docs/source/types/tes3alchemy.md
@@ -131,17 +131,6 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3alchemy.md
+++ b/docs/source/types/tes3alchemy.md
@@ -131,6 +131,17 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -315,6 +326,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3apparatus.md
+++ b/docs/source/types/tes3apparatus.md
@@ -77,6 +77,17 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -272,6 +283,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3apparatus.md
+++ b/docs/source/types/tes3apparatus.md
@@ -77,17 +77,6 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3armor.md
+++ b/docs/source/types/tes3armor.md
@@ -134,17 +134,6 @@ See also [isWearableByBeasts](https://mwse.github.io/MWSE/types/tes3armor/#iswea
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLeftPart`
 <div class="search_terms" style="display: none">isleftpart, leftpart</div>
 

--- a/docs/source/types/tes3armor.md
+++ b/docs/source/types/tes3armor.md
@@ -134,6 +134,17 @@ See also [isWearableByBeasts](https://mwse.github.io/MWSE/types/tes3armor/#iswea
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLeftPart`
 <div class="search_terms" style="display: none">isleftpart, leftpart</div>
 
@@ -386,6 +397,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3baseObject.md
+++ b/docs/source/types/tes3baseObject.md
@@ -54,6 +54,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -117,6 +128,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3baseObject.md
+++ b/docs/source/types/tes3baseObject.md
@@ -54,17 +54,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3birthsign.md
+++ b/docs/source/types/tes3birthsign.md
@@ -66,17 +66,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3birthsign.md
+++ b/docs/source/types/tes3birthsign.md
@@ -66,6 +66,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -151,6 +162,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` ([tes3spellList](../types/tes3spellList.md), [tes3spell](../types/tes3spell.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3bodyPart.md
+++ b/docs/source/types/tes3bodyPart.md
@@ -77,6 +77,17 @@ A flag that marks this body part as used for female actors.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -283,6 +294,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3bodyPart.md
+++ b/docs/source/types/tes3bodyPart.md
@@ -77,17 +77,6 @@ A flag that marks this body part as used for female actors.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3book.md
+++ b/docs/source/types/tes3book.md
@@ -99,6 +99,17 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -294,6 +305,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3book.md
+++ b/docs/source/types/tes3book.md
@@ -99,17 +99,6 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3cell.md
+++ b/docs/source/types/tes3cell.md
@@ -288,17 +288,6 @@ If true, the cell is an interior.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isOrBehavesAsExterior`
 <div class="search_terms" style="display: none">isorbehavesasexterior, orbehavesasexterior</div>
 

--- a/docs/source/types/tes3cell.md
+++ b/docs/source/types/tes3cell.md
@@ -288,6 +288,17 @@ If true, the cell is an interior.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isOrBehavesAsExterior`
 <div class="search_terms" style="display: none">isorbehavesasexterior, orbehavesasexterior</div>
 
@@ -461,6 +472,19 @@ The cell's sun color. Only available on interior cells.
 **Returns**:
 
 * `result` ([niPackedColor](../types/niPackedColor.md))
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3class.md
+++ b/docs/source/types/tes3class.md
@@ -231,17 +231,6 @@ The path used for the class selection/level up menus, where appropriate. Custom 
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `majorSkills`
 <div class="search_terms" style="display: none">majorskills</div>
 

--- a/docs/source/types/tes3class.md
+++ b/docs/source/types/tes3class.md
@@ -231,6 +231,17 @@ The path used for the class selection/level up menus, where appropriate. Custom 
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `majorSkills`
 <div class="search_terms" style="display: none">majorskills</div>
 
@@ -437,6 +448,19 @@ The specialization for the class. Maps to values in the [`tes3.specialization`](
 **Returns**:
 
 * `result` ([tes3.specialization](../references/specializations.md))
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3clothing.md
+++ b/docs/source/types/tes3clothing.md
@@ -99,6 +99,17 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLeftPart`
 <div class="search_terms" style="display: none">isleftpart, leftpart</div>
 
@@ -338,6 +349,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3clothing.md
+++ b/docs/source/types/tes3clothing.md
@@ -99,17 +99,6 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLeftPart`
 <div class="search_terms" style="display: none">isleftpart, leftpart</div>
 

--- a/docs/source/types/tes3container.md
+++ b/docs/source/types/tes3container.md
@@ -156,6 +156,17 @@ Always returns false.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -364,6 +375,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3container.md
+++ b/docs/source/types/tes3container.md
@@ -156,17 +156,6 @@ Always returns false.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3containerInstance.md
+++ b/docs/source/types/tes3containerInstance.md
@@ -156,17 +156,6 @@ Always returns true.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3containerInstance.md
+++ b/docs/source/types/tes3containerInstance.md
@@ -156,6 +156,17 @@ Always returns true.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -375,6 +386,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3creature.md
+++ b/docs/source/types/tes3creature.md
@@ -262,17 +262,6 @@ Always returns false.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3creature.md
+++ b/docs/source/types/tes3creature.md
@@ -262,6 +262,17 @@ Always returns false.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -534,6 +545,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3creatureInstance.md
+++ b/docs/source/types/tes3creatureInstance.md
@@ -273,17 +273,6 @@ Always returns true.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3creatureInstance.md
+++ b/docs/source/types/tes3creatureInstance.md
@@ -273,6 +273,17 @@ Always returns true.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -567,6 +578,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3dialogue.md
+++ b/docs/source/types/tes3dialogue.md
@@ -66,6 +66,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `journalIndex`
 <div class="search_terms" style="display: none">journalindex</div>
 
@@ -140,6 +151,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3dialogue.md
+++ b/docs/source/types/tes3dialogue.md
@@ -66,17 +66,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `journalIndex`
 <div class="search_terms" style="display: none">journalindex</div>
 

--- a/docs/source/types/tes3dialogueInfo.md
+++ b/docs/source/types/tes3dialogueInfo.md
@@ -99,17 +99,6 @@ The actor that the player first heard the info from.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isQuestFinished`
 <div class="search_terms" style="display: none">isquestfinished, questfinished</div>
 

--- a/docs/source/types/tes3dialogueInfo.md
+++ b/docs/source/types/tes3dialogueInfo.md
@@ -99,6 +99,17 @@ The actor that the player first heard the info from.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isQuestFinished`
 <div class="search_terms" style="display: none">isquestfinished, questfinished</div>
 
@@ -283,6 +294,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3door.md
+++ b/docs/source/types/tes3door.md
@@ -79,17 +79,6 @@ The sound to be played when the door closes.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3door.md
+++ b/docs/source/types/tes3door.md
@@ -79,6 +79,17 @@ The sound to be played when the door closes.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -274,6 +285,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3enchantment.md
+++ b/docs/source/types/tes3enchantment.md
@@ -120,6 +120,17 @@ A bit field for the enchantment's flags.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -271,6 +282,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3enchantment.md
+++ b/docs/source/types/tes3enchantment.md
@@ -120,17 +120,6 @@ A bit field for the enchantment's flags.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3faction.md
+++ b/docs/source/types/tes3faction.md
@@ -66,6 +66,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -217,6 +228,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3faction.md
+++ b/docs/source/types/tes3faction.md
@@ -66,17 +66,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3gameSetting.md
+++ b/docs/source/types/tes3gameSetting.md
@@ -77,17 +77,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3gameSetting.md
+++ b/docs/source/types/tes3gameSetting.md
@@ -77,6 +77,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -151,6 +162,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3globalVariable.md
+++ b/docs/source/types/tes3globalVariable.md
@@ -55,6 +55,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -118,6 +129,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3globalVariable.md
+++ b/docs/source/types/tes3globalVariable.md
@@ -55,17 +55,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3ingredient.md
+++ b/docs/source/types/tes3ingredient.md
@@ -110,17 +110,6 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3ingredient.md
+++ b/docs/source/types/tes3ingredient.md
@@ -110,6 +110,17 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -294,6 +305,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3item.md
+++ b/docs/source/types/tes3item.md
@@ -66,17 +66,6 @@ The bounding box for the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3item.md
+++ b/docs/source/types/tes3item.md
@@ -66,6 +66,17 @@ The bounding box for the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -217,6 +228,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3land.md
+++ b/docs/source/types/tes3land.md
@@ -88,6 +88,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `maxHeight`
 <div class="search_terms" style="display: none">maxheight</div>
 
@@ -184,6 +195,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3land.md
+++ b/docs/source/types/tes3land.md
@@ -88,17 +88,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `maxHeight`
 <div class="search_terms" style="display: none">maxheight</div>
 

--- a/docs/source/types/tes3landTexture.md
+++ b/docs/source/types/tes3landTexture.md
@@ -77,6 +77,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -140,6 +151,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3landTexture.md
+++ b/docs/source/types/tes3landTexture.md
@@ -77,17 +77,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3leveledCreature.md
+++ b/docs/source/types/tes3leveledCreature.md
@@ -110,6 +110,17 @@ A numerical representation of bit flags for the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -272,6 +283,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3leveledCreature.md
+++ b/docs/source/types/tes3leveledCreature.md
@@ -110,17 +110,6 @@ A numerical representation of bit flags for the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3leveledItem.md
+++ b/docs/source/types/tes3leveledItem.md
@@ -121,6 +121,17 @@ A numerical representation of bit flags for the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -283,6 +294,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3leveledItem.md
+++ b/docs/source/types/tes3leveledItem.md
@@ -121,17 +121,6 @@ A numerical representation of bit flags for the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3light.md
+++ b/docs/source/types/tes3light.md
@@ -143,17 +143,6 @@ Access to the light's flags, determining if the light represents flame.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3light.md
+++ b/docs/source/types/tes3light.md
@@ -143,6 +143,17 @@ Access to the light's flags, determining if the light represents flame.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -411,6 +422,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3lockpick.md
+++ b/docs/source/types/tes3lockpick.md
@@ -77,17 +77,6 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3lockpick.md
+++ b/docs/source/types/tes3lockpick.md
@@ -77,6 +77,17 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -283,6 +294,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3magicSourceInstance.md
+++ b/docs/source/types/tes3magicSourceInstance.md
@@ -88,6 +88,17 @@ The number of hours passed since the player's corprus state last worsened.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `item`
 <div class="search_terms" style="display: none">item</div>
 
@@ -261,6 +272,19 @@ Shows if the state is pre-cast, cast, beginning, working, ending, retired, etc. 
 **Returns**:
 
 * `result` ([tes3.spellState](../references/spell-states.md))
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3magicSourceInstance.md
+++ b/docs/source/types/tes3magicSourceInstance.md
@@ -88,17 +88,6 @@ The number of hours passed since the player's corprus state last worsened.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `item`
 <div class="search_terms" style="display: none">item</div>
 

--- a/docs/source/types/tes3misc.md
+++ b/docs/source/types/tes3misc.md
@@ -88,6 +88,17 @@ True if the misc item is a valid form of gold.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isKey`
 <div class="search_terms" style="display: none">iskey, key</div>
 
@@ -316,6 +327,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3misc.md
+++ b/docs/source/types/tes3misc.md
@@ -88,17 +88,6 @@ True if the misc item is a valid form of gold.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isKey`
 <div class="search_terms" style="display: none">iskey, key</div>
 

--- a/docs/source/types/tes3npc.md
+++ b/docs/source/types/tes3npc.md
@@ -328,17 +328,6 @@ Always returns false.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3npc.md
+++ b/docs/source/types/tes3npc.md
@@ -328,6 +328,17 @@ Always returns false.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -600,6 +611,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3npcInstance.md
+++ b/docs/source/types/tes3npcInstance.md
@@ -339,6 +339,17 @@ Always returns true.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -633,6 +644,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3npcInstance.md
+++ b/docs/source/types/tes3npcInstance.md
@@ -339,17 +339,6 @@ Always returns true.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3object.md
+++ b/docs/source/types/tes3object.md
@@ -55,6 +55,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -195,6 +206,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3object.md
+++ b/docs/source/types/tes3object.md
@@ -55,17 +55,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3pathGrid.md
+++ b/docs/source/types/tes3pathGrid.md
@@ -66,6 +66,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLoaded`
 <div class="search_terms" style="display: none">isloaded, loaded</div>
 
@@ -173,6 +184,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3pathGrid.md
+++ b/docs/source/types/tes3pathGrid.md
@@ -66,17 +66,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLoaded`
 <div class="search_terms" style="display: none">isloaded, loaded</div>
 

--- a/docs/source/types/tes3physicalObject.md
+++ b/docs/source/types/tes3physicalObject.md
@@ -66,17 +66,6 @@ The bounding box for the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3physicalObject.md
+++ b/docs/source/types/tes3physicalObject.md
@@ -66,6 +66,17 @@ The bounding box for the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -217,6 +228,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3probe.md
+++ b/docs/source/types/tes3probe.md
@@ -77,17 +77,6 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3probe.md
+++ b/docs/source/types/tes3probe.md
@@ -77,6 +77,17 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -283,6 +294,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3quest.md
+++ b/docs/source/types/tes3quest.md
@@ -77,6 +77,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -140,6 +151,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3quest.md
+++ b/docs/source/types/tes3quest.md
@@ -77,17 +77,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3race.md
+++ b/docs/source/types/tes3race.md
@@ -132,6 +132,17 @@ Access to the beast race flag.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isPlayable`
 <div class="search_terms" style="display: none">isplayable, playable</div>
 
@@ -239,6 +250,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3race.md
+++ b/docs/source/types/tes3race.md
@@ -132,17 +132,6 @@ Access to the beast race flag.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isPlayable`
 <div class="search_terms" style="display: none">isplayable, playable</div>
 

--- a/docs/source/types/tes3reference.md
+++ b/docs/source/types/tes3reference.md
@@ -291,17 +291,6 @@ Friendly access onto the reference's empty inventory flag.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLeveledSpawn`
 <div class="search_terms" style="display: none">isleveledspawn, leveledspawn</div>
 

--- a/docs/source/types/tes3reference.md
+++ b/docs/source/types/tes3reference.md
@@ -291,6 +291,17 @@ Friendly access onto the reference's empty inventory flag.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLeveledSpawn`
 <div class="search_terms" style="display: none">isleveledspawn, leveledspawn</div>
 
@@ -658,6 +669,19 @@ Access to the size of a stack, if the reference represents one or more items.
 **Returns**:
 
 * `result` ([tes3vector3](../types/tes3vector3.md))
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3region.md
+++ b/docs/source/types/tes3region.md
@@ -55,6 +55,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -151,6 +162,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3region.md
+++ b/docs/source/types/tes3region.md
@@ -55,17 +55,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3repairTool.md
+++ b/docs/source/types/tes3repairTool.md
@@ -77,17 +77,6 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3repairTool.md
+++ b/docs/source/types/tes3repairTool.md
@@ -77,6 +77,17 @@ The path to the object's icon. Relative to `Data Files\\icons\\`.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -283,6 +294,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3script.md
+++ b/docs/source/types/tes3script.md
@@ -77,6 +77,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `longVariableCount`
 <div class="search_terms" style="display: none">longvariablecount</div>
 
@@ -162,6 +173,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3script.md
+++ b/docs/source/types/tes3script.md
@@ -77,17 +77,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `longVariableCount`
 <div class="search_terms" style="display: none">longvariablecount</div>
 

--- a/docs/source/types/tes3skill.md
+++ b/docs/source/types/tes3skill.md
@@ -99,6 +99,17 @@ Loads from disk and returns the description of the skill.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -184,6 +195,19 @@ The specialization in which the skill belongs. Maps to values in the [`tes3.spec
 **Returns**:
 
 * `result` ([tes3.specialization](../references/specializations.md))
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3skill.md
+++ b/docs/source/types/tes3skill.md
@@ -99,17 +99,6 @@ Loads from disk and returns the description of the skill.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3sound.md
+++ b/docs/source/types/tes3sound.md
@@ -66,6 +66,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `maxDistance`
 <div class="search_terms" style="display: none">maxdistance</div>
 
@@ -151,6 +162,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3sound.md
+++ b/docs/source/types/tes3sound.md
@@ -66,17 +66,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `maxDistance`
 <div class="search_terms" style="display: none">maxdistance</div>
 

--- a/docs/source/types/tes3soundGenerator.md
+++ b/docs/source/types/tes3soundGenerator.md
@@ -55,6 +55,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -129,6 +140,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3soundGenerator.md
+++ b/docs/source/types/tes3soundGenerator.md
@@ -55,17 +55,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3spell.md
+++ b/docs/source/types/tes3spell.md
@@ -153,17 +153,6 @@ A bit field for the spell's flags.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3spell.md
+++ b/docs/source/types/tes3spell.md
@@ -153,6 +153,17 @@ A bit field for the spell's flags.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -326,6 +337,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3startScript.md
+++ b/docs/source/types/tes3startScript.md
@@ -55,6 +55,17 @@ The blocked state of the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 
@@ -129,6 +140,19 @@ The soruceless flag of the object.
 **Returns**:
 
 * `result` (string)
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3startScript.md
+++ b/docs/source/types/tes3startScript.md
@@ -55,17 +55,6 @@ The blocked state of the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `modified`
 <div class="search_terms" style="display: none">modified, ified</div>
 

--- a/docs/source/types/tes3static.md
+++ b/docs/source/types/tes3static.md
@@ -68,6 +68,17 @@ The bounding box for the object.
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -230,6 +241,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3static.md
+++ b/docs/source/types/tes3static.md
@@ -68,17 +68,6 @@ The bounding box for the object.
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/docs/source/types/tes3weapon.md
+++ b/docs/source/types/tes3weapon.md
@@ -165,6 +165,17 @@ Access to the flag that controls if this weapon bypasses the "Resist normal weap
 
 ***
 
+### `isItem`
+<div class="search_terms" style="display: none">isitem, item</div>
+
+If true, the object is an item. This property is false for non-carriable lights.
+
+**Returns**:
+
+* `result` (boolean)
+
+***
+
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 
@@ -509,6 +520,19 @@ A list of actors that the object has been stolen from.
 **Returns**:
 
 * `result` ([tes3baseObject](../types/tes3baseObject.md)[])
+
+***
+
+### `supportsActivate`
+<div class="search_terms" style="display: none">supportsactivate</div>
+
+If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+
+However, the activation of such an object may still be blocked via mwscript or a Lua script.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/tes3weapon.md
+++ b/docs/source/types/tes3weapon.md
@@ -165,17 +165,6 @@ Access to the flag that controls if this weapon bypasses the "Resist normal weap
 
 ***
 
-### `isItem`
-<div class="search_terms" style="display: none">isitem, item</div>
-
-If true, the object is an item. This property is false for non-carriable lights.
-
-**Returns**:
-
-* `result` (boolean)
-
-***
-
 ### `isLocationMarker`
 <div class="search_terms" style="display: none">islocationmarker, locationmarker</div>
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3baseObject.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3baseObject.lua
@@ -8,7 +8,6 @@
 --- @field deleted boolean *Read-only*. The deleted state of the object.
 --- @field disabled boolean *Read-only*. The disabled state of the object.
 --- @field id string *Read-only*. The unique identifier for the object.
---- @field isItem boolean If true, the object is an item. This property is false for non-carriable lights.
 --- @field modified boolean The modification state of the object since the last save.
 --- @field objectFlags number *Read-only*. The raw flags of the object.
 --- @field objectType tes3.objectType *Read-only*. The type of object. Maps to values in [`tes3.objectType`](https://mwse.github.io/MWSE/references/object-types/).

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3baseObject.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3baseObject.lua
@@ -8,12 +8,16 @@
 --- @field deleted boolean *Read-only*. The deleted state of the object.
 --- @field disabled boolean *Read-only*. The disabled state of the object.
 --- @field id string *Read-only*. The unique identifier for the object.
+--- @field isItem boolean If true, the object is an item. This property is false for non-carriable lights.
 --- @field modified boolean The modification state of the object since the last save.
 --- @field objectFlags number *Read-only*. The raw flags of the object.
 --- @field objectType tes3.objectType *Read-only*. The type of object. Maps to values in [`tes3.objectType`](https://mwse.github.io/MWSE/references/object-types/).
 --- @field persistent boolean The persistent flag of the object.
 --- @field sourceless boolean The soruceless flag of the object.
 --- @field sourceMod string *Read-only*. The filename (including the extension) of the mod that owns this object. It has `nil` value if the object was anything other than loaded from an ESP or ESM file.
+--- @field supportsActivate boolean If true, the object supports activation. This includes all the items (excluding non-carriable lights), actors outside combat, activators, containers and doors.
+--- 
+--- However, the activation of such an object may still be blocked via mwscript or a Lua script.
 --- @field supportsLuaData boolean If true, references of this object can store temporary or persistent lua data.
 tes3baseObject = {}
 


### PR DESCRIPTION
This adds `canActivate` field. It's true for all the items (excluding non-carriable lights), actors outside of combat, activators, containers, and doors.

It also adds the `tes3baseObject.isItem` property that returns true for all items except non-carriable lights which is used to implement `canActivate` check.