### PR TITLE
MCM: Only update `__index` field once

### DIFF
--- a/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/Component.lua
@@ -15,6 +15,8 @@ end
 
 --- @class mwseMCMComponent
 local Component = {}
+Component.__index = Component
+
 Component.componentType = "Component"
 Component.paddingBottom = 4
 Component.indent = 12
@@ -38,7 +40,6 @@ function Component:new(data)
 	end
 
 	setmetatable(t, self)
-	self.__index = self
 	--- @cast t mwseMCMComponent
 	return t
 end

--- a/misc/package/Data Files/MWSE/core/mcm/components/categories/SideBySideBlock.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/categories/SideBySideBlock.lua
@@ -11,6 +11,7 @@ local Parent = require("mcm.components.categories.Category")
 
 --- @class mwseMCMSideBySideBlock
 local SideBySideBlock = Parent:new()
+SideBySideBlock.__index = SideBySideBlock
 
 --- @param parentBlock tes3uiElement
 function SideBySideBlock:createSubcomponentsContainer(parentBlock)

--- a/misc/package/Data Files/MWSE/core/mcm/components/infos/ActiveInfo.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/infos/ActiveInfo.lua
@@ -2,6 +2,8 @@ local Parent = require("mcm.components.infos.MouseOverInfo")
 
 --- @class mwseMCMActiveInfo
 local ActiveInfo = Parent:new()
+ActiveInfo.__index = ActiveInfo
+
 ActiveInfo.triggerOn = "MCM:refresh"
 ActiveInfo.triggerOff = "--unused--"
 

--- a/misc/package/Data Files/MWSE/core/mcm/components/infos/Hyperlink.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/infos/Hyperlink.lua
@@ -11,6 +11,7 @@ local Parent = require("mcm.components.infos.Info")
 --- @class mwseMCMHyperlink
 --- @field exec string *Deprecated*
 local Hyperlink = Parent:new()
+Hyperlink.__index = Hyperlink
 
 --- @param parentBlock tes3uiElement
 function Hyperlink:makeComponent(parentBlock)

--- a/misc/package/Data Files/MWSE/core/mcm/components/infos/Info.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/infos/Info.lua
@@ -17,6 +17,8 @@ local Parent = require("mcm.components.settings.Setting")
 
 --- @class mwseMCMInfo
 local Info = Parent:new()
+Info.__index = Info
+
 Info.componentType = "Info"
 Info.text = ""
 -- CONTROL METHODS

--- a/misc/package/Data Files/MWSE/core/mcm/components/infos/MouseOverInfo.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/infos/MouseOverInfo.lua
@@ -10,6 +10,8 @@ local Parent = require("mcm.components.infos.Info")
 
 --- @class mwseMCMMouseOverInfo
 local MouseOverInfo = Parent:new()
+MouseOverInfo.__index = MouseOverInfo
+
 MouseOverInfo.triggerOn = "MCM:MouseOver"
 MouseOverInfo.triggerOff = "MCM:MouseLeave"
 

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/ExclusionsPage.lua
@@ -13,6 +13,7 @@ local Parent = require("mcm.components.pages.Page")
 
 --- @class mwseMCMExclusionsPage
 local ExclusionsPage = Parent:new()
+ExclusionsPage.__index = ExclusionsPage
 -- public fields
 ExclusionsPage.label = mwse.mcm.i18n("Exclusions")
 ExclusionsPage.rightListLabel = mwse.mcm.i18n("Allowed")
@@ -35,7 +36,6 @@ function ExclusionsPage:new(data)
 		utils.getOrInheritVariableData(t)
 	end
 	setmetatable(t, self)
-	self.__index = self
 	return t
 end
 

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/FilterPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/FilterPage.lua
@@ -6,6 +6,7 @@ local Parent = require("mcm.components.pages.SideBarPage")
 
 --- @class mwseMCMFilterPage
 local FilterPage = Parent:new()
+FilterPage.__index = FilterPage
 FilterPage.placeholderSearchText = mwse.mcm.i18n("Search...")
 
 function FilterPage:filterComponents()

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/MouseOverPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/MouseOverPage.lua
@@ -6,6 +6,7 @@ local Parent = require("mcm.components.pages.Page")
 
 --- @class mwseMCMMouseOverPage
 local MouseOverPage = Parent:new()
+MouseOverPage.__index = MouseOverPage
 MouseOverPage.noScroll = true
 
 --- @param parentBlock tes3uiElement

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/Page.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/Page.lua
@@ -10,6 +10,7 @@ local Parent = require("mcm.components.categories.Category")
 
 --- @class mwseMCMPage
 local Page = Parent:new()
+Page.__index = Page
 Page.componentType = "Page"
 Page.indent = 6
 
@@ -31,7 +32,6 @@ function Page:new(data)
 		t.tabUID = tes3ui.registerID(tabUID)
 	end
 	setmetatable(t, self)
-	self.__index = self
 	return t --[[@as mwseMCMPage]]
 
 end

--- a/misc/package/Data Files/MWSE/core/mcm/components/pages/SideBarPage.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/pages/SideBarPage.lua
@@ -17,6 +17,7 @@ local MouseOverPage = require("mcm.components.pages.MouseOverPage")
 --- @class mwseMCMSideBarPage
 --- @field sidebarComponents mwseMCMComponent[] *Deprecated*
 local SideBarPage = Parent:new()
+SideBarPage.__index = SideBarPage
 SideBarPage.triggerOn = "MCM:MouseOver"
 SideBarPage.triggerOff = "MCM:MouseLeave"
 
@@ -28,7 +29,6 @@ function SideBarPage:new(data)
 	t.sidebar = MouseOverPage:new({ parentComponent = self})
 
 	setmetatable(t, self)
-	self.__index = self
 	return t
 
 end

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Binder.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Binder.lua
@@ -10,6 +10,7 @@ local Parent = require("mcm.components.settings.Button")
 
 --- @class mwseMCMBinder
 local Binder = Parent:new()
+Binder.__index = Binder
 Binder.allowCombinations = true
 
 local popupId = tes3ui.registerID("KeyMouseBinderPopup")

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Button.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Button.lua
@@ -6,6 +6,8 @@ local Parent = require("mcm.components.settings.Setting")
 
 --- @class mwseMCMButton
 local Button = Parent:new()
+Button.__index = Button
+
 Button.disabledText = "---"
 Button.leftSide = true
 Button.buttonText = "---"

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/ColorPicker.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/ColorPicker.lua
@@ -13,6 +13,7 @@ local Parent = require("mcm.components.settings.Setting")
 
 --- @class mwseMCMColorPicker
 local ColorPicker = Parent:new()
+ColorPicker.__index = ColorPicker
 ColorPicker.initialColor = { r = 1.0, g = 1.0, b = 1.0 }
 ColorPicker.initialAlpha = 1.0
 

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/ColorPickerButton.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/ColorPickerButton.lua
@@ -11,6 +11,7 @@ local Setting = require("mcm.components.settings.Setting")
 
 --- @class mwseMCMColorPickerButton
 local PickerButton = Parent:new()
+PickerButton.__index = PickerButton
 
 --- @param newValue mwseColorATable
 function PickerButton:setVariableValue(newValue)

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/CycleButton.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/CycleButton.lua
@@ -14,6 +14,7 @@ local Parent = require("mcm.components.settings.Button")
 --- Class object
 --- @class mwseMCMCycleButton
 local CycleButton = Parent:new()
+CycleButton.__index = CycleButton
 
 --- @param parentBlock tes3uiElement
 function CycleButton:makeComponent(parentBlock)

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/DecimalSlider.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/DecimalSlider.lua
@@ -15,6 +15,7 @@ local Parent = require("mcm.components.settings.Slider")
 --- @deprecated
 --- @class mwseMCMDecimalSlider : mwseMCMSlider
 local DecimalSlider = Parent:new()
+DecimalSlider.__index = DecimalSlider
 DecimalSlider.min = 0.0
 DecimalSlider.max = 1.0
 DecimalSlider.step = 0.01

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Dropdown.lua
@@ -6,6 +6,7 @@ local Parent = require("mcm.components.settings.Setting")
 
 --- @class mwseMCMDropdown
 local Dropdown = Parent:new()
+Dropdown.__index = Dropdown
 Dropdown.idleColor = tes3ui.getPalette(tes3.palette.normalColor)
 Dropdown.overColor = tes3ui.getPalette(tes3.palette.normalOverColor)
 Dropdown.pressedColor = tes3ui.getPalette(tes3.palette.normalPressedColor)

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/KeyBinder.lua
@@ -18,6 +18,7 @@ local Parent = require("mcm.components.settings.Binder")
 
 --- @class mwseMCMKeyBinder
 local KeyBinder = Parent:new()
+KeyBinder.__index = KeyBinder
 KeyBinder.allowMouse = false
 
 -- TODO: Implement flags for enabling the binding of mouse wheel or mouse buttons separately
@@ -28,7 +29,6 @@ function KeyBinder:new(data)
 	local t = Parent:new(data)
 
 	setmetatable(t, self)
-	self.__index = self
 	--- @cast t mwseMCMKeyBinder
 
 	-- All KeyBinders observe keyboard input.

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/LogLevelOptions.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/LogLevelOptions.lua
@@ -10,6 +10,8 @@ local pathResolver = require("logger.pathResolver")
 --- @class mwseMCMLogLevelOptions : mwseMCMDropdown
 --- @field logger mwseLogger
 local LogLevelOptions = Parent:new()
+LogLevelOptions.__index = LogLevelOptions
+
 LogLevelOptions.label = mwse.mcm.i18n("Logging Level")
 LogLevelOptions.options = {
 	{ label = mwse.mcm.i18n("Trace"), value = mwse.logLevel.trace },

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/MouseBinder.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/MouseBinder.lua
@@ -17,6 +17,7 @@ local Parent = require("mcm.components.settings.Binder")
 
 --- @class mwseMCMMouseBinder
 local MouseBinder = Parent:new()
+MouseBinder.__index = MouseBinder
 MouseBinder.allowButtons = true
 
 --- @param data mwseMCMMouseBinder.new.data|nil
@@ -25,7 +26,6 @@ function MouseBinder:new(data)
 	local t = Parent:new(data)
 
 	setmetatable(t, self)
-	self.__index = self
 	--- @cast t mwseMCMMouseBinder
 
 	local bothDisabled = (not t.allowButtons) and (not t.allowWheel)

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/OnOffButton.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/OnOffButton.lua
@@ -14,6 +14,7 @@ local Parent = require("mcm.components.settings.Button")
 
 --- @class mwseMCMOnOffButton
 local OnOffButton = Parent:new()
+OnOffButton.__index = OnOffButton
 
 function OnOffButton:convertToLabelValue(variableValue)
 	return variableValue and self.sOn or self.sOff

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/ParagraphField.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/ParagraphField.lua
@@ -6,6 +6,7 @@ local Parent = require("mcm.components.settings.TextField")
 
 --- @class mwseMCMParagraphField
 local ParagraphField = Parent:new()
+ParagraphField.__index = ParagraphField
 
 function ParagraphField:enable()
 	self.elements.inputField.text = self:convertToLabelValue(self.variable.value)

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/PercentageSlider.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/PercentageSlider.lua
@@ -14,6 +14,7 @@ local Parent = require("mcm.components.settings.Slider")
 
 --- @class mwseMCMPercentageSlider
 local PercentageSlider = Parent:new()
+PercentageSlider.__index = PercentageSlider
 
 PercentageSlider.min = 0.0
 PercentageSlider.max = 1.0

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Setting.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Setting.lua
@@ -13,6 +13,7 @@ local Parent = require("mcm.components.Component")
 
 --- @class mwseMCMSetting
 local Setting = Parent:new()
+Setting.__index = Setting
 Setting.componentType = "Setting"
 Setting.restartRequired = false
 Setting.restartRequiredMessage = mwse.mcm.i18n("The game must be restarted before this change will come into effect.")
@@ -24,7 +25,6 @@ function Setting:new(data)
 	local t = Parent:new(data) --[[@as mwseMCMSetting]]
 	utils.getOrInheritVariableData(t)
 	setmetatable(t, self)
-	self.__index = self
 	return t
 end
 

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/Slider.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/Slider.lua
@@ -27,6 +27,8 @@ local Parent = require("mcm.components.settings.Setting")
 
 --- @class mwseMCMSlider
 local Slider = Parent:new()
+Slider.__index = Slider
+
 Slider.min = 0
 Slider.decimalPlaces = 0
 Slider.max = 100

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/TextField.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/TextField.lua
@@ -8,6 +8,8 @@ local Parent = require("mcm.components.settings.Setting")
 --- Class Object
 --- @class mwseMCMTextField
 local TextField = Parent:new()
+TextField.__index = TextField
+
 TextField.buttonText = mwse.mcm.i18n("Submit")
 TextField.sNewValue = mwse.mcm.i18n("New value: '%s'")
 TextField.defaultSetting = ""

--- a/misc/package/Data Files/MWSE/core/mcm/components/settings/YesNoButton.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/settings/YesNoButton.lua
@@ -15,6 +15,7 @@ local Parent = require("mcm.components.settings.Button")
 
 --- @class mwseMCMYesNoButton
 local YesNoButton = Parent:new()
+YesNoButton.__index = YesNoButton
 
 function YesNoButton:convertToLabelValue(variableValue)
 	return variableValue and self.sYes or self.sNo

--- a/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
@@ -29,7 +29,7 @@ function Template:new(data)
 			if not componentClass then
 				error(string.format("Could not intialize page %q", page.label))
 			end
-			page.parentComponent = self
+			page.parentComponent = t
 			page = componentClass:new(page)
 		end
 		table.insert(pages, page)

--- a/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
+++ b/misc/package/Data Files/MWSE/core/mcm/components/templates/Template.lua
@@ -9,6 +9,7 @@ local Parent = require("mcm.components.Component")
 --- Class object
 --- @class mwseMCMTemplate
 local Template = Parent:new()
+Template.__index = Template
 
 Template.componentType = "Template"
 
@@ -36,7 +37,6 @@ function Template:new(data)
 	end
 	t.pages = pages
 
-	self.__index = Template.__index
 	return t --[[@as mwseMCMTemplate]]
 end
 
@@ -170,7 +170,7 @@ end
 --- @param thisPage mwseMCMExclusionsPage|mwseMCMFilterPage|mwseMCMMouseOverPage|mwseMCMPage|mwseMCMSideBarPage
 function Template:clickTab(thisPage)
 	local pageBlock = self.elements.pageBlock
-	
+
 	-- Clear previous page
 	pageBlock:destroyChildren()
 	-- Create new page
@@ -354,10 +354,10 @@ function Template:register()
 end
 
 function Template.__index(tbl, key)
-	-- If the `key` starts with `"create"`, and if there's an `mwse.mcm.create<Component>` method, 
+	-- If the `key` starts with `"create"`, and if there's an `mwse.mcm.create<Component>` method,
 	-- Make a new `Template.create<Component>` method.
 	-- Otherwise, look the value up in the `metatable`.
-	
+
 	if not key:startswith("create") or mwse.mcm[key] == nil then
 		return getmetatable(tbl)[key]
 	end


### PR DESCRIPTION
This changes the MCM code to follow the paradigm
```lua
Class.__index = Class
function Class:new(data)
	setmetatable(data, self)
	return data
end
```
instead of 
```lua
function Class:new(data)
	self.__index = self
	setmetatable(data, self)
	return data
end
```

The justification is that the `self.__index = self` approach is overly complex and makes other parts of the codebase more delicate. In particular:
1. Unlike very other method in the codebase, the `self` in `Class:new` refers to the `Class`, rather than the object being created. This has historically led to bugs where `self` gets modified in `Class:new` under the assumption that the object is being changed, instead of the Class.
2. `self.__index = self` updates the _Class_ every time a new _object_ is created. This has historically led to problems where the `__index` metamethods of certain classes were overridden as soon as a new object was created. (This happened previously with the `__index` metamethod of `mwseMCMCategory`.)

Consider the following code snippet

```lua
local Parent = {}

function Parent:new(data)
	data = data or {}
	self.__index = self
	setmetatable(data, self)
	return data
end

local Class = Parent:new()

function Class:new(data)
	data = Parent:new(data)
	self.__index = self
	setmetatable(data, self)
	return data
end

local Class2 =  Parent:new()
```
Whenever a new instance of `Class` gets created, the `__index` field of _both_ `Parent` _and_ `Class` get updated. In particular, if `Parent` had its own custom `__index` logic (like `mwseMCMCategory` does), then it could be overwritten by the `new` method of its subclasses. 

On the other hand, whenever a new instance of `Class2` is created, the `__index` field of `Class2` gets updated while the `__index` field of `Parent` remains unchanged.

If we instead adopt the paradigm that the `__index` metamethod gets assigned only once, then it avoids a lot of these peculiarities.
Hopefully, using `Class.__index = Class` prevents these bugs because it makes the metatable relationships clearer.