### PR TITLE
Docs: Fix typo regarding `load-priority` in the `metadata` guide

### DIFF
--- a/docs/source/guides/metadata.md
+++ b/docs/source/guides/metadata.md
@@ -55,7 +55,7 @@ The following fields are available:
     The following fields are available:
 
     * `lua-mod` - The path to the main.lua associated with this mod. For example, if your main.lua file is located in `"Data Files\MWSE\mods\g7\myMod\main.lua"`, then this field should be set to `"g7.myMod"`.
-    * `load-priority` - The priority for when this mod is loaded. Lower numbers are loaded first.
+    * `load-priority` - The priority for when this mod is loaded. Higher numbers are loaded first.
     * `wait-until-initialize` - Whether to wait until the game has initialized before loading this mod.
 
     Example:


### PR DESCRIPTION
The metadata guide states that a lower `load-priority` results in a mod loading earlier. But this does not seem to be consistent with my testing. I have updated the page to state that a higher `load-priority` results in mods loading earlier.

## Explanation

The package sorting function (defined in `core/startLuaMods.lua`) has the code:
```lua
-- Then we sort by explicit load order.
if (a.load_priority ~= b.load_priority) then
    return a.load_priority > b.load_priority
end
```
This results in mods with a higher `load_priority` being placed earlier in the `runtimes` array, resulting in them executing earlier.

## Testing

To verify this, I created two mods, named `priority_5` and `priority_10`, with metadata files:
```toml
[package]
name = "Priority 10"

[tools.mwse]
lua-mod = "priority_10"
load-priority = 10
```
and
```toml
[package]
name = "Priority 5"

[tools.mwse]
lua-mod = "priority_5"
load-priority = 5
```
Each of their `main.lua` files consists of a single print statement saying `"loaded with priority 5"` and `"loaded with priority 10"`, respectively.

This results in the following log statements being printed in this order:
```
running mod with priority 10
running mod with priority 5
```

