### PR TITLE
MCM: Add a universal keybinding menu.

### DIFF
--- a/misc/package/Data Files/MWSE/core/i18n/eng.lua
+++ b/misc/package/Data Files/MWSE/core/i18n/eng.lua
@@ -25,7 +25,12 @@ return {
 	["Middle mouse button"] = "Middle mouse button",
 	["Mouse %s"] = "Mouse %%s",
 	["SET %s KEYBIND"] = "SET %%s KEYBIND",
-	["Open Keybind Menu"] = "Keybinds",
+	["KeybindMenu.buttonText"] = "Keybinds",
+	["KeybindMenu.name"] = "Configure Keybinds",
+	["KeybindMenu.description"] = "This page lets you view and modify keybindings added by the configuration menus of your installed mods.\n\n\z
+		Note: This page will only display keybindings added by mods that use MCM Templates to create MCM KeyBinders. \z
+		This covers the vast majority of mods that add custom keybindings, but there may be a few outliers here and there.\z
+		",
 	["SET NEW KEYBIND"] = "SET NEW KEYBIND",
 	["Press any key to set the bind or ESC to cancel."] = "Press any key to set the bind or ESC to cancel.",
 	["Unbound action"] = "Unbound action",

--- a/misc/package/Data Files/MWSE/core/i18n/eng.lua
+++ b/misc/package/Data Files/MWSE/core/i18n/eng.lua
@@ -25,6 +25,7 @@ return {
 	["Middle mouse button"] = "Middle mouse button",
 	["Mouse %s"] = "Mouse %%s",
 	["SET %s KEYBIND"] = "SET %%s KEYBIND",
+	["Open Keybind Menu"] = "Keybinds",
 	["SET NEW KEYBIND"] = "SET NEW KEYBIND",
 	["Press any key to set the bind or ESC to cancel."] = "Press any key to set the bind or ESC to cancel.",
 	["Unbound action"] = "Unbound action",

--- a/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
@@ -335,7 +335,8 @@ function Template:createContentsContainer(parentBlock)
 end
 
 function Template:register()
-	local mcm = {}
+	---@type mwse.registerModConfig.package
+	local mcm = { template = self }
 
 	--- @param container tes3uiElement
 	mcm.onCreate = function(container)

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -591,8 +591,7 @@ local function onClickModConfigButton()
 
 			local keyBindMenuButton = bottomLeftButtons:createButton({
 				id = "MWSE:ModConfigMenu_Keybind",
-				-- TODO: make this use i18n
-				text = "Keybinds"
+				text = mwse.mcm.i18n("Open Keybind Menu")
 			})
 			keyBindMenuButton:register("mouseClick", onClickKeybindMenuButton)
 		end

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -423,8 +423,7 @@ local function onClickKeybindMenuButton(e)
 	closeCurrentModConfig()
 	modConfigContainer:destroyChildren()
 
-	local Template = require("mcm.components.templates.Template")
-	local status, error = pcall(Template.create, keybindMenu.template, modConfigContainer)
+	local status, error = pcall(keybindMenu.template.create, keybindMenu.template, modConfigContainer)
 
 	-- Change the mod config title bar to include the mod's name.
 	local menu = tes3ui.findMenu("MWSE:ModConfigMenu") --[[@as tes3uiElement]]

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -381,7 +381,7 @@ local function initializeKeybindTemplate()
 		---@diagnostic disable-next-line: inject-field
 		keybindTemplate._updatedTemplates = {}
 	end
-	local page = keybindTemplate:createSideBarPage()
+	local page = keybindTemplate:createFilterPage()
 	local sortedModTemplates = {} --- @type mwseMCMTemplate[]
 	for _, package in pairs(configMods) do
 		-- if package.template and not package.hidden then

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -170,7 +170,7 @@ end
 local function onClickModName(e)
 	-- If we have a current mod, fire its close event.
 	closeCurrentModConfig()
-	
+
 	local modName = e.source.text
 
 	-- Update the current mod package.
@@ -328,12 +328,12 @@ local KEYBINDER_CLASSES = {
 	MouseBinder = true,
 }
 
+--- Gets the description for a `Category`. This function will check parent components until a description is found.
+--- It will also check for `Info` components in a `SideBarPage` if appropriate.
 ---@param category mwseMCMCategory
 ---@return string?
-local function getCategoryDescriptionRecursive(category)
+local function getCategoryDescription(category)
 	repeat
-		mwse.log("\tchecking %q", category.description)
-
 		if category.description ~= nil and category.description ~= "" then
 			return category.description
 		end
@@ -341,8 +341,6 @@ local function getCategoryDescriptionRecursive(category)
 		if category.class == "SideBarPage" then
 			---@cast category mwseMCMSideBarPage
 			for _, comp in ipairs(category.sidebar.components) do
-				mwse.log("\tchecking %q", comp.description or comp.text)
-
 				if comp.componentType == "Info" then
 					---@cast comp mwseMCMInfo
 					local text = comp.text or comp.description
@@ -387,13 +385,10 @@ local function addAllKeybindsRecursive(keybindMenuCategory, modTemplate, modCate
 				keybindMenuCategory:createMouseBinder(copy --[[@as mwseMCMCategory.createMouseBinder.data]])
 			end
 			if keybindMenuCategory.description ~= false then
-				mwse.log("getting description for %q", modTemplate.name)
-				local categoryDescription = getCategoryDescriptionRecursive(modCategory)
+				local categoryDescription = getCategoryDescription(modCategory)
 				if keybindMenuCategory.description == nil or keybindMenuCategory.description == "" then
 					keybindMenuCategory.description = categoryDescription
-					mwse.log("updated keybindMenuCategory.description = %q (%q)", keybindMenuCategory.description, categoryDescription)
 				elseif keybindMenuCategory.description ~= categoryDescription then
-					mwse.log("updated keybindMenuCategory.description = %s", false)
 					keybindMenuCategory.description = false
 				end
 			end

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -420,6 +420,9 @@ local function onClickKeybindMenuButton(e)
 	local Template = require("mcm.components.templates.Template")
 	local status, error = pcall(Template.create, keybindTemplate, modConfigContainer)
 
+	-- Change the mod config title bar to include the mod's name.
+	local menu = tes3ui.findMenu("MWSE:ModConfigMenu") --[[@as tes3uiElement]]
+	menu.text = mwse.mcm.i18n("Mod Configuration - %s", { "Keybind Menu" })
 	if (status == false) then
 		mwse.log("Error in mod config close callback: %s\n%s", error, debug.traceback())
 	end
@@ -577,6 +580,7 @@ local function onClickModConfigButton()
 
 		local keyBindMenuButton = bottomBlock:createButton({
 			id = "MWSE:ModConfigMenu_Keybind",
+			-- TODO: make this use i18n
 			text = "Keybinds"
 		})
 		keyBindMenuButton:register("mouseClick", onClickKeybindMenuButton)

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -575,22 +575,35 @@ local function onClickModConfigButton()
 		local bottomBlock = menu:createBlock({ id = "BottomFlow" })
 		bottomBlock.widthProportional = 1.0
 		bottomBlock.autoHeight = true
-		bottomBlock.childAlignX = 1.0
+		-- bottomBlock.childAlignX = -1.0
 
+		do	-- bottom left buttons
+			local bottomLeftButtons = bottomBlock:createBlock{id = "BottomFlowLeft"}
+			bottomLeftButtons.widthProportional = 1.0
+			bottomLeftButtons.autoHeight = true
+			bottomLeftButtons.childAlignX = 0.0
 
-		local keyBindMenuButton = bottomBlock:createButton({
-			id = "MWSE:ModConfigMenu_Keybind",
-			-- TODO: make this use i18n
-			text = "Keybinds"
-		})
-		keyBindMenuButton:register("mouseClick", onClickKeybindMenuButton)
-		-- Add a close button to the bottom block.
-		local closeButton = bottomBlock:createButton({
-			id = "MWSE:ModConfigMenu_Close",
-			text = tes3.findGMST(tes3.gmst.sClose).value --[[@as string]]
-		})
-		closeButton:register("mouseClick", onClickCloseButton)
-		event.register("keyDown", onClickCloseButton, { filter = tes3.scanCode.escape })
+			local keyBindMenuButton = bottomLeftButtons:createButton({
+				id = "MWSE:ModConfigMenu_Keybind",
+				-- TODO: make this use i18n
+				text = "Keybinds"
+			})
+			keyBindMenuButton:register("mouseClick", onClickKeybindMenuButton)
+		end
+		do -- Bottom right buttons
+			local bottomRightButtons = bottomBlock:createBlock{id = "BottomFlowRight"}
+			bottomRightButtons.widthProportional = 1.0
+			bottomRightButtons.autoHeight = true
+			bottomRightButtons.childAlignX = 1.0
+			-- Add a close button to the bottom block.
+			local closeButton = bottomRightButtons:createButton({
+				id = "MWSE:ModConfigMenu_Close",
+				text = tes3.findGMST(tes3.gmst.sClose).value --[[@as string]]
+			})
+			closeButton:register("mouseClick", onClickCloseButton)
+			event.register("keyDown", onClickCloseButton, { filter = tes3.scanCode.escape })
+		end
+
 
 		-- Cause the menu to refresh itself.
 		menu:updateLayout()

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -542,6 +542,7 @@ event.register("uiActivated", onCreatedMenuOptions, { filter = "MenuOptions" })
 --- @field name string
 --- @field hidden boolean hide it?
 --- @field favorite boolean is this mod a favorite
+--- @field template mwseMCMTemplate? The template for this mod package, if it exists.
 
 --- Define a new function in the mwse namespace that lets mods register for mod config.
 --- @param name string

--- a/misc/package/Data Files/MWSE/core/mcm/main.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/main.lua
@@ -138,7 +138,9 @@ end
 local function closeCurrentModConfig()
 	-- HACK: try to close the keybind menu.
 	-- In the curent implementation, this will do nothing unless the keybindMenu.template is active.
-	pcall(keybindMenu.template.onClose, modConfigContainer)
+	if keybindMenu.template then
+		pcall(keybindMenu.template.onClose, modConfigContainer)
+	end
 	if not currentModConfig then return end
 
 	local activeModConfig = currentModConfig
@@ -400,6 +402,10 @@ local function addAllKeybindsRecursive(keybindMenuCategory, modTemplate, modCate
 end
 
 local function initializeKeybindMenuTemplate()
+	if keybindMenu.template then
+		return
+	end
+	mwse.log("MCM: Initializing Keybinds Menu.")
 
 	keybindMenu.template = mwse.mcm.createTemplate{
 		name = mwse.mcm.i18n("KeybindMenu.name"),
@@ -474,6 +480,7 @@ end
 
 --- @param e tes3uiEventData
 local function onClickKeybindMenuButton(e)
+	initializeKeybindMenuTemplate()
 	-- Destroy and recreate the parent container.
 	closeCurrentModConfig()
 	modConfigContainer:destroyChildren()
@@ -690,7 +697,6 @@ local function onClickModConfigButton()
 		mwse.log("Couldn't find main menu!")
 	end
 
-	initializeKeybindMenuTemplate()
 	tes3ui.enterMenuMode(menu.id)
 end
 


### PR DESCRIPTION
## Summary
This PR depends on #624, and it adds a universal keybinding menu to the MCM. This menu allows users to view and update the keybindings of all their mods in one place. This is something that C3pa have discussed adding in the past, and it [was recently requested by a user in the MWSE discord channel a few day ago](https://discord.com/channels/210394599246659585/381219559094616064/1402035124211810345).

Here are some screenshots of what the early prototype looks like:
<img width="537" height="362" src="https://github.com/user-attachments/assets/b39ec828-ef83-4b7f-9208-25274d29856e" />
<img width="537" height="362" src="https://github.com/user-attachments/assets/1d8881ba-5655-4a89-91ef-c465e67efb2e" />


## Status
- This PR should currently be viewed as a very early prototype/proof of concept of the feature. 
- The code changes are a bit messy, and the implementation still needs to be refined and thoroughly tested. 
- But I figured that for something like this, it would be best to make the PR early so that the implementation, presentation, and behavior of it can be discussed and modified before the PR gets overly developed. 

## Current Features
- Displays all keybindings of all mods that register an `mwseMCMTemplate`.
- When the menu is closed, the `modConfigEntryClosed` event will fire, and the `Template.onClose` function will be called for every template that had a keybinding updated. 
    - This lets all mods perform their necessary update logic, including calling `mwse.saveConfig` to serialize their updated configs.
    - (It will not be called on all templates, just those that were actually updated.)
- The description of keybindings are displayed in the sidebar, just as they would be in the relevant mod configuration menus.

## Potential Problems
This list is very likely to grow with time, but at the moment I can only think of one thing:
1. Calling `template:onClose()` might cause problems for certain mods if the templates in question want to access certain UI elements that are specific to that mods configuration menu.
    - This will need further investigation, likely by doing a review of the lua code dump.
    - If we get lucky and no mods are currently doing this, then it might be best to change the API surrounding `template:onClose` to ensure this problem does not happen in the future.

## Known problems
1. The keybinder button text should be fed through `i18n`.

## Questions
1. Should the keybind menu be stored as a button on the bottom right, or somewhere else?
3. Should we try to support non-template mod config menus in some way? If so, how?


