### PR TITLE
Hide double trigger for equip event when calling tes3.equip

### DIFF
--- a/MWSE/TES3MobileActor.cpp
+++ b/MWSE/TES3MobileActor.cpp
@@ -1171,20 +1171,20 @@ namespace TES3 {
 
 	const auto TES3_MobileActor_wearItem = reinterpret_cast<void(__thiscall*)(MobileActor*, Object*, ItemData*, bool, bool)>(0x52C770);
 	bool MobileActor::wearItem(Object * item, ItemData * itemData, bool addItem, bool unknown, bool useEvents) {
-		if (useEvents && mwse::lua::event::EquipEvent::getEventEnabled()) {
-			const auto stateHandle = mwse::lua::LuaManager::getInstance().getThreadSafeStateHandle();
-			sol::table eventData = stateHandle.triggerEvent(new mwse::lua::event::EquipEvent(reference, item, itemData));
-			if (eventData.valid() && eventData.get_or("block", false)) {
-				return false;
-			}
-		}
+		//if (useEvents && mwse::lua::event::EquipEvent::getEventEnabled()) {
+		//	const auto stateHandle = mwse::lua::LuaManager::getInstance().getThreadSafeStateHandle();
+		//	sol::table eventData = stateHandle.triggerEvent(new mwse::lua::event::EquipEvent(reference, item, itemData));
+		//	if (eventData.valid() && eventData.get_or("block", false)) {
+		//		return false;
+		//	}
+		//}
 
 		TES3_MobileActor_wearItem(this, item, itemData, addItem, unknown);
 
-		if (useEvents && mwse::lua::event::EquippedEvent::getEventEnabled()) {
-			const auto stateHandle = mwse::lua::LuaManager::getInstance().getThreadSafeStateHandle();
-			stateHandle.triggerEvent(new mwse::lua::event::EquippedEvent(static_cast<TES3::Actor*>(reference->baseObject), this, item, itemData));
-		}
+		//if (useEvents && mwse::lua::event::EquippedEvent::getEventEnabled()) {
+		//	const auto stateHandle = mwse::lua::LuaManager::getInstance().getThreadSafeStateHandle();
+		//	stateHandle.triggerEvent(new mwse::lua::event::EquippedEvent(static_cast<TES3::Actor*>(reference->baseObject), this, item, itemData));
+		//}
 
 		return true;
 	}


### PR DESCRIPTION
This will prevent `tes3.equip` from triggering equip/equipped events twice. But, of course, this will completely disable the functionality of the `bypassEquipEvents` argument. 

Related: #633.