### PR TITLE
Update MCM layout an extra time to shake out unnecessary newlines.

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -450,6 +450,8 @@ local function onClickModConfigButton()
 		-- Cause the menu to refresh itself.
 		menu:updateLayout()
 		modList.widget:contentsChanged()
+		-- Mods with a certain title length can add an unnecessary newline, which goes away when the layout is refreshed.
+		menu:updateLayout()
 
 		if lastModName ~= nil then
 			for _, child in ipairs(modListContents.children) do


### PR DESCRIPTION
A mod with title of (e.g.) "Pete's Itinerant Intervention" will add a newline in the MCM even though it fits on one line, which annoyingly goes away as soon as you hover the scrollview.
Fixes that.