### PR TITLE
Make MCM Template reopen the last page

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
@@ -317,10 +317,9 @@ function Template:createSubcomponentsContainer(parentBlock)
 	local pageBlock = parentBlock:createBlock()
 	pageBlock.heightProportional = 1.0
 	pageBlock.widthProportional = 1.0
-	self.currentPage = self.pages[1]
-	self.currentPage:create(pageBlock)
-	self.elements.pageBlock = pageBlock
 	pageBlock.flowDirection = tes3.flowDirection.leftToRight
+	self.elements.pageBlock = pageBlock
+	self:clickTab(self.currentPage or self.pages[1])
 end
 
 --- @param parentBlock tes3uiElement


### PR DESCRIPTION
If the MCM is closed and reopened, the most recently viewed page of a mods config menu will be displayed. If no previous page was viewed, then the first page is opened instead.

This is accomplished by just making the `Template:createSubcomponentsContainer` method call the already existing `clickTab` page instead of manually initializing the first page.

## Notes
- This change was previously a part of #532, but I realized today that a more efficient implementation is possible by modifying the `mwseMCMTemplate` class itself. 
    - The implementation in #532 would create the first page of a mods MCM and then click the most recently viewed tab. 
    - The approach in this PR skips the creation of the first page, and only creates the most recently viewed page.

## Disadvantages of this approach
- This approach will remember the most recently viewed page of _every_ MCM, _forever_ (until the game is closed).
- Example: 
    - Say a user opens the config menu for `Mod A`, and changes things on page 2 of that mod config menu, and then the user clicks on various other config menus for different mods.
    - When the user opens the config menu for `Mod A` again, the menu will be opened to page 2, rather than page 1.

## Proposed Solution
The previous problem can be solved by 
1. Adding a `resetLastPage` method to the `mwseMCMTemplate` class that resets the page being most recently viewed.
2. Using the refactor in #532, the `mcm/main.lua` file can be modified so that each time the user clicks on a different mod, the `mwseMCMTemplate:resetLastPage()` method is called on the previously opened mod config menu.


If this solution sounds reasonable, I can implement those changes in  #532, or this PR, or make a new PR that combines the changes in this PR with the changes in #532, whichever is best.
