### PR TITLE
Fix docs for `tes3uiElement:reorder`

### DIFF
--- a/autocomplete/definitions/namedTypes/tes3uiElement/reorder.lua
+++ b/autocomplete/definitions/namedTypes/tes3uiElement/reorder.lua
@@ -5,8 +5,8 @@ return {
 		name = "params",
 		type = "table",
 		tableParams = {
-			{ name = "before", type = "tes3uiElement", description = "The calling element will be moved to before this element." },
-			{ name = "after", type = "tes3uiElement", description = "The calling element will be moved to after this element." },
+			{ name = "before", type = "tes3uiElement", optional = true, description = "The calling element will be moved to before this element." },
+			{ name = "after", type = "tes3uiElement", optional = true, description = "The calling element will be moved to after this element." },
 		},
 	}},
 	valuetype = "boolean",

--- a/docs/source/types/tes3uiElement.md
+++ b/docs/source/types/tes3uiElement.md
@@ -1735,8 +1735,8 @@ local result = myObject:reorder({ before = ..., after = ... })
 **Parameters**:
 
 * `params` (table)
-	* `before` ([tes3uiElement](../types/tes3uiElement.md)): The calling element will be moved to before this element.
-	* `after` ([tes3uiElement](../types/tes3uiElement.md)): The calling element will be moved to after this element.
+	* `before` ([tes3uiElement](../types/tes3uiElement.md)): *Optional*. The calling element will be moved to before this element.
+	* `after` ([tes3uiElement](../types/tes3uiElement.md)): *Optional*. The calling element will be moved to after this element.
 
 **Returns**:
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3uiElement.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3uiElement.lua
@@ -792,16 +792,16 @@ function tes3uiElement:removeProperty(property) end
 --- Re-orders an element to before or after a sibling element. Provide either a `before` or `after` parameter.
 --- @param params tes3uiElement.reorder.params This table accepts the following values:
 --- 
---- `before`: tes3uiElement — The calling element will be moved to before this element.
+--- `before`: tes3uiElement? — *Optional*. The calling element will be moved to before this element.
 --- 
---- `after`: tes3uiElement — The calling element will be moved to after this element.
+--- `after`: tes3uiElement? — *Optional*. The calling element will be moved to after this element.
 --- @return boolean result No description yet available.
 function tes3uiElement:reorder(params) end
 
 ---Table parameter definitions for `tes3uiElement.reorder`.
 --- @class tes3uiElement.reorder.params
---- @field before tes3uiElement The calling element will be moved to before this element.
---- @field after tes3uiElement The calling element will be moved to after this element.
+--- @field before tes3uiElement? *Optional*. The calling element will be moved to before this element.
+--- @field after tes3uiElement? *Optional*. The calling element will be moved to after this element.
 
 --- This method is deprecated. Prefer to use `tes3uiElement.reorder` when moving single children.
 --- 


### PR DESCRIPTION
This marks `before` and `after` as optional since only one of them is required.