### PR TITLE
Fix warning C4018

### DIFF
--- a/MWSE/CrashLogCallTrace.cpp
+++ b/MWSE/CrashLogCallTrace.cpp
@@ -374,7 +374,7 @@ namespace CrashLogger::LuaMods {
 			std::vector<LuaModResult> results;
 
 			// Gather our lua mod information.
-			for (auto i = 1; i <= luaRuntimes.size(); ++i) {
+			for (auto i = 1u; i <= luaRuntimes.size(); ++i) {
 				sol::table runtime = luaRuntimes[i];
 
 				// We can ignore core mods.

--- a/MWSE/MgeTes3Machine.cpp
+++ b/MWSE/MgeTes3Machine.cpp
@@ -208,9 +208,9 @@ long TES3MACHINE::GetArrayValue(std::string const& caller, long const id, long c
 	}
 
 	long value = 0;
-	if (id > 0 && id <= arrays_.size()) {
+	if (id > 0 && (unsigned long)id <= arrays_.size()) {
 		std::vector<long> const& a = arrays_[id - 1];
-		if (index >= 0 && index < a.size()) {
+		if (index >= 0 && (unsigned long)index < a.size()) {
 			value = a[index];
 		}
 		else {
@@ -234,10 +234,10 @@ long TES3MACHINE::SetArrayValue(std::string const& caller, long const id, long c
 	}
 
 	long success = 0;
-	if (id > 0 && id <= arrays_.size()) {
+	if (id > 0 && (unsigned long)id <= arrays_.size()) {
 		if (index >= 0) {
 			std::vector<long>& a = arrays_[id - 1];
-			if (index + 1 > a.size()) {
+			if ((unsigned long)index + 1 > a.size()) {
 				a.resize(index + 1);
 			}
 			a[index] = value;
@@ -264,7 +264,7 @@ long TES3MACHINE::GetArraySize(std::string const& caller, long const id) {
 	}
 
 	long size = 0;
-	if (id > 0 && id <= arrays_.size()) {
+	if (id > 0 && (unsigned long)id <= arrays_.size()) {
 		size = arrays_[id - 1].size();
 	}
 	else {
@@ -282,7 +282,7 @@ long TES3MACHINE::ClearArray(std::string const& caller, long const id) {
 	}
 
 	long success = 0;
-	if (id > 0 && id <= arrays_.size()) {
+	if (id > 0 && (unsigned long)id <= arrays_.size()) {
 		arrays_[id - 1].clear();
 		success = 1;
 	}

--- a/MWSE/NIKeyframeController.cpp
+++ b/MWSE/NIKeyframeController.cpp
@@ -71,25 +71,25 @@ namespace NI {
 		switch (scaleType) {
 		case AnimationKey::KeyType::NoInterp:
 		case AnimationKey::KeyType::Linear:
-			for (int i = 0; i < rotationKeyCount; ++i) {
+			for (auto i = 0u; i < rotationKeyCount; ++i) {
 				if (rotationKeys.asRotKey[i].timing >= time) { break; }
 				lastKeyIndex = i;
 			}
 			break;
 		case AnimationKey::KeyType::Bezier:
-			for (int i = 0; i < rotationKeyCount; ++i) {
+			for (auto i = 0u; i < rotationKeyCount; ++i) {
 				if (rotationKeys.asBezRotKey[i].timing >= time) { break; }
 				lastKeyIndex = i;
 			}
 			break;
 		case AnimationKey::KeyType::TCB:
-			for (int i = 0; i < rotationKeyCount; ++i) {
+			for (auto i = 0u; i < rotationKeyCount; ++i) {
 				if (rotationKeys.asTCBRotKey[i].timing >= time) { break; }
 				lastKeyIndex = i;
 			}
 			break;
 		case AnimationKey::KeyType::Euler:
-			for (int i = 0; i < rotationKeyCount; ++i) {
+			for (auto i = 0u; i < rotationKeyCount; ++i) {
 				if (rotationKeys.asEulerRotKey[i].timing >= time) { break; }
 				lastKeyIndex = i;
 			}
@@ -114,19 +114,19 @@ namespace NI {
 		switch (positionType) {
 		case AnimationKey::KeyType::NoInterp:
 		case AnimationKey::KeyType::Linear:
-			for (int i = 0; i < positionKeyCount; ++i) {
+			for (auto i = 0u; i < positionKeyCount; ++i) {
 				if (positionKeys.asPosKey[i].timing >= time) { break; }
 				lastKeyIndex = i;
 			}
 			break;
 		case AnimationKey::KeyType::Bezier:
-			for (int i = 0; i < positionKeyCount; ++i) {
+			for (auto i = 0u; i < positionKeyCount; ++i) {
 				if (positionKeys.asBezPosKey[i].timing >= time) { break; }
 				lastKeyIndex = i;
 			}
 			break;
 		case AnimationKey::KeyType::TCB:
-			for (int i = 0; i < positionKeyCount; ++i) {
+			for (auto i = 0u; i < positionKeyCount; ++i) {
 				if (positionKeys.asTCBPosKey[i].timing >= time) { break; }
 				lastKeyIndex = i;
 			}
@@ -151,19 +151,19 @@ namespace NI {
 		switch (scaleType) {
 		case AnimationKey::KeyType::NoInterp:
 		case AnimationKey::KeyType::Linear:
-			for (int i = 0; i < scaleKeyCount; ++i) {
+			for (auto i = 0u; i < scaleKeyCount; ++i) {
 				if (scaleKeys.asFloatKey[i].timing >= time) { break; }
 				lastKeyIndex = i;
 			}
 			break;
 		case AnimationKey::KeyType::Bezier:
-			for (int i = 0; i < scaleKeyCount; ++i) {
+			for (auto i = 0u; i < scaleKeyCount; ++i) {
 				if (scaleKeys.asBezFloatKey[i].timing >= time) { break; }
 				lastKeyIndex = i;
 			}
 			break;
 		case AnimationKey::KeyType::TCB:
-			for (int i = 0; i < scaleKeyCount; ++i) {
+			for (auto i = 0u; i < scaleKeyCount; ++i) {
 				if (scaleKeys.asTCBFloatKey[i].timing >= time) { break; }
 				lastKeyIndex = i;
 			}

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -1515,7 +1515,7 @@ namespace mwse::patch {
 
 		// Clone the sorted data back into the TList, without any allocations.
 		auto itt = dialogues->head;
-		for (auto i = 0; i < sortedDialogues.size(); ++i) {
+		for (auto i = 0u; i < sortedDialogues.size(); ++i) {
 			itt->data = sortedDialogues[i].dialogue;
 			itt = itt->next;
 		}

--- a/MWSE/TES3Script.cpp
+++ b/MWSE/TES3Script.cpp
@@ -42,7 +42,7 @@ namespace TES3 {
 	}
 
 	sol::optional<unsigned int> Script::getShortVarIndex(const char* name) const {
-		for (int i = 0; i < header.shortCount; ++i) {
+		for (auto i = 0u; i < header.shortCount; ++i) {
 			const char* varName = shortVarNamePointers[i];
 			if (varName && _stricmp(name, varName) == 0) {
 				return i;
@@ -95,19 +95,19 @@ namespace TES3 {
 		sol::table results = state.create_table();
 
 		// Append any short variables.
-		for (int i = 0; i < header.shortCount; ++i) {
+		for (auto i = 0u; i < header.shortCount; ++i) {
 			const char* varName = shortVarNamePointers[i];
 			results[varName] = state.create_table_with("type", 's', "index", i, "value", getShortValue(i, useLocals.value_or(false)));
 		}
 
 		// Append any long variables.
-		for (int i = 0; i < header.longCount; ++i) {
+		for (auto i = 0u; i < header.longCount; ++i) {
 			const char* varName = longVarNamePointers[i];
 			results[varName] = state.create_table_with("type", 'l', "index", i, "value", getLongValue(i, useLocals.value_or(false)));
 		}
 
 		// Append any float variables.
-		for (int i = 0; i < header.floatCount; ++i) {
+		for (auto i = 0u; i < header.floatCount; ++i) {
 			const char* varName = floatVarNamePointers[i];
 			results[varName] = state.create_table_with("type", 'f', "index", i, "value", getFloatValue(i, useLocals.value_or(false)));
 		}

--- a/MWSE/TES3ScriptLua.cpp
+++ b/MWSE/TES3ScriptLua.cpp
@@ -71,19 +71,19 @@ namespace mwse::lua {
 		sol::table results = state.create_table();
 
 		// Append any short variables.
-		for (int i = 0; i < script->header.shortCount; ++i) {
+		for (auto i = 0u; i < script->header.shortCount; ++i) {
 			const char* varName = script->shortVarNamePointers[i];
 			results[varName] = state.create_table_with("type", 's', "index", i, "value", vars->shortVarValues[i]);
 		}
 
 		// Append any long variables.
-		for (int i = 0; i < script->header.longCount; ++i) {
+		for (auto i = 0u; i < script->header.longCount; ++i) {
 			const char* varName = script->longVarNamePointers[i];
 			results[varName] = state.create_table_with("type", 'l', "index", i, "value", vars->longVarValues[i]);
 		}
 
 		// Append any float variables.
-		for (int i = 0; i < script->header.floatCount; ++i) {
+		for (auto i = 0u; i < script->header.floatCount; ++i) {
 			const char* varName = script->floatVarNamePointers[i];
 			results[varName] = state.create_table_with("type", 'f', "index", i, "value", vars->floatVarValues[i]);
 		}

--- a/MWSE/VirtualMachine.cpp
+++ b/MWSE/VirtualMachine.cpp
@@ -178,7 +178,7 @@ long VirtualMachine::getLongVariable(int index, TES3::Reference& reference)
 void VirtualMachine::setLongVariable(int index, long value)
 {
 	auto localVariables = *(reinterpret_cast<TES3::ScriptVariables**>(TES3_LOCALVARIABLES_IMAGE));
-	if (index >= script->header.longCount) {
+	if ((size_t)index >= script->header.longCount) {
 		return;
 	}
 	localVariables->longVarValues[index] = value;
@@ -208,7 +208,7 @@ void VirtualMachine::setLongVariable(int index, long value, TES3::Reference& ref
 
 	TES3::Script* script = attachment->script;
 	TES3::ScriptVariables* localVariables = attachment->scriptData;
-	if (index >= script->header.longCount) {
+	if ((size_t)index >= script->header.longCount) {
 		return;
 	}
 	localVariables->longVarValues[index] = value;
@@ -245,7 +245,7 @@ short VirtualMachine::getShortVariable(int index, TES3::Reference& reference)
 void VirtualMachine::setShortVariable(int index, short value)
 {
 	auto localVariables = *(reinterpret_cast<TES3::ScriptVariables**>(TES3_LOCALVARIABLES_IMAGE));
-	if (index >= script->header.shortCount) {
+	if ((size_t)index >= script->header.shortCount) {
 		return;
 	}
 	localVariables->shortVarValues[index] = value;
@@ -275,7 +275,7 @@ void VirtualMachine::setShortVariable(int index, short value, TES3::Reference& r
 
 	TES3::Script* script = attachment->script;
 	TES3::ScriptVariables* localVariables = attachment->scriptData;
-	if (index >= script->header.shortCount) {
+	if ((size_t)index >= script->header.shortCount) {
 		return;
 	}
 	localVariables->shortVarValues[index] = value;
@@ -312,7 +312,7 @@ float VirtualMachine::getFloatVariable(int index, TES3::Reference& reference)
 void VirtualMachine::setFloatVariable(int index, float value)
 {
 	auto localVariables = *(reinterpret_cast<TES3::ScriptVariables**>(TES3_LOCALVARIABLES_IMAGE));
-	if (index >= script->header.floatCount) {
+	if ((size_t)index >= script->header.floatCount) {
 		return;
 	}
 	localVariables->floatVarValues[index] = value;
@@ -342,7 +342,7 @@ void VirtualMachine::setFloatVariable(int index, float value, TES3::Reference& r
 
 	TES3::Script* script = attachment->script;
 	TES3::ScriptVariables* localVariables = attachment->scriptData;
-	if (index >= script->header.floatCount) {
+	if ((size_t)index >= script->header.floatCount) {
 		return;
 	}
 	localVariables->floatVarValues[index] = value;
@@ -583,17 +583,17 @@ void VirtualMachine::dumpScriptVariables()
 	mwse::log::getLog() << __FUNCTION__ << " - Variable dump for '" << script->header.name << "'" << std::endl;
 
 	mwse::log::getLog() << "  Longs (" << script->header.longCount << "):" << std::endl;
-	for (int i = 0; i < script->header.longCount; ++i) {
+	for (auto i = 0u; i < script->header.longCount; ++i) {
 		mwse::log::getLog() << "    " << script->longVarNamePointers[i] << " = " << std::dec << script->varValues.longVarValues[i] << std::endl;
 	}
 
 	mwse::log::getLog() << "  Floats (" << script->header.floatCount << "):" << std::endl;
-	for (int i = 0; i < script->header.floatCount; ++i) {
+	for (auto i = 0u; i < script->header.floatCount; ++i) {
 		mwse::log::getLog() << "    " << script->floatVarNamePointers[i] << " = " << std::dec << script->varValues.floatVarValues[i] << std::endl;
 	}
 
 	mwse::log::getLog() << "  Shorts (" << script->header.shortCount << "):" << std::endl;
-	for (int i = 0; i < script->header.shortCount; ++i) {
+	for (auto i = 0u; i < script->header.shortCount; ++i) {
 		mwse::log::getLog() << "    " << script->shortVarNamePointers[i] << " = " << std::dec << script->varValues.shortVarValues[i] << std::endl;
 	}
 }

--- a/MWSE/xDeleteEffect.cpp
+++ b/MWSE/xDeleteEffect.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		// Get parameters.
 		long type = mwse::Stack::getInstance().popLong();
 		mwseString& id = virtualMachine.getString(mwse::Stack::getInstance().popLong());
-		long effectIndex = mwse::Stack::getInstance().popLong() - 1; // 0-based index.
+		unsigned long effectIndex = mwse::Stack::getInstance().popLong() - 1; // 0-based index.
 		size_t effectCount = 0;
 
 		// Get the desired effect.


### PR DESCRIPTION
Had this lying around for a long time now. It should fix all instances of `warning C4018: '<': signed/unsigned mismatch` compiler warning.

Some of these are purely cosmetic, but someone with more knowledge should have a look at places where I used casts.

