### PR TITLE
Fix niche documentation typos and delete `brief`

### DIFF
--- a/autocomplete/definitions/events/standard/uiActivated.lua
+++ b/autocomplete/definitions/events/standard/uiActivated.lua
@@ -73,7 +73,7 @@ Menu id                 | Description
 		["newlyCreated"] = {
 			type = "boolean",
 			readOnly = true,
-			description = "true if the menu was created for the first time or destroyed and re-created; false if it was made visible after being hidden. This can be used when adding custom elements to a menu, as elements previously added will still exist if the menu was hidden. If the menu was re-created, the elements will need to be added again.",
+			description = "`true` if the menu was created for the first time or destroyed and re-created; `false` if it was made visible after being hidden. This can be used when adding custom elements to a menu, as elements previously added will still exist if the menu was hidden. If the menu was re-created, the elements will need to be added again.",
 		},
 	},
 	filter = "element.name",

--- a/autocomplete/definitions/global/mge/saveScreenshot.lua
+++ b/autocomplete/definitions/global/mge/saveScreenshot.lua
@@ -5,7 +5,7 @@ return {
 		name = "params",
 		type = "table",
 		tableParams = {
-			{ name = "path", type = "string", "The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension." },
+			{ name = "path", type = "string", description = "The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension." },
 			{ name = "captureWithUI", type = "boolean", optional = true, default = false, description = "If set to `true`, the screenshot will include the user interface." },
 		},
 	}},

--- a/autocomplete/definitions/global/mge/saveScreenshot.lua
+++ b/autocomplete/definitions/global/mge/saveScreenshot.lua
@@ -5,7 +5,7 @@ return {
 		name = "params",
 		type = "table",
 		tableParams = {
-			{ name = "path", type = "string", description = "The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension." },
+			{ name = "path", type = "string", description = "The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension. The supported file formats are `bmp`, `jpeg`, `dds`, `png`, and `tga`." },
 			{ name = "captureWithUI", type = "boolean", optional = true, default = false, description = "If set to `true`, the screenshot will include the user interface." },
 		},
 	}},

--- a/autocomplete/definitions/global/table/filter.lua
+++ b/autocomplete/definitions/global/table/filter.lua
@@ -8,7 +8,7 @@ Any additional arguments will be passed to `f`. For example, `table.filter(t, f,
 ]],
 	arguments = {
 		{ name = "t", type = "table" },
-		{ name = "f", type = "fun(k: unknown, v: unknown, ...): boolean", "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
+		{ name = "f", type = "fun(k: unknown, v: unknown, ...): boolean", description = "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
 		{ name = "...", type = "any", description = "Additional parameters to pass to `f`." },
 	},
 	returns = {

--- a/autocomplete/definitions/global/table/filterarray.lua
+++ b/autocomplete/definitions/global/table/filterarray.lua
@@ -7,7 +7,7 @@ Any additional arguments will be passed to `f`. For example, `table.filterarray(
 When an element gets filtered out, the index of subsequent items will be shifted down, so that the resulting table plays nicely with the `#` operator and the `ipairs` function.]],
 	arguments = {
 		{ name = "arr", type = "table" },
-		{ name = "f", type = "fun(i: integer, v: unknown, ...): boolean", "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
+		{ name = "f", type = "fun(i: integer, v: unknown, ...): boolean", description = "The function to use when filtering values of `t`. (This is sometimes called a predicate function.)" },
 		{ name = "...", type = "any", description = "Additional parameters to pass to `f`." },
 	},
 	returns = {

--- a/autocomplete/definitions/global/table/map.lua
+++ b/autocomplete/definitions/global/table/map.lua
@@ -4,7 +4,7 @@ return {
 Any additional arguments will be passed to `f`. For example, `table.map(t, f, 10)` would call `f(k, v, 10)` on each value `v` of `t`.]],
 	arguments = {
 		{ name = "t", type = "table" },
-		{ name = "f", type = "fun(k: unknown, v: unknown, ...): unknown", "The function to apply to each element of `t`." },
+		{ name = "f", type = "fun(k: unknown, v: unknown, ...): unknown", description = "The function to apply to each element of `t`." },
 		{ name = "...", type = "any", description = "Additional parameters to pass to `f`." },
 	},
 	returns = {

--- a/autocomplete/definitions/global/table/traverse.lua
+++ b/autocomplete/definitions/global/table/traverse.lua
@@ -5,7 +5,7 @@ return {
 Each "node" is an object with a children table of other "nodes", each of which might have their own children. For example, a sceneNode is made up of niNodes, and each niNodes can have a list of niNode children. This is best used for recursive data structures like UI elements and sceneNodes etc.]],
 	arguments = {
 		{ name = "t", type = "table", description = "A table to transverse." },
-		{ name = "k", type = "string", optional = "true", default = "children", description = "The subtable key." },
+		{ name = "k", type = "string", optional = true, default = "children", description = "The subtable key." },
 	},
 	returns = {
 		name = "iterator",

--- a/autocomplete/definitions/global/tes3/isKeyEqual.lua
+++ b/autocomplete/definitions/global/tes3/isKeyEqual.lua
@@ -110,7 +110,7 @@ return {
 		},
 	}},
 	returns = {
-		{ name = "equal", valuetype = "boolean" }
+		{ name = "equal", type = "boolean" }
 	},
 	examples = {
 		["filtering"] = {

--- a/autocomplete/definitions/global/tes3ui/enterMenuMode.lua
+++ b/autocomplete/definitions/global/tes3ui/enterMenuMode.lua
@@ -4,6 +4,7 @@ return {
 	arguments = {
 		{ name = "id", type = "string|number" },
 	},
-	returnDescription = "true if the menu was switched, or false if it was already active.",
-	valuetype = "boolean",
+	returns = {
+		{ type = "boolean", description =  "true if the menu was switched, or false if it was already active.", }
+	}
 }

--- a/autocomplete/definitions/global/tes3ui/enterMenuMode.lua
+++ b/autocomplete/definitions/global/tes3ui/enterMenuMode.lua
@@ -5,6 +5,6 @@ return {
 		{ name = "id", type = "string|number" },
 	},
 	returns = {
-		{ name = "result", type = "boolean", description =  "true if the menu was switched, or false if it was already active.", }
+		{ name = "result", type = "boolean", description =  "True if the menu was switched, or false if it was already active.", }
 	}
 }

--- a/autocomplete/definitions/global/tes3ui/enterMenuMode.lua
+++ b/autocomplete/definitions/global/tes3ui/enterMenuMode.lua
@@ -5,6 +5,6 @@ return {
 		{ name = "id", type = "string|number" },
 	},
 	returns = {
-		{ type = "boolean", description =  "true if the menu was switched, or false if it was already active.", }
+		{ name = "result", type = "boolean", description =  "true if the menu was switched, or false if it was already active.", }
 	}
 }

--- a/autocomplete/definitions/global/tes3ui/menuMode.lua
+++ b/autocomplete/definitions/global/tes3ui/menuMode.lua
@@ -1,6 +1,7 @@
 return {
 	type = "function",
 	description = [[Checks if the game is in menu mode.]],
-	returnDescription = "true if in menu mode.",
-	valuetype = "boolean",
+	returns = {
+		{ type = "boolean", description = "true if in menu mode." }
+	}
 }

--- a/autocomplete/definitions/global/tes3ui/menuMode.lua
+++ b/autocomplete/definitions/global/tes3ui/menuMode.lua
@@ -2,6 +2,6 @@ return {
 	type = "function",
 	description = [[Checks if the game is in menu mode.]],
 	returns = {
-		{ name = "result", type = "boolean", description = "true if in menu mode." }
+		{ name = "result", type = "boolean", description = "`true` if in menu mode." }
 	}
 }

--- a/autocomplete/definitions/global/tes3ui/menuMode.lua
+++ b/autocomplete/definitions/global/tes3ui/menuMode.lua
@@ -2,6 +2,6 @@ return {
 	type = "function",
 	description = [[Checks if the game is in menu mode.]],
 	returns = {
-		{ type = "boolean", description = "true if in menu mode." }
+		{ name = "result", type = "boolean", description = "true if in menu mode." }
 	}
 }

--- a/autocomplete/definitions/namedTypes/mgeCameraConfig/zoomOut.lua
+++ b/autocomplete/definitions/namedTypes/mgeCameraConfig/zoomOut.lua
@@ -6,7 +6,7 @@ return {
 		type = "table",
 		optional = true,
 		tableParams = {
-			{ name = "amount", type = "number", amount = 0.0625 },
+			{ name = "amount", type = "number", default = 0.0625 },
 		},
 	}},
 }

--- a/autocomplete/definitions/namedTypes/mwseTimer/reset.lua
+++ b/autocomplete/definitions/namedTypes/mwseTimer/reset.lua
@@ -1,5 +1,5 @@
 return {
 	type = "method",
 	description = [[Resets the timer completion time and iterations count.]],
-	returntype = "boolean"
+	returns = "boolean"
 }

--- a/autocomplete/definitions/namedTypes/mwseTimerController/new.lua
+++ b/autocomplete/definitions/namedTypes/mwseTimerController/new.lua
@@ -2,7 +2,7 @@ return {
 	type = "function",
 	description = [[Creates a new Timer Controller. Its initial clock is zero, unless a start time is provided.]],
 	arguments = {
-		{ name = "startTime", type = "number", optional = true, defualt = 0 },
+		{ name = "startTime", type = "number", optional = true, default = 0 },
 	},
 	valuetype = "mwseTimerController"
 }

--- a/autocomplete/definitions/namedTypes/tes3actor.lua
+++ b/autocomplete/definitions/namedTypes/tes3actor.lua
@@ -1,6 +1,5 @@
 return {
 	type = "class",
-	brief = [[[An Actor (not to be confused with a Mobile Actor) is an object that can be cloned and that has an inventory. Creatures, NPCs, and containers are all considered actors.]],
 	description = [[An Actor (not to be confused with a Mobile Actor) is an object that can be cloned and that has an inventory. Creatures, NPCs, and containers are all considered actors.
 
 It is standard for creatures and NPCs to be composed of an actor and a mobile actor, linked together with a reference.]],

--- a/autocomplete/definitions/namedTypes/tes3actorAnimationController.lua
+++ b/autocomplete/definitions/namedTypes/tes3actorAnimationController.lua
@@ -1,5 +1,4 @@
 return {
 	type = "class",
-	brief = [[A controller for mobile actor animation.]],
 	description = [[Works in conjuction with mobile AI to perform idle, movement, and attack animations. Holds data on the status of the current and next desired animation states for the different body sections that can be animated.]],
 }

--- a/autocomplete/definitions/namedTypes/tes3playerAnimationController.lua
+++ b/autocomplete/definitions/namedTypes/tes3playerAnimationController.lua
@@ -1,6 +1,5 @@
 return {
 	type = "class",
-	brief = [[[A controller for mobile player animation.]],
 	description = [[Works in conjuction with mobile AI to perform idle, movement, and attack animations. Holds data on the status of the current and next desired animation states for the different body sections that can be animated.]],
 	inherits = "tes3actorAnimationController",
 }

--- a/autocomplete/definitions/namedTypes/tes3processManager/detectPresence.lua
+++ b/autocomplete/definitions/namedTypes/tes3processManager/detectPresence.lua
@@ -5,5 +5,5 @@ return {
 		{ name = "actor", type = "tes3mobileActor", description = "The actor to perform a check for." },
 		{ name = "ignoreCreatures", type = "boolean", optional = true, default = true },
 	},
-	valueType = "boolean"
+	valuetype = "boolean"
 }

--- a/docs/source/apis/mge.md
+++ b/docs/source/apis/mge.md
@@ -590,7 +590,7 @@ mge.saveScreenshot({ path = ..., captureWithUI = ... })
 **Parameters**:
 
 * `params` (table)
-	* `path` (string): The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension.
+	* `path` (string): The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension. The supported file formats are `bmp`, `jpeg`, `dds`, `png`, and `tga`.
 	* `captureWithUI` (boolean): *Default*: `false`. If set to `true`, the screenshot will include the user interface.
 
 ***

--- a/docs/source/apis/mge.md
+++ b/docs/source/apis/mge.md
@@ -590,7 +590,7 @@ mge.saveScreenshot({ path = ..., captureWithUI = ... })
 **Parameters**:
 
 * `params` (table)
-	* `path` (string)
+	* `path` (string): The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension.
 	* `captureWithUI` (boolean): *Default*: `false`. If set to `true`, the screenshot will include the user interface.
 
 ***

--- a/docs/source/apis/table.md
+++ b/docs/source/apis/table.md
@@ -198,7 +198,7 @@ local result = table.filter(t, f, ...)
 **Parameters**:
 
 * `t` (table)
-* `f` (fun(k: unknown, v: unknown, ...): boolean)
+* `f` (fun(k: unknown, v: unknown, ...): boolean): The function to use when filtering values of `t`. (This is sometimes called a predicate function.)
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:
@@ -223,7 +223,7 @@ local result = table.filterarray(arr, f, ...)
 **Parameters**:
 
 * `arr` (table)
-* `f` (fun(i: integer, v: unknown, ...): boolean)
+* `f` (fun(i: integer, v: unknown, ...): boolean): The function to use when filtering values of `t`. (This is sometimes called a predicate function.)
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:
@@ -346,7 +346,7 @@ local result = table.map(t, f, ...)
 **Parameters**:
 
 * `t` (table)
-* `f` (fun(k: unknown, v: unknown, ...): unknown)
+* `f` (fun(k: unknown, v: unknown, ...): unknown): The function to apply to each element of `t`.
 * `...` (any): Additional parameters to pass to `f`.
 
 **Returns**:

--- a/docs/source/apis/tes3.md
+++ b/docs/source/apis/tes3.md
@@ -3316,7 +3316,7 @@ local equal = tes3.isKeyEqual({ actual = ..., expected = ... })
 
 **Returns**:
 
-* `equal`
+* `equal` (boolean)
 
 ??? example "Example: Filtering out key presses that aren't equal to the bound key combination"
 

--- a/docs/source/apis/tes3ui.md
+++ b/docs/source/apis/tes3ui.md
@@ -239,7 +239,7 @@ local result = tes3ui.enterMenuMode(id)
 
 **Returns**:
 
-* `result` (boolean): true if the menu was switched, or false if it was already active.
+* `result` (boolean): True if the menu was switched, or false if it was already active.
 
 ***
 
@@ -627,7 +627,7 @@ local result = tes3ui.menuMode()
 
 **Returns**:
 
-* `result` (boolean): true if in menu mode.
+* `result` (boolean): `true` if in menu mode.
 
 ***
 

--- a/docs/source/apis/tes3ui.md
+++ b/docs/source/apis/tes3ui.md
@@ -230,7 +230,7 @@ local result = tes3ui.createTooltipMenu({ object = ..., itemData = ..., spell = 
 Requests menu mode be activated on a menu with a given id.
 
 ```lua
-local unnamed1 = tes3ui.enterMenuMode(id)
+local result = tes3ui.enterMenuMode(id)
 ```
 
 **Parameters**:
@@ -239,7 +239,7 @@ local unnamed1 = tes3ui.enterMenuMode(id)
 
 **Returns**:
 
-* `unnamed` (boolean): true if the menu was switched, or false if it was already active.
+* `result` (boolean): true if the menu was switched, or false if it was already active.
 
 ***
 
@@ -622,12 +622,12 @@ local executed = tes3ui.lookupID(id)
 Checks if the game is in menu mode.
 
 ```lua
-local unnamed1 = tes3ui.menuMode()
+local result = tes3ui.menuMode()
 ```
 
 **Returns**:
 
-* `unnamed` (boolean): true if in menu mode.
+* `result` (boolean): true if in menu mode.
 
 ***
 

--- a/docs/source/apis/tes3ui.md
+++ b/docs/source/apis/tes3ui.md
@@ -230,7 +230,7 @@ local result = tes3ui.createTooltipMenu({ object = ..., itemData = ..., spell = 
 Requests menu mode be activated on a menu with a given id.
 
 ```lua
-local result = tes3ui.enterMenuMode(id)
+local unnamed1 = tes3ui.enterMenuMode(id)
 ```
 
 **Parameters**:
@@ -239,7 +239,7 @@ local result = tes3ui.enterMenuMode(id)
 
 **Returns**:
 
-* `result` (boolean)
+* `unnamed` (boolean): true if the menu was switched, or false if it was already active.
 
 ***
 
@@ -622,12 +622,12 @@ local executed = tes3ui.lookupID(id)
 Checks if the game is in menu mode.
 
 ```lua
-local result = tes3ui.menuMode()
+local unnamed1 = tes3ui.menuMode()
 ```
 
 **Returns**:
 
-* `result` (boolean)
+* `unnamed` (boolean): true if in menu mode.
 
 ***
 

--- a/docs/source/events/uiActivated.md
+++ b/docs/source/events/uiActivated.md
@@ -87,5 +87,5 @@ event.register(tes3.event.uiActivated, uiActivatedCallback)
 ## Event Data
 
 * `element` ([tes3uiElement](../types/tes3uiElement.md)): *Read-only*. The menu element that was created. The event is filtered on element.name.
-* `newlyCreated` (boolean): *Read-only*. true if the menu was created for the first time or destroyed and re-created; false if it was made visible after being hidden. This can be used when adding custom elements to a menu, as elements previously added will still exist if the menu was hidden. If the menu was re-created, the elements will need to be added again.
+* `newlyCreated` (boolean): *Read-only*. `true` if the menu was created for the first time or destroyed and re-created; `false` if it was made visible after being hidden. This can be used when adding custom elements to a menu, as elements previously added will still exist if the menu was hidden. If the menu was re-created, the elements will need to be added again.
 

--- a/docs/source/types/mgeCameraConfig.md
+++ b/docs/source/types/mgeCameraConfig.md
@@ -156,5 +156,5 @@ mgeCameraConfig.zoomOut({ amount = ... })
 **Parameters**:
 
 * `params` (table): *Optional*.
-	* `amount` (number)
+	* `amount` (number): *Default*: `0.0625`.
 

--- a/docs/source/types/mwseTimer.md
+++ b/docs/source/types/mwseTimer.md
@@ -125,8 +125,12 @@ local paused = myObject:pause()
 Resets the timer completion time and iterations count.
 
 ```lua
-myObject:reset()
+local result = myObject:reset()
 ```
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/docs/source/types/mwseTimerController.md
+++ b/docs/source/types/mwseTimerController.md
@@ -63,7 +63,7 @@ local result = mwseTimerController.new(startTime)
 
 **Parameters**:
 
-* `startTime` (number): *Optional*.
+* `startTime` (number): *Default*: `0`.
 
 **Returns**:
 

--- a/docs/source/types/tes3processManager.md
+++ b/docs/source/types/tes3processManager.md
@@ -104,13 +104,17 @@ myObject:checkPlayerDistance()
 This function performs a check for presence of a given mobile actor.
 
 ```lua
-myObject:detectPresence(actor, ignoreCreatures)
+local result = myObject:detectPresence(actor, ignoreCreatures)
 ```
 
 **Parameters**:
 
 * `actor` ([tes3mobileActor](../types/tes3mobileActor.md)): The actor to perform a check for.
 * `ignoreCreatures` (boolean): *Default*: `true`.
+
+**Returns**:
+
+* `result` (boolean)
 
 ***
 

--- a/misc/package/Data Files/MWSE/core/meta/class/mgeCameraConfig.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mgeCameraConfig.lua
@@ -44,10 +44,10 @@ function mgeCameraConfig.zoomIn(params) end
 --- Zooms out by the specified amount, or by a small amount if no amount is provided.
 --- @param params mgeCameraConfig.zoomOut.params? This table accepts the following values:
 --- 
---- `amount`: number — No description yet available.
+--- `amount`: number? — *Default*: `0.0625`. No description yet available.
 function mgeCameraConfig.zoomOut(params) end
 
 ---Table parameter definitions for `mgeCameraConfig.zoomOut`.
 --- @class mgeCameraConfig.zoomOut.params
---- @field amount number No description yet available.
+--- @field amount number? *Default*: `0.0625`. No description yet available.
 

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseTimer.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseTimer.lua
@@ -23,6 +23,7 @@ function mwseTimer:cancel() end
 function mwseTimer:pause() end
 
 --- Resets the timer completion time and iterations count.
+--- @return boolean result No description yet available.
 function mwseTimer:reset() end
 
 --- Resumes a paused timer.

--- a/misc/package/Data Files/MWSE/core/meta/class/mwseTimerController.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/mwseTimerController.lua
@@ -9,7 +9,7 @@
 mwseTimerController = {}
 
 --- Creates a new Timer Controller. Its initial clock is zero, unless a start time is provided.
---- @param startTime number? *Optional*. No description yet available.
+--- @param startTime number? *Default*: `0`. No description yet available.
 --- @return mwseTimerController result No description yet available.
 function mwseTimerController.new(startTime) end
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3processManager.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3processManager.lua
@@ -26,6 +26,7 @@ function tes3processManager:checkPlayerDistance() end
 --- This function performs a check for presence of a given mobile actor.
 --- @param actor tes3mobileActor|tes3mobileCreature|tes3mobileNPC|tes3mobilePlayer The actor to perform a check for.
 --- @param ignoreCreatures boolean? *Default*: `true`. No description yet available.
+--- @return boolean result No description yet available.
 function tes3processManager:detectPresence(actor, ignoreCreatures) end
 
 --- This function performs a check whether a detector can detect another actor sneaking.

--- a/misc/package/Data Files/MWSE/core/meta/event/uiActivated.lua
+++ b/misc/package/Data Files/MWSE/core/meta/event/uiActivated.lua
@@ -70,4 +70,4 @@
 --- @class uiActivatedEventData
 --- @field claim boolean If set to `true`, any lower-priority event callbacks will be skipped. Returning `false` will set this to `true`.
 --- @field element tes3uiElement *Read-only*. The menu element that was created. The event is filtered on element.name.
---- @field newlyCreated boolean *Read-only*. true if the menu was created for the first time or destroyed and re-created; false if it was made visible after being hidden. This can be used when adding custom elements to a menu, as elements previously added will still exist if the menu was hidden. If the menu was re-created, the elements will need to be added again.
+--- @field newlyCreated boolean *Read-only*. `true` if the menu was created for the first time or destroyed and re-created; `false` if it was made visible after being hidden. This can be used when adding custom elements to a menu, as elements previously added will still exist if the menu was hidden. If the menu was re-created, the elements will need to be added again.

--- a/misc/package/Data Files/MWSE/core/meta/lib/mge.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mge.lua
@@ -104,14 +104,14 @@ function mge.saveConfig() end
 --- Saves a screenshot.
 --- @param params mge.saveScreenshot.params This table accepts the following values:
 --- 
---- `path`: string — The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension.
+--- `path`: string — The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension. The supported file formats are `bmp`, `jpeg`, `dds`, `png`, and `tga`.
 --- 
 --- `captureWithUI`: boolean? — *Default*: `false`. If set to `true`, the screenshot will include the user interface.
 function mge.saveScreenshot(params) end
 
 ---Table parameter definitions for `mge.saveScreenshot`.
 --- @class mge.saveScreenshot.params
---- @field path string The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension.
+--- @field path string The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension. The supported file formats are `bmp`, `jpeg`, `dds`, `png`, and `tga`.
 --- @field captureWithUI boolean? *Default*: `false`. If set to `true`, the screenshot will include the user interface.
 
 --- Sets the lighting mode used by MGE XE. The values passed can be used from the [`mge.lightingMode`](https://mwse.github.io/MWSE/references/mge/lighting-modes/) constants.

--- a/misc/package/Data Files/MWSE/core/meta/lib/mge.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/mge.lua
@@ -104,14 +104,14 @@ function mge.saveConfig() end
 --- Saves a screenshot.
 --- @param params mge.saveScreenshot.params This table accepts the following values:
 --- 
---- `path`: string — No description yet available.
+--- `path`: string — The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension.
 --- 
 --- `captureWithUI`: boolean? — *Default*: `false`. If set to `true`, the screenshot will include the user interface.
 function mge.saveScreenshot(params) end
 
 ---Table parameter definitions for `mge.saveScreenshot`.
 --- @class mge.saveScreenshot.params
---- @field path string No description yet available.
+--- @field path string The location of the folder to save the screenshot to. Relative to the Morrowind directory. *Needs* to include the file format extension.
 --- @field captureWithUI boolean? *Default*: `false`. If set to `true`, the screenshot will include the user interface.
 
 --- Sets the lighting mode used by MGE XE. The values passed can be used from the [`mge.lightingMode`](https://mwse.github.io/MWSE/references/mge/lighting-modes/) constants.

--- a/misc/package/Data Files/MWSE/core/meta/lib/table.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/table.lua
@@ -79,7 +79,7 @@ function table.empty(t, deepCheck) end
 ---  	Do not use this function on array-style tables, as it will not shift indices down after filtering out elements. Instead, you should use `table.filterarray` on array-style tables.
 --- 
 --- @param t table No description yet available.
---- @param f fun(k: unknown, v: unknown, ...): boolean No description yet available.
+--- @param f fun(k: unknown, v: unknown, ...): boolean The function to use when filtering values of `t`. (This is sometimes called a predicate function.)
 --- @param ... any Additional parameters to pass to `f`.
 --- @return table result The result of using `f` to filter out elements of `t`.
 function table.filter(t, f, ...) end
@@ -90,7 +90,7 @@ function table.filter(t, f, ...) end
 --- 
 --- When an element gets filtered out, the index of subsequent items will be shifted down, so that the resulting table plays nicely with the `#` operator and the `ipairs` function.
 --- @param arr table No description yet available.
---- @param f fun(i: integer, v: unknown, ...): boolean No description yet available.
+--- @param f fun(i: integer, v: unknown, ...): boolean The function to use when filtering values of `t`. (This is sometimes called a predicate function.)
 --- @param ... any Additional parameters to pass to `f`.
 --- @return table result The result of using `f` to filter out elements of `t`.
 function table.filterarray(arr, f, ...) end
@@ -129,7 +129,7 @@ function table.keys(t, sort) end
 --- Creates a new table consisting of key value pairs `k, f(k, v)`, where `k, v` is a pair in `t`.
 --- Any additional arguments will be passed to `f`. For example, `table.map(t, f, 10)` would call `f(k, v, 10)` on each value `v` of `t`.
 --- @param t table No description yet available.
---- @param f fun(k: unknown, v: unknown, ...): unknown No description yet available.
+--- @param f fun(k: unknown, v: unknown, ...): unknown The function to apply to each element of `t`.
 --- @param ... any Additional parameters to pass to `f`.
 --- @return table result The result of applying `f` to each value in `t`.
 function table.map(t, f, ...) end

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3.lua
@@ -1671,7 +1671,7 @@ function tes3.isInitialized() end
 --- `actual`: table|mwseKeyCombo|mwseKeyMouseCombo|mwseKeyMouseCombo|keyDownEventData|keyUpEventData|keyEventData|mouseButtonDownEventData|mouseButtonUpEventData|mouseWheelEventData — The key object that is being compared.
 --- 
 --- `expected`: table|mwseKeyCombo|mwseKeyMouseCombo|mwseKeyMouseCombo|keyDownEventData|keyUpEventData|keyEventData|mouseButtonDownEventData|mouseButtonUpEventData|mouseWheelEventData — The key object that is being compared against.
---- @return any equal No description yet available.
+--- @return boolean equal No description yet available.
 function tes3.isKeyEqual(params) end
 
 ---Table parameter definitions for `tes3.isKeyEqual`.

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
@@ -114,7 +114,7 @@ function tes3ui.createTooltipMenu(params) end
 
 --- Requests menu mode be activated on a menu with a given id.
 --- @param id string|number No description yet available.
---- @return boolean result true if the menu was switched, or false if it was already active.
+--- @return boolean result True if the menu was switched, or false if it was already active.
 function tes3ui.enterMenuMode(id) end
 
 --- Locates a help layer menu through its id. Help layer menus include notifications and tooltips that are always above the rest of the interface. The game realizes this using a separate menu root and set of functions.
@@ -199,7 +199,7 @@ function tes3ui.logToConsole(text, isCommand) end
 function tes3ui.lookupID(id) end
 
 --- Checks if the game is in menu mode.
---- @return boolean result true if in menu mode.
+--- @return boolean result `true` if in menu mode.
 function tes3ui.menuMode() end
 
 --- Brings a menu forward to be the top-most menu, firing any associated front-related events. The desired element must be a top-level menu.

--- a/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/tes3ui.lua
@@ -114,7 +114,7 @@ function tes3ui.createTooltipMenu(params) end
 
 --- Requests menu mode be activated on a menu with a given id.
 --- @param id string|number No description yet available.
---- @return boolean result No description yet available.
+--- @return boolean result true if the menu was switched, or false if it was already active.
 function tes3ui.enterMenuMode(id) end
 
 --- Locates a help layer menu through its id. Help layer menus include notifications and tooltips that are always above the rest of the interface. The game realizes this using a separate menu root and set of functions.
@@ -199,7 +199,7 @@ function tes3ui.logToConsole(text, isCommand) end
 function tes3ui.lookupID(id) end
 
 --- Checks if the game is in menu mode.
---- @return boolean result No description yet available.
+--- @return boolean result true if in menu mode.
 function tes3ui.menuMode() end
 
 --- Brings a menu forward to be the top-most menu, firing any associated front-related events. The desired element must be a top-level menu.


### PR DESCRIPTION
This PR does two things:
1. Fix niche typos in the documentation files. All of these changes address typos related to internal (Lua) values utilized by the documentation generators.
    - This results in more documentation being generated for the affected files. 
    - Some of those changes may require further review.
2. Removes the `brief` description from three documentation files. (No other files have a `brief` description.)
    - This was done because the current documentation generator does not utilize this field and the [type definitions guide](https://github.com/MWSE/MWSE/blob/master/docs/type-definitions-guide.md#value-definitions) gave me the impression that this field has been deprecated.
    - I can walk back this change if desirable.
