### PR TITLE
MCM Slider: Remove `assert`s from constructor, update documentation

### DIFF
--- a/autocomplete/definitions/namedTypes/mwseMCMSlider/new.lua
+++ b/autocomplete/definitions/namedTypes/mwseMCMSlider/new.lua
@@ -6,7 +6,7 @@ return {
 		type = "table",
 		optional = true,
 		tableParams = {
-			{ name = "label", type = "string", optional = true, description = "Text shown above the slider. If left as a normal string, it will be shown in the form: [`label`]: [`self.variable.value`]. If the string contains a '%s' format operator, the value will be formatted into it." },
+			{ name = "label", type = "string", description = "Text shown above the slider. If left as a normal string, it will be shown in the form: [`label`]: [`self.variable.value`]. If the string contains a '%s' format operator, the value will be formatted into it." },
 			{ name = "variable", type = "mwseMCMVariable|mwseMCMSettingNewVariable", optional = true, description = "A variable for this setting." },
 			{ name = "config", type = "table", optional = true,  default = "`parentComponent.config`",
 				description = "The config to use when creating a [`mwseMCMTableVariable`](./mwseMCMTableVariable.md) for this `Setting`. \z

--- a/docs/source/types/mwseMCMSlider.md
+++ b/docs/source/types/mwseMCMSlider.md
@@ -727,7 +727,7 @@ local slider = myObject:new({ label = ..., variable = ..., config = ..., default
 **Parameters**:
 
 * `data` (table): *Optional*.
-	* `label` (string): *Optional*. Text shown above the slider. If left as a normal string, it will be shown in the form: [`label`]: [`self.variable.value`]. If the string contains a '%s' format operator, the value will be formatted into it.
+	* `label` (string): Text shown above the slider. If left as a normal string, it will be shown in the form: [`label`]: [`self.variable.value`]. If the string contains a '%s' format operator, the value will be formatted into it.
 	* `variable` ([mwseMCMVariable](../types/mwseMCMVariable.md), [mwseMCMSettingNewVariable](../types/mwseMCMSettingNewVariable.md)): *Optional*. A variable for this setting.
 	* `config` (table): *Default*: ``parentComponent.config``. The config to use when creating a [`mwseMCMTableVariable`](./mwseMCMTableVariable.md) for this `Setting`. If provided, it will override the config stored in `parentComponent`. Otherwise, the value in `parentComponent` will be used.
 	* `defaultConfig` (table): *Default*: ``parentComponent.defaultConfig``. The `defaultConfig` to use when creating a [`mwseMCMTableVariable`](./mwseMCMTableVariable.md) for this `Setting`. If provided, it will override the `defaultConfig` stored in `parentComponent`. Otherwise, the value in `parentComponent` will be used.

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Slider.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Slider.lua
@@ -62,30 +62,45 @@ function Slider:new(data)
 			printSliderWarning(t.label, "Slider.max (=%s) should be greater than Slider.min (=%s)", t.max, t.min)
 		end
 		if t.step <= 0 then
-			printSliderWarning(t.label, "Slider.step (=%s) should be greater than 0.", t.step)
+			printSliderWarning(t.label, "Slider.step (=%s) should be a positive number.", t.step)
 		end
 		if t.jump <= 0 then
-			printSliderWarning(t.label, "Slider.jump (=%s) should be greater than 0.", t.jump)
+			printSliderWarning(t.label, "Slider.jump (=%s) should be a positive number.", t.jump)
 		end
 		if t.decimalPlaces % 1 ~= 0 or t.decimalPlaces < 0 then
-			printSliderWarning(t.label, "Slider.decimalPlaces (=%s) should be a positive whole number.", t.decimalPlaces)
-			-- If we don't change this now then an error will occur later.
-			t.decimalPlaces = 0
+			error(string.format(
+				'A slider labeled "%s" was created with invalid parameters:\n\t\z
+					Slider.decimalPlaces (=%s) should be a positive whole number.',
+				t.label, t.decimalPlaces
+			))
+		end
+
+		-- Avoid breaking existing mods that have variable min or max but a fixed step/jump.
+		-- Clamp instead of asserting.
+		if t.step > dist + math.epsilon then
+			-- Only print the error message when `slider.min` and `slider.max` are set properly.
+			-- Seeing something like "It should be less than -1 = Slider.max - Slider.min" is not very helpful.
+			if dist > 0 then
+				printSliderWarning(t.label, 
+					"Slider.step (= %s) is too big! It should be less than %s = Slider.max - Slider.min.",
+					t.step, dist
+				)
+			end
+			t.step = dist
+		end
+		if t.jump > dist + math.epsilon then
+			-- Only print the error message when `slider.min` and `slider.max` are set properly.
+			if dist > 0 then
+				printSliderWarning(t.label, 
+					"Slider.jump (= %s) is too big! It should be less than %s = Slider.max - Slider.min.",
+					t.jump, dist
+				)
+			end
+			t.jump = dist
 		end
 	end
 
-	-- Avoid breaking existing mods that have variable min or max but a fixed step/jump.
-	-- Clamp instead of asserting.
-	if t.step > dist + math.epsilon then
-		mwse.log("mcm.Slider: 'step' parameter is greater than 'max' - 'min'")
-		mwse.log(debug.traceback())
-		t.step = dist
-	end
-	if t.jump > dist + math.epsilon then
-		mwse.log("mcm.Slider: 'jump' parameter is greater than 'max' - 'min'")
-		mwse.log(debug.traceback())
-		t.jump = dist
-	end
+	
 
 	return t
 end

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Slider.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Slider.lua
@@ -39,7 +39,6 @@ Slider.jump = 5
 ---@param sliderLabel string Label of the slider that triggered an error.
 ---@param msg string The error message. 
 ---@param ... string|number Parameters to pass to `string.format(msg, ...)`
----@return nil
 local function printSliderWarning(sliderLabel, msg, ...)
 	mwse.log(
 		'[createSlider WARNING] A slider labeled "%s" was created with invalid parameters:\n\t%s',

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Slider.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Slider.lua
@@ -34,6 +34,19 @@ Slider.step = 1
 Slider.jump = 5
 
 
+--- Prints a warning message letting the user know some slider parameters are invalid.
+--- This function is only used inside the `Slider` constructor.
+---@param sliderLabel string Label of the slider that triggered an error.
+---@param msg string The error message. 
+---@param ... string|number Parameters to pass to `string.format(msg, ...)`
+---@return nil
+local function printSliderWarning(sliderLabel, msg, ...)
+	mwse.log(
+		'[createSlider WARNING] A slider labeled "%s" was created with invalid parameters:\n\t%s',
+		-- Start the traceback at level `2` to avoid including `printSliderWarning` in the traceback.
+		sliderLabel, debug.traceback(msg:format(...), 2)
+	)
+end
 function Slider:new(data)
 	-- initialize metatable, make variable, etc
 	local t = Parent.new(self, data)
@@ -44,15 +57,22 @@ function Slider:new(data)
 	if rawget(t, "jump") == nil then
 		t.jump = math.min(dist, 5 * t.step)
 	end
-
-	assert(dist > 0, "mcm.Slider: Invalid 'max' and 'min' parameters provided. 'max' must be greater than 'min'.")
-	assert(t.step > 0, "mcm.Slider: Invalid 'step' parameter provided. It must be greater than 0.")
-	assert(t.jump > 0, "mcm.Slider: Invalid 'jump' parameter provided. It must be greater than 0.")
-
-	assert(
-		t.decimalPlaces % 1 == 0 and t.decimalPlaces >= 0,
-		"mcm.Slider: Invalid 'decimalPlaces' parameter provided. It must be a nonnegative whole number."
-	)
+	do -- Check parameters and print error messages if necessary.
+		if dist <= 0 then
+			printSliderWarning(t.label, "Slider.max (=%s) should be greater than Slider.min (=%s)", t.max, t.min)
+		end
+		if t.step <= 0 then
+			printSliderWarning(t.label, "Slider.step (=%s) should be greater than 0.", t.step)
+		end
+		if t.jump <= 0 then
+			printSliderWarning(t.label, "Slider.jump (=%s) should be greater than 0.", t.jump)
+		end
+		if t.decimalPlaces % 1 ~= 0 or t.decimalPlaces < 0 then
+			printSliderWarning(t.label, "Slider.decimalPlaces (=%s) should be a positive whole number.", t.decimalPlaces)
+			-- If we don't change this now then an error will occur later.
+			t.decimalPlaces = 0
+		end
+	end
 
 	-- Avoid breaking existing mods that have variable min or max but a fixed step/jump.
 	-- Clamp instead of asserting.

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseMCMSlider.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseMCMSlider.lua
@@ -50,7 +50,7 @@ function mwseMCMSlider:makeComponent(parentBlock) end
 --- Creates a new Slider.
 --- @param data mwseMCMSlider.new.data? This table accepts the following values:
 --- 
---- `label`: string? — *Optional*. Text shown above the slider. If left as a normal string, it will be shown in the form: [`label`]: [`self.variable.value`]. If the string contains a '%s' format operator, the value will be formatted into it.
+--- `label`: string — Text shown above the slider. If left as a normal string, it will be shown in the form: [`label`]: [`self.variable.value`]. If the string contains a '%s' format operator, the value will be formatted into it.
 --- 
 --- `variable`: mwseMCMConfigVariable|mwseMCMCustomVariable|mwseMCMGlobal|mwseMCMGlobalBoolean|mwseMCMPlayerData|mwseMCMTableVariable|mwseMCMVariable|mwseMCMSettingNewVariable|nil — *Optional*. A variable for this setting.
 --- 
@@ -106,7 +106,7 @@ function mwseMCMSlider:new(data) end
 
 ---Table parameter definitions for `mwseMCMSlider.new`.
 --- @class mwseMCMSlider.new.data
---- @field label string? *Optional*. Text shown above the slider. If left as a normal string, it will be shown in the form: [`label`]: [`self.variable.value`]. If the string contains a '%s' format operator, the value will be formatted into it.
+--- @field label string Text shown above the slider. If left as a normal string, it will be shown in the form: [`label`]: [`self.variable.value`]. If the string contains a '%s' format operator, the value will be formatted into it.
 --- @field variable mwseMCMConfigVariable|mwseMCMCustomVariable|mwseMCMGlobal|mwseMCMGlobalBoolean|mwseMCMPlayerData|mwseMCMTableVariable|mwseMCMVariable|mwseMCMSettingNewVariable|nil *Optional*. A variable for this setting.
 --- @field config table? *Default*: ``parentComponent.config``. The config to use when creating a [`mwseMCMTableVariable`](./mwseMCMTableVariable.md) for this `Setting`. If provided, it will override the config stored in `parentComponent`. Otherwise, the value in `parentComponent` will be used.
 --- @field defaultConfig table? *Default*: ``parentComponent.defaultConfig``. The `defaultConfig` to use when creating a [`mwseMCMTableVariable`](./mwseMCMTableVariable.md) for this `Setting`. If provided, it will override the `defaultConfig` stored in `parentComponent`. Otherwise, the value in `parentComponent` will be used.


### PR DESCRIPTION
This PR makes two changes:
1. The `label` field is now marked as required in the documentation for the `mwseMCMSlider` constructor. This is because the default implementation of `Slider:updateValueLabel()` triggers an error if `self.label == nil`.
2. The `assert` statements were removed from the `mwseMCMSlider` constructor. The checks are still performed but will now log warning messages instead. This should hopefully result in fewer unnecessary softlocks in people's mods.