### PR TITLE
Docs: add support for type properties

### DIFF
--- a/autocomplete/builders/common.lua
+++ b/autocomplete/builders/common.lua
@@ -467,6 +467,7 @@ end
 --- @field children table<string, package>|nil
 --- @field functions packageFunction[]|nil
 --- @field values packageValue[]|nil
+--- @field typeValues packageValue[]|nil
 
 ---@class packageOverload
 ---@field rightType string

--- a/autocomplete/builders/emmy.lua
+++ b/autocomplete/builders/emmy.lua
@@ -62,7 +62,7 @@ local function shouldCreateTable(package)
 	return (
 		package.type == "lib" or
 		package.type == "class" and (
-			package.methods and	#package.methods > 0 or
+			package.methods and #package.methods > 0 or
 			package.functions and #package.functions > 0
 		)
 		or false
@@ -402,13 +402,16 @@ local function build(package)
 
 
 	-- Write out fields.
-	if (package.values) then
-		table.sort(package.values, function(a, b)
-			return a.key:lower() < b.key:lower()
-		end)
-		for _, value in ipairs(package.values) do
-			if (not value.deprecated) then
-				file:write(string.format("--- @field %s %s %s\n", value.key, getAllPossibleVariationsOfType(value.valuetype, value) or "any", formatLineBreaks(common.getDescriptionString(value))))
+	local fieldKeys = { "values", "typeValues" }
+	for _, valueKey in ipairs(fieldKeys) do
+		if (package[valueKey]) then
+			table.sort(package[valueKey], function(a, b)
+				return a.key:lower() < b.key:lower()
+			end)
+			for _, value in ipairs(package[valueKey]) do
+				if (not value.deprecated) then
+					file:write(string.format("--- @field %s %s %s\n", value.key, getAllPossibleVariationsOfType(value.valuetype, value) or "any", formatLineBreaks(common.getDescriptionString(value))))
+				end
 			end
 		end
 	end

--- a/autocomplete/builders/mkdocs.lua
+++ b/autocomplete/builders/mkdocs.lua
@@ -482,6 +482,11 @@ local function writePackageDetails(file, package)
 		or needsHorizontalRule
 	)
 
+	needsHorizontalRule = (
+		writeFields(file, package, "typeValues", "Type Properties", writeSubPackage, needsHorizontalRule)
+		or needsHorizontalRule
+	)
+
 	-- Write out methods.
 	needsHorizontalRule = (
 		writeFields(file, package, "methods", "Methods", writeSubPackage, needsHorizontalRule)

--- a/docs/type-definitions-guide.md
+++ b/docs/type-definitions-guide.md
@@ -53,7 +53,30 @@ return {
 	type = "value",
 	description = [[Array-style table for the different weather types. Each object in the table is a [tes3weather](https://mwse.github.io/MWSE/types/tes3weather/). The indexes in the table correspond to the [`tes3.weather`](https://mwse.github.io/MWSE/references/weather-types/) enumeration.]],
 	readOnly = true,
-	valuetype = "table<number, tes3weather>",
+	valuetype = "table<tes3.weather, tes3weather>",
+}
+```
+
+### Type Property Definitions
+
+This kind of definitions is meant for documenting constants available on types not instances. For example some math classes such as `tes3vector3` could have a `forward` property documented this way. Type property definition schema:
+| Field       | Type      | Description |
+| ----------- | --------- | ----------- |
+| type        | `string`  | The type of the definition. This flag is used when generating syntax highlighting files. This should always be `"typeValue"` for type property defintions. |
+| description | `string`  | The description for the property. |
+| readOnly    | `boolean` | If the property is writable, this field is unnecessary. |
+| valuetype   | `string`  | This allows to specify the property type. You can put string names for basic
+Lua types: `number`, `boolean` and `string`, or objects exposed by MWSE, such as `tes3reference`. If the value can be of two or more types, then you should pass all the types joined by the vertical bar character, thereby passing a union of all the possible types. If the type is `table`, consider adding the key and value types like this: `table<indexType, keyType>`. This will allow autocomplete to automatically deduce the types when the table is indexed. See more in the example below. |
+| examples    | `table`   | A table with entries that are the names of the files included as examples. Each entry is a table itself with one available field, `title`. The title will be shown as the title of the example on the documentation page. It works the same as examples for [event](https://github.com/MWSE/MWSE/blob/master/docs/event-definitions-guide.md) or [function](https://github.com/MWSE/MWSE/blob/master/docs/function-definitions-guide.md) definitions. |
+
+An example of a hypothetical type property definition:
+
+```lua
+-- autocomplete\definitions\namedTypes\tes3vector3\forward.lua
+return {
+	type = "typeValue",
+	description = [[A vector pointing along the positive X axis.]],
+	valuetype = "tes3vector3",
 }
 ```
 
@@ -86,7 +109,7 @@ For a more elaborate description of the argument and return tables, please refer
 
 ## Notes
 
-Some types may have fields that are not values or methods. In that case, you can pass different types to the `type` value of the definition. For example, some types also expose functions. In that case, you can pass `type = "function."`. Here is an example of such a definition:
+Some types may have fields that are not values or methods. In that case, you can pass different types to the `type` value of the definition. For example, some types also expose functions. In that case, you can pass `type = "function"`. Here is an example of such a definition:
 
 ```lua
 -- autocomplete\definitions\namedTypes\tes3vector3\new.lua


### PR DESCRIPTION
For example, `tes3vector3.unitX` would could be documented as:
```lua
return {
	type = "typeValue",
	description = [[Creates a new vector pointing along the positive X axis.]],
	valuetype = "tes3vector3",
}
```
Which would look like this on site:
![image](https://github.com/user-attachments/assets/1d8d0c34-3018-49db-b865-c11e92c291fa)
