### PR TITLE
Make dialogue filters behave more like vanilla

### DIFF
--- a/MWSE/TES3DialogueFilterContext.cpp
+++ b/MWSE/TES3DialogueFilterContext.cpp
@@ -101,6 +101,7 @@ namespace TES3 {
 
 		const auto speakerBase = context->parentContext->speakerBaseActor;
 		if (speakerBase->objectType != ObjectType::NPC) {
+			context->compareValue = 0.0f;
 			return;
 		}
 
@@ -121,6 +122,7 @@ namespace TES3 {
 
 		const auto speakerBase = context->parentContext->speakerBaseActor;
 		if (speakerBase->objectType != ObjectType::NPC) {
+			context->compareValue = 0.0f;
 			return;
 		}
 
@@ -141,11 +143,13 @@ namespace TES3 {
 
 		const auto speakerBase = context->parentContext->speakerBaseActor;
 		if (speakerBase->objectType != ObjectType::NPC) {
+			context->compareValue = 0.0f;
 			return;
 		}
 
 		const auto faction = speakerBase->getFaction();
 		if (faction == nullptr) {
+			context->compareValue = 0.0f;
 			return;
 		}
 
@@ -160,6 +164,7 @@ namespace TES3 {
 
 		const auto speaker = context->parentContext->speaker;
 		if (speaker->objectType != ObjectType::NPC) {
+			context->compareValue = 0.0f;
 			return;
 		}
 
@@ -268,11 +273,13 @@ namespace TES3 {
 
 		const auto speakerBase = context->parentContext->speakerBaseActor;
 		if (speakerBase->objectType != ObjectType::NPC) {
+			context->compareValue = 0.0f;
 			return;
 		}
 
 		const auto faction = speakerBase->getFaction();
 		if (faction == nullptr) {
+			context->compareValue = 0.0f;
 			return;
 		}
 
@@ -350,11 +357,8 @@ namespace TES3 {
 		}
 
 		const auto speakerBase = context->parentContext->speakerBaseActor;
-		if (speakerBase->objectType != ObjectType::NPC) {
-			return;
-		}
 
-		const auto faction = speakerBase->getFaction();
+		const auto faction = speakerBase->objectType != ObjectType::NPC ? nullptr : speakerBase->getFaction();
 		context->compareValue = faction && faction->getPlayerJoined() ? 1.0f : 0.0f;
 		context->compareOperator = DialogueConditionalComparator::Equal;
 	}
@@ -367,6 +371,7 @@ namespace TES3 {
 
 		const auto speakerBase = context->parentContext->speakerBaseActor;
 		if (speakerBase->objectType != ObjectType::NPC) {
+			context->compareValue = 0.0f;
 			return;
 		}
 


### PR DESCRIPTION
Analogous to https://gitlab.com/OpenMW/openmw/-/merge_requests/4525

SHotN features a bunch of `PC Expelled` filters on an NPC without a faction. When MWSE dialogue filtering is enabled, those lines don't fire. When it's disabled, they work fine.
https://discord.com/channels/261789910594355200/1046088021071638538/1353642015023435856

Note that I didn't actually set up a dev environment or anything so this is essentially untested code.