### PR TITLE
Set m_Type in CalculateMovementSpeed constructor

### DIFF
--- a/MWSE/LuaCalcMovementSpeedEvent.cpp
+++ b/MWSE/LuaCalcMovementSpeedEvent.cpp
@@ -9,6 +9,7 @@
 namespace mwse::lua::event {
 	CalculateMovementSpeed::CalculateMovementSpeed(MovementType type, TES3::MobileActor* mobile, float speed) :
 		ObjectFilteredEvent(NULL, mobile->reference),
+		m_Type(type),
 		m_MobileActor(mobile),
 		m_Speed(speed)
 	{


### PR DESCRIPTION
It wasn't only the `calcWalkSpeed` event that had `type == 1`, but all of the [movement speed related](https://mwse.github.io/MWSE/events/calcFlySpeed/#related-events) events had the same problem. After this patch, they get their type set as indicated in the docs.