### PR TITLE
Docs: Fix fields in `tes3ui.showMessageMenu.params.tooltip` not marked optional

### DIFF
--- a/autocomplete/definitions/namedTypes/tes3ui.showMessageMenu.params.tooltip/callback.lua
+++ b/autocomplete/definitions/namedTypes/tes3ui.showMessageMenu.params.tooltip/callback.lua
@@ -1,5 +1,5 @@
 return {
 	type = "value",
 	description = [[A function to call when the tooltip has been created. Passes context information. Can be used to make further adjustments to the tooltip.]],
-	valuetype = "fun(params: tes3ui.showMessageMenu.params.tooltip.callbackData)",
+	valuetype = "nil|fun(params: tes3ui.showMessageMenu.params.tooltip.callbackData)",
 }

--- a/autocomplete/definitions/namedTypes/tes3ui.showMessageMenu.params.tooltip/header.lua
+++ b/autocomplete/definitions/namedTypes/tes3ui.showMessageMenu.params.tooltip/header.lua
@@ -1,5 +1,5 @@
 return {
 	type = "value",
 	description = [[The header at the top of the tooltip. Can also be a function that returns a string.]],
-	valuetype = "string|fun(callbackParams: table): string|nil",
+	valuetype = "nil|string|fun(callbackParams: table): string|nil",
 }

--- a/autocomplete/definitions/namedTypes/tes3ui.showMessageMenu.params.tooltip/text.lua
+++ b/autocomplete/definitions/namedTypes/tes3ui.showMessageMenu.params.tooltip/text.lua
@@ -1,5 +1,5 @@
 return {
 	type = "value",
 	description = [[The text in the body of the tooltip. Can also be a function that returns a string.]],
-	valuetype = "string|fun(callbackParams: table): string|nil",
+	valuetype = "nil|string|fun(callbackParams: table): string|nil",
 }

--- a/docs/source/types/tes3ui.showMessageMenu.params.tooltip.md
+++ b/docs/source/types/tes3ui.showMessageMenu.params.tooltip.md
@@ -17,7 +17,7 @@ A function to call when the tooltip has been created. Passes context information
 
 **Returns**:
 
-* `result` (fun(params: [tes3ui.showMessageMenu.params.tooltip.callbackData](../types/tes3ui.showMessageMenu.params.tooltip.callbackData.md)))
+* `result` (nil, fun(params: [tes3ui.showMessageMenu.params.tooltip.callbackData](../types/tes3ui.showMessageMenu.params.tooltip.callbackData.md)))
 
 ***
 
@@ -28,7 +28,7 @@ The header at the top of the tooltip. Can also be a function that returns a stri
 
 **Returns**:
 
-* `result` (string, fun(callbackParams: table): string, nil)
+* `result` (nil, string, fun(callbackParams: table): string, nil)
 
 ***
 
@@ -39,5 +39,5 @@ The text in the body of the tooltip. Can also be a function that returns a strin
 
 **Returns**:
 
-* `result` (string, fun(callbackParams: table): string, nil)
+* `result` (nil, string, fun(callbackParams: table): string, nil)
 

--- a/misc/package/Data Files/MWSE/core/meta/class/tes3ui.showMessageMenu.params.tooltip.lua
+++ b/misc/package/Data Files/MWSE/core/meta/class/tes3ui.showMessageMenu.params.tooltip.lua
@@ -5,6 +5,6 @@
 
 --- Layout for the tooltip table passed to `tes3ui.showMessageMenu` function.
 --- @class tes3ui.showMessageMenu.params.tooltip
---- @field callback fun(params: tes3ui.showMessageMenu.params.tooltip.callbackData) A function to call when the tooltip has been created. Passes context information. Can be used to make further adjustments to the tooltip.
---- @field header string|fun(callbackParams: table): string|nil The header at the top of the tooltip. Can also be a function that returns a string.
---- @field text string|fun(callbackParams: table): string|nil The text in the body of the tooltip. Can also be a function that returns a string.
+--- @field callback nil|fun(params: tes3ui.showMessageMenu.params.tooltip.callbackData) A function to call when the tooltip has been created. Passes context information. Can be used to make further adjustments to the tooltip.
+--- @field header nil|string|fun(callbackParams: table): string|nil The header at the top of the tooltip. Can also be a function that returns a string.
+--- @field text nil|string|fun(callbackParams: table): string|nil The text in the body of the tooltip. Can also be a function that returns a string.


### PR DESCRIPTION
None of the fields `callback`, `header`, `text` are required, this removes the incorrect `missing-fields` warning