### PR TITLE
Attempt to fix `niRenderer:takeScreenshot` color channel order

### DIFF
--- a/MWSE/NIRenderer.cpp
+++ b/MWSE/NIRenderer.cpp
@@ -1,4 +1,5 @@
 #include "NIRenderer.h"
+
 #include "NIPixelData.h"
 
 namespace NI {
@@ -28,11 +29,14 @@ namespace NI {
 
 	PixelData* Renderer::takeScreenshot(const Rect<unsigned int>* bounds) {
 		auto pixelData = vTable.asRenderer->takeScreenshot(this, bounds);
+		if (pixelData == nullptr) {
+			return nullptr;
+		}
 		const auto desiredFormat = pixelData->pixelFormat.getD3DFormat();
 
 		// For some reason the game needs to swap B and R pixels.
 		// See paper doll code, or around 0x42F939.
-		if (desiredFormat == D3DFMT_A8R8G8B8) {
+		if (desiredFormat == D3DFMT_X8R8G8B8) {
 			const auto pixels = reinterpret_cast<NI::PixelRGBA*>(pixelData->pixels);
 			const auto pixelCount = pixelData->getWidth() * pixelData->getHeight();
 			for (auto i = 0u; i < pixelCount; ++i) {

--- a/MWSE/NIRenderer.cpp
+++ b/MWSE/NIRenderer.cpp
@@ -1,4 +1,5 @@
 #include "NIRenderer.h"
+#include "NIPixelData.h"
 
 namespace NI {
 	char* Renderer::getDriverInfo() {
@@ -26,7 +27,21 @@ namespace NI {
 	}
 
 	PixelData* Renderer::takeScreenshot(const Rect<unsigned int>* bounds) {
-		return vTable.asRenderer->takeScreenshot(this, bounds);
+		auto pixelData = vTable.asRenderer->takeScreenshot(this, bounds);
+		const auto desiredFormat = pixelData->pixelFormat.getD3DFormat();
+
+		// For some reason the game needs to swap B and R pixels.
+		// See paper doll code, or around 0x42F939.
+		if (desiredFormat == D3DFMT_A8R8G8B8) {
+			const auto pixels = reinterpret_cast<NI::PixelRGBA*>(pixelData->pixels);
+			const auto pixelCount = pixelData->getWidth() * pixelData->getHeight();
+			for (auto i = 0u; i < pixelCount; ++i) {
+				auto& pixel = pixels[i];
+				std::swap(pixel.r, pixel.b);
+			}
+		}
+
+		return pixelData;
 	}
 
 	bool Renderer::getTextureMemoryStats(unsigned int& total, unsigned int& available) {


### PR DESCRIPTION
Some time has passed since this PR was opened. For context, this fixes a bug reported by Qlonever:

<img width="1051" height="639" alt="image" src="https://github.com/user-attachments/assets/d02b9d6c-7aae-43a2-ba05-6266dcf0ff24" />

[Discord link](https://discord.com/channels/210394599246659585/381219559094616064/1479531755768778812) to the start of the discussion.


The idea behind the fix is the same as: https://github.com/MWSE/MWSE/commit/683f5947858d8a1cf32021722b3c7806be7d9f76. The actual RGBA data that the engine receives from DX is in a different order than assumed. The color channel order is now fixed before returning new pixel data.