### PR TITLE
Fix bug in `Template:clickTab`

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
@@ -170,7 +170,7 @@ end
 --- @param thisPage mwseMCMExclusionsPage|mwseMCMFilterPage|mwseMCMMouseOverPage|mwseMCMPage|mwseMCMSideBarPage
 function Template:clickTab(thisPage)
 	local pageBlock = self.elements.pageBlock
-	local tabsBlock = self.elements.tabsBlock
+	
 	-- Clear previous page
 	pageBlock:destroyChildren()
 	-- Create new page
@@ -178,23 +178,28 @@ function Template:clickTab(thisPage)
 	-- Set new page to current
 	self.currentPage = thisPage
 
-	-- Disable tabs and tally width
-	local totalWidth = 0
-	for id, page in pairs(self.pages) do
-		local tab = tabsBlock:findChild(page.tabUID)
-		tab.widget.state =  tes3.uiState.normal
-		totalWidth = totalWidth + tab.width
+	local tabsBlock = self.elements.tabsBlock
+
+	-- Update the tabs (if there are any)
+	if tabsBlock then
+		-- Disable tabs and tally width
+		local totalWidth = 0
+		for _id, page in pairs(self.pages) do
+			local tab = tabsBlock:findChild(page.tabUID)
+			tab.widget.state =  tes3.uiState.normal
+			totalWidth = totalWidth + tab.width
+		end
+		-- Enable tab for this page
+		local tab = tabsBlock:findChild(thisPage.tabUID)
+		tab.widget.state = tes3.uiState.active
+
+		-- Ensure tabs are visible.
+		tabsBlock.childOffsetX = 0
+		tabsBlock:updateLayout()
+		tabsBlock.childOffsetX = math.clamp(-tab.positionX, -totalWidth + tabsBlock.width, 0)
+
+		self:padTabBlock()
 	end
-	-- Enable tab for this page
-	local tab = tabsBlock:findChild(thisPage.tabUID)
-	tab.widget.state = tes3.uiState.active
-
-	-- Ensure tabs are visible.
-	tabsBlock.childOffsetX = 0
-	tabsBlock:updateLayout()
-	tabsBlock.childOffsetX = math.clamp(-tab.positionX, -totalWidth + tabsBlock.width, 0)
-
-	self:padTabBlock()
 
 	-- update view
 	pageBlock:getTopLevelMenu():updateLayout()


### PR DESCRIPTION
The changes made in #610 resulted in `Template:clickTab` being called when `Template.elements.tabsBlock` might be `nil`. This could happen if the `Template` only had a single page.

This PR makes a small fix that adds a `nil` check to `Template:clickTab` to ensure `tabsBlock` is not `nil` before doing any `tabsBlock` related updates.

Note that while the actual change to the code is rather small, the git diff is a bit unpleasant because of the added indentation. If desired, this could be mitigated by instead doing something like
```lua
if not tabsBlock then
    pageBlock:getTopLevelMenu():updateLayout()
    return
end
```
Let me know if that would be better and I can make that change.