### PR TITLE
Ni utilities

### DIFF
--- a/MWSE/FileUtil.cpp
+++ b/MWSE/FileUtil.cpp
@@ -203,7 +203,7 @@ namespace mwse {
 		if (file != INVALID_HANDLE_VALUE)
 		{
 			//Tp21 2006-06-21: Stop MWSE getting stuck if there's no data available to be read (original code from timeslip)
-			if (*fileName == '|') { //check if it's an pipe
+			if (*fileName == '|') { //check if it's a pipe
 				DWORD toread;
 				PeekNamedPipe(file, NULL, 0, NULL, &toread, NULL); //look if there is something to read
 				if (!toread) return 0; //if not, return

--- a/MWSE/NIAVObject.cpp
+++ b/MWSE/NIAVObject.cpp
@@ -6,6 +6,7 @@
 
 #include "BitUtil.h"
 #include "MemoryUtil.h"
+#include "StringUtil.h"
 
 constexpr auto NI_AVObject_updateEffects = 0x6EB380;
 constexpr auto NI_AVObject_updateProperties = 0x6EB0E0;
@@ -34,8 +35,19 @@ namespace NI {
 		}
 	}
 
-	AVObject * AVObject::getObjectByName(const char* name) {
+	AVObject* AVObject::getObjectByName(const char* name) {
 		return vTable.asAVObject->getObjectByName(this, name);
+	}
+
+	AVObject* AVObject::getParentByName(const char* name) const {
+		Node* result = parentNode;
+		while (result != nullptr) {
+			if (mwse::string::equal(name, result->name)) {
+				return result;
+			}
+			result = result->parentNode;
+		}
+		return nullptr;
 	}
 
 	bool AVObject::getAppCulled() const {

--- a/MWSE/NIAVObject.h
+++ b/MWSE/NIAVObject.h
@@ -111,6 +111,8 @@ namespace NI {
 		void copyTransforms_lua(const sol::stack_object from);
 		TES3::Transform getTransforms() const;
 
+		AVObject* getParentByName(const char*) const;
+
 		Pointer<Property> getProperty(PropertyType type) const;
 		Pointer<AlphaProperty> getAlphaProperty() const;
 		void setAlphaProperty(sol::optional<AlphaProperty*> prop);

--- a/MWSE/NIObjectLua.h
+++ b/MWSE/NIObjectLua.h
@@ -86,6 +86,7 @@ namespace mwse::lua {
 
 		// Functions that need their results wrapped.
 		usertypeDefinition["getObjectByName"] = &NI::AVObject::getObjectByName;
+		usertypeDefinition["getParentByName"] = &NI::AVObject::getParentByName;
 		usertypeDefinition["getProperty"] = &NI::AVObject::getProperty;
 		usertypeDefinition["parent"] = sol::readonly_property(&NI::AVObject::parentNode);
 

--- a/MWSE/NIPixelData.cpp
+++ b/MWSE/NIPixelData.cpp
@@ -43,6 +43,77 @@ namespace NI {
 		return widths[mipMapLevel];
 	}
 
+	void PixelData::exportTGA(const char* fileName) const {
+		if (pixelFormat.format != PixelFormat::Format::RGBA) {
+			std::exception("Unsupported pixel format for export to TGA.");
+		}
+		HANDLE hFile = CreateFileA(
+			fileName,
+			GENERIC_WRITE,
+			0,
+			NULL,
+			CREATE_ALWAYS,
+			FILE_ATTRIBUTE_NORMAL,
+			NULL
+		);
+		if (hFile == INVALID_HANDLE_VALUE) {
+			std::exception("Couldn't open the file for export.");
+		}
+		auto width = getWidth();
+		auto height = getHeight();
+		HeaderTGA header{
+			0, // idLength - No image description
+			0, // colormapType - No color pallete
+			HeaderTGA::DataType::UNCOMPRESSED_RGB,
+			0, // colormapOrigin
+			0, // colormapLength
+			0, // colormapDepth
+			0, // xOrigin
+			0, // yOrigin
+			static_cast<short>(width),
+			static_cast<short>(height),
+			static_cast<unsigned char>(bytesPerPixel * 8), // bitsPerPixel
+			0x08 | 0x20 // Flag bit 3: 8 bits for alpha + flag bit 5: origin in the upper left-hand corner
+		};
+
+		// Write the TGA header
+		DWORD bytesWritten = 0;
+		WriteFile(
+			hFile,
+			&header,
+			sizeof(header),
+			&bytesWritten,
+			NULL
+		);
+
+		// Write the pixel data
+		size_t bytesToWrite = width * height * bytesPerPixel;
+		std::vector<unsigned char> imageData;
+		imageData.reserve(bytesToWrite);
+
+		size_t offset = 0;
+		// TGA stores channels in BGR(A) format, so we need to swap blue and red channels
+		for (size_t y = 0; y < height; ++y) {
+			for (size_t x = 0; x < width; ++x) {
+				imageData.emplace_back(pixels[offset + 2]); // Blue
+				imageData.emplace_back(pixels[offset + 1]); // Green
+				imageData.emplace_back(pixels[offset + 0]); // Red
+				imageData.emplace_back(pixels[offset + 3]); // Alpha
+				offset += bytesPerPixel;
+			}
+		}
+
+		WriteFile(
+			hFile,
+			imageData.data(),
+			bytesToWrite,
+			&bytesWritten,
+			NULL
+		);
+		SetEndOfFile(hFile);
+		CloseHandle(hFile);
+	}
+
 	unsigned int PixelData::getHeight_lua(sol::optional<unsigned int> mipMapLevel) const {
 		return getHeight(mipMapLevel.value_or(1) - 1);
 	}

--- a/MWSE/NIPixelData.h
+++ b/MWSE/NIPixelData.h
@@ -8,6 +8,34 @@
 
 namespace NI {
 	struct PixelData : Object {
+#pragma pack(push, 1)
+		struct HeaderTGA {
+			enum struct DataType : unsigned char {
+				NO_IMAGE_DATA = 0,
+				UNCOMPRESSED_PALLETIZED = 1,
+				UNCOMPRESSED_RGB = 2,
+				UNCOMPRESSED_BLACK_WHITE = 3,
+				RLE_PALLETIZED = 9,
+				RLE_RGB = 10,
+				COMPRESSED_BLACK_WHITE = 11,
+				COMPRESSED_1 = 32,
+				COMPRESSED_2 = 33
+			};
+			unsigned char idLength;
+			unsigned char colormapType;
+			DataType datatypeCode;
+			short colormapOrigin;
+			short colormapLength;
+			unsigned char colormapDepth;
+			short xOrigin;
+			short yOrigin;
+			short width;
+			short height;
+			unsigned char bitsPerPixel;
+			unsigned char imageDescriptor;
+		};
+#pragma pack(pop)
+
 		PixelFormat pixelFormat;
 		void * palette; // 0x28
 		unsigned char * pixels; // 0x2C // The raw pixel data, in the given format.
@@ -29,6 +57,7 @@ namespace NI {
 
 		unsigned int getHeight(unsigned int mipMapLevel = 0) const;
 		unsigned int getWidth(unsigned int mipMapLevel = 0) const;
+		void exportTGA(const char* fileName) const;
 
 		unsigned int getHeight_lua(sol::optional<unsigned int> mipMapLevel) const;
 		unsigned int getWidth_lua(sol::optional<unsigned int> mipMapLevel) const;

--- a/MWSE/NIPixelDataLua.cpp
+++ b/MWSE/NIPixelDataLua.cpp
@@ -35,6 +35,7 @@ namespace mwse::lua {
 			usertypeDefinition["createSourceTexture"] = &NI::PixelData::createSourceTexture;
 			usertypeDefinition["getWidth"] = &NI::PixelData::getWidth_lua;
 			usertypeDefinition["getHeight"] = &NI::PixelData::getHeight_lua;
+			usertypeDefinition["exportTGA"] = &NI::PixelData::exportTGA;
 			usertypeDefinition["setPixelsByte"] = &NI::PixelData::setPixelsByte_lua;
 			usertypeDefinition["setPixelsFloat"] = &NI::PixelData::setPixelsFloat_lua;
 			usertypeDefinition["fill"] = &NI::PixelData::fill_lua;

--- a/MWSE/NISwitchNode.cpp
+++ b/MWSE/NISwitchNode.cpp
@@ -1,5 +1,7 @@
 #include "NISwitchNode.h"
 
+#include "StringUtil.h"
+
 namespace NI {
 	int SwitchNode::getSwitchIndex() {
 		return switchIndex;
@@ -18,6 +20,15 @@ namespace NI {
 			return children.at(switchIndex);
 		}
 		return nullptr;
+	}
+
+	int SwitchNode::getChildIndexByName(const char* name) const {
+		for (auto i = 0u; i < children.size(); ++i) {
+			if (mwse::string::equal(name, children[i].get()->name)) {
+				return i;
+			}
+		}
+		return -1;
 	}
 }
 

--- a/MWSE/NISwitchNode.h
+++ b/MWSE/NISwitchNode.h
@@ -17,6 +17,7 @@ namespace NI {
 		int getSwitchIndex();
 		void setSwitchIndex(int index);
 		Pointer<AVObject> getActiveChild() const;
+		int getChildIndexByName(const char*) const;
 
 	};
 	static_assert(sizeof(SwitchNode) == 0xD8, "NI::SwitchNode failed size validation");

--- a/MWSE/NISwitchNodeLua.cpp
+++ b/MWSE/NISwitchNodeLua.cpp
@@ -28,5 +28,6 @@ namespace mwse::lua {
 
 		// Basic function binding.
 		usertypeDefinition["getActiveChild"] = &NI::SwitchNode::getActiveChild;
+		usertypeDefinition["getChildIndexByName"] = &NI::SwitchNode::getChildIndexByName;
 	}
 }


### PR DESCRIPTION
This PR adds the following:

```lua
-- Case-sensitive search for the first parent node with the matching "name"
---@param name string
---@return niAVObject
function niAVObject:getParentByName(name) end

-- Case-sensitive search for the first parent node with the matching "name"
---@param name string
---@return integer index
function niSwitchNode:getChildIndexByName(name) end

-- Saves the first mipmap of an RGB32 pixel data as an uncompressed TGA image. If an image of the same name already exists it will be overwritten.
---@param fileName string The filename for the new image. Relative to Morrowind install directory. Needs to include the `.tga` extension.
function niPixelData:exportTGA(fileName) end
```

Based on:
Crafting framework's [`NodeUtils.getNamedParent`](https://github.com/jhaakma/crafting-framework/blob/master/Data%20Files/MWSE/mods/CraftingFramework/util/NodeUtils.lua#L12)
Crafting framework's [`SwitchNode.getIndex`](
https://github.com/jhaakma/crafting-framework/blob/master/Data%20Files/MWSE/mods/CraftingFramework/nodeVisuals/SwitchNode.lua#L39)
Joy of Painting's [`common.writeTGAFromPixelMap`](https://github.com/jhaakma/joy-of-painting/blob/master/Data%20Files/MWSE/mods/mer/joyOfPainting/common.lua#L248)

I expect `niPixelData:exportTGA` to be useful when working on #565.