### PR TITLE
Store the `mwseMCMTemplate` of registered mod config menus

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
@@ -335,7 +335,8 @@ function Template:createContentsContainer(parentBlock)
 end
 
 function Template:register()
-	local mcm = {}
+	---@type mwse.registerModConfig.package
+	local mcm = { template = self }
 
 	--- @param container tes3uiElement
 	mcm.onCreate = function(container)

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -542,6 +542,7 @@ event.register("uiActivated", onCreatedMenuOptions, { filter = "MenuOptions" })
 --- @field name string
 --- @field hidden boolean hide it?
 --- @field favorite boolean is this mod a favorite
+--- @field template mwseMCMTemplate? The template for this mod package, if it exists.
 
 --- Define a new function in the mwse namespace that lets mods register for mod config.
 --- @param name string


### PR DESCRIPTION
This PR makes a minor change that lets the `mcm/main.lua` file access the `mwseMCMTemplate`s of registered mod configs (provided those mod configs had a template).

At the moment, the main motivation for this is that it allows adding a universal keybinding menu to the MCM (#625). It's a boring backend change that lets exciting stuff be done later.

This is still a WIP version and may need some more testing. It is being developed in conjunction with #625, and the implementation of this PR may be influenced by #625 as that PR gets refined.

## Notes
- This PR contains two commits.
    - The first commit contains all the changes to the underlying logic. It is extremely tiny, changing only 2 LOC (ignoring comments).
    - The second commit consists solely of formatting changes (obtained by running a lua formatter on `mcm/main.lua` and `Template.lua`.
- This functionality was previously implemented in #614 and reverted in #618. 
    - #614 was reverted because of a bug in its implementation. Namely, the `table.copy` call introduced a bug that ended up resetting user's mod configs back to their default settings.
    - This implementation tries to avoid that problem, but would nevertheless benefit from thorough testing to make sure it doesn't cause other problems.