### PR TITLE
Configurable background load poll interval

### DIFF
--- a/MWSE/MWSEConfig.cpp
+++ b/MWSE/MWSEConfig.cpp
@@ -21,6 +21,7 @@ namespace mwse {
 	bool Configuration::SuppressUselessWarnings = true;
 	bool Configuration::UseGlobalAudio = false;
 	bool Configuration::ReplaceLightSorting = true;
+	UINT Configuration::BackgroundLoadPollIntervalMs = 5;
 #ifdef APPVEYOR_BUILD_NUMBER
 	UINT Configuration::BuildNumber = APPVEYOR_BUILD_NUMBER;
 #else
@@ -70,6 +71,7 @@ namespace mwse {
 		DECLARE_CONFIG(SuppressUselessWarnings)
 		DECLARE_CONFIG(UseGlobalAudio)
 		DECLARE_CONFIG(ReplaceLightSorting)
+		DECLARE_CONFIG(BackgroundLoadPollIntervalMs)
 		DECLARE_CONFIG(BuildNumber)
 	}
 }

--- a/MWSE/MWSEConfig.h
+++ b/MWSE/MWSEConfig.h
@@ -18,6 +18,7 @@ namespace mwse {
 		static bool SuppressUselessWarnings;
 		static bool UseGlobalAudio;
 		static bool ReplaceLightSorting;
+		static UINT BackgroundLoadPollIntervalMs;
 		static UINT BuildNumber;
 
 		static sol::table getDefaults();

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -1626,6 +1626,14 @@ namespace mwse::patch {
 		return context.getResult();
 	}
 
+	// Replacement for the Sleep() call inside DataHandler::sub_48F5F0's
+	// background-load polling loop. Ignores the value originally pushed by the
+	// call site and re-reads the configured interval on every invocation, so
+	// the MCM slider can be tweaked live without restarting the game.
+	static void __stdcall PatchBackgroundLoadSleep(DWORD) {
+		Sleep(Configuration::BackgroundLoadPollIntervalMs);
+	}
+
 	//
 	// Install all the patches.
 	//
@@ -2309,6 +2317,13 @@ namespace mwse::patch {
 			genCallEnforced(0x5BC9E1, 0x4065E0, reinterpret_cast<DWORD>(PatchGetMorrowindMainWindow_NoBackgroundInput));
 			genCallEnforced(0x5BCA33, 0x4065E0, reinterpret_cast<DWORD>(PatchGetMorrowindMainWindow_NoBackgroundInput));
 		}
+
+		// Patch: Replace the Sleep(100) call inside the background loader's
+		// progress-show polling loop with a wrapper that reads
+		// Configuration::BackgroundLoadPollIntervalMs at every call. The site
+		// is a 6-byte `FF 15 [IAT_Sleep]` indirect call at 0x48F88E; the
+		// preceding `push 64h` is left in place and ignored by the wrapper.
+		genCallUnprotected(0x48F88E, reinterpret_cast<DWORD>(PatchBackgroundLoadSleep), 0x6);
 
 		// Patch: Fix NiFlipController losing its affectedMap on clone.
 		if (Configuration::PatchNiFlipController) {

--- a/misc/package/Data Files/MWSE/core/mwse/config/i18n/eng.lua
+++ b/misc/package/Data Files/MWSE/core/mwse/config/i18n/eng.lua
@@ -32,4 +32,6 @@ return {
 	["suppressUselessWarnings.description"] = "If enabled, the initial startup warning about mismatched masters is suppressed. This warning is almost always displayed on any modded install, and often prompts users to click Yes to All, hiding actually helpful warnings.",
 	["replaceLightSorting.label"] = "Replace light sorting?",
 	["replaceLightSorting.description"] = "If enabled, the default method of prioritizing lights that affect a mesh is replaced with a new method. This greatly reduces the amount of landscape seams as well as the amount of light popping, but may diminish the impact of carried torches in some environments.",
+	["backgroundLoadPollIntervalMs.label"] = "Background load poll interval (ms)",
+	["backgroundLoadPollIntervalMs.description"] = "Controls how often the game polls the background cell loader while a progress bar is being shown (most noticeable in exterior transitions). Morrowind's default is 100 ms, which can cause slightly noticeable stalls on fast machines that finish loading quickly. Lower values make the game resume sooner at the cost of slightly higher CPU use during loads.",
 }

--- a/misc/package/Data Files/MWSE/core/mwse/config/main.lua
+++ b/misc/package/Data Files/MWSE/core/mwse/config/main.lua
@@ -179,6 +179,20 @@ local config = {
 					},
 					callback = resetLighting,
 				},
+				{
+					class = "Slider",
+					label = i18n("backgroundLoadPollIntervalMs.label"),
+					description = i18n("backgroundLoadPollIntervalMs.description"),
+					min = 5,
+					max = 100,
+					step = 1,
+					jump = 5,
+					variable = {
+						id = "BackgroundLoadPollIntervalMs",
+						class = "TableVariable",
+						table = mwseConfig,
+					},
+				},
 			},
 			sidebarComponents = {
 				{


### PR DESCRIPTION
Instead of the fancy clanker proposals, we can check whether the loading screen can be rendered invisible by taking one frame instead of 100 ms. It does seem to work in my local install.