### PR TITLE
Docs: Update description of `table.removevalue`

### DIFF
--- a/autocomplete/definitions/global/table/removevalue.lua
+++ b/autocomplete/definitions/global/table/removevalue.lua
@@ -1,8 +1,8 @@
 return {
 	type = "function",
-	description = [[Removes a value from a given table. Returns true if the value was successfully removed.]],
+	description = [[Removes a `value` from a given `list`. Returns `true` if the value was successfully removed.]],
 	arguments = {
-		{ name = "t", type = "table" },
+		{ name = "list", type = "table" },
 		{ name = "value", type = "unknown" },
 	},
 	valuetype = "boolean",

--- a/docs/source/apis/table.md
+++ b/docs/source/apis/table.md
@@ -426,15 +426,15 @@ local newTable = table.new(narray, nhash)
 ### `table.removevalue`
 <div class="search_terms" style="display: none">removevalue, value</div>
 
-Removes a value from a given table. Returns true if the value was successfully removed.
+Removes a `value` from a given `list`. Returns `true` if the value was successfully removed.
 
 ```lua
-local result = table.removevalue(t, value)
+local result = table.removevalue(list, value)
 ```
 
 **Parameters**:
 
-* `t` (table)
+* `list` (table)
 * `value` (unknown)
 
 **Returns**:

--- a/misc/package/Data Files/MWSE/core/meta/lib/table.lua
+++ b/misc/package/Data Files/MWSE/core/meta/lib/table.lua
@@ -160,11 +160,11 @@ function table.map(t, f, ...) end
 --- @return table newTable The pre-sized table that was created.
 function table.new(narray, nhash) end
 
---- Removes a value from a given table. Returns true if the value was successfully removed.
---- @param t table No description yet available.
+--- Removes a `value` from a given `list`. Returns `true` if the value was successfully removed.
+--- @param list table No description yet available.
 --- @param value unknown No description yet available.
 --- @return boolean result No description yet available.
-function table.removevalue(t, value) end
+function table.removevalue(list, value) end
 
 --- Shuffles the table in place using the Fisher-Yates algorithm. Passing in table size as the second argument saves the function from having to get it itself.
 --- @param t table No description yet available.


### PR DESCRIPTION
My goal was to make it clearer that this function only works on array-style tables. But I can make this more explicit if desirable.
