### PR TITLE
Add async voiceover loading

### DIFF
--- a/MWSE/MWSE.vcxproj
+++ b/MWSE/MWSE.vcxproj
@@ -543,6 +543,7 @@
     <ClInclude Include="UIUtil.h" />
     <ClInclude Include="UTF8Convert.h" />
     <ClInclude Include="TES3VFXManager.h" />
+    <ClInclude Include="TES3VoiceStreamer.h" />
     <ClInclude Include="VirtualMachine.h" />
     <ClInclude Include="VMExecuteInterface.h" />
     <ClInclude Include="VMHookInterface.h" />
@@ -1012,6 +1013,7 @@
     <ClCompile Include="TES3VectorsLua.cpp" />
     <ClCompile Include="TES3VFXManager.cpp" />
     <ClCompile Include="TES3VFXManagerLua.cpp" />
+    <ClCompile Include="TES3VoiceStreamer.cpp" />
     <ClCompile Include="TES3WaterController.cpp" />
     <ClCompile Include="TES3WaterControllerLua.cpp" />
     <ClCompile Include="TES3Weapon.cpp" />

--- a/MWSE/MWSE.vcxproj.filters
+++ b/MWSE/MWSE.vcxproj.filters
@@ -1605,6 +1605,9 @@
     <ClInclude Include="TES3VFXManager.h">
       <Filter>Header Files\DataAdapters\TES3\Magic</Filter>
     </ClInclude>
+    <ClInclude Include="TES3VoiceStreamer.h">
+      <Filter>Header Files\DataAdapters\TES3</Filter>
+    </ClInclude>
     <ClInclude Include="MathUtil.h">
       <Filter>Header Files\Utility</Filter>
     </ClInclude>
@@ -3696,6 +3699,9 @@
       <Filter>Source Files\Lua\Events</Filter>
     </ClCompile>
     <ClCompile Include="TES3VFXManager.cpp">
+      <Filter>Source Files\DataAdapters\TES3</Filter>
+    </ClCompile>
+    <ClCompile Include="TES3VoiceStreamer.cpp">
       <Filter>Source Files\DataAdapters\TES3</Filter>
     </ClCompile>
     <ClCompile Include="LuaSpellResistedEvent.cpp">

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -2359,6 +2359,12 @@ namespace mwse::patch {
 		voice::install();
 	}
 
+	void uninstallPatches() {
+		// Patch: Async voiceover loading — stop the worker before the engine
+		// starts tearing down DSound / DataHandler.
+		voice::shutdown();
+	}
+
 	//
 	// Create minidumps.
 	//

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -34,6 +34,7 @@
 #include "TES3UIInventoryTile.h"
 #include "TES3UIMenuController.h"
 #include "TES3VFXManager.h"
+#include "TES3VoiceStreamer.h"
 #include "TES3WorldController.h"
 
 #include "NIAVObject.h"
@@ -2350,6 +2351,12 @@ namespace mwse::patch {
 			windows::SetThreadDescription(dataHandler->mainThread, L"GameMainThread");
 			windows::SetThreadDescription(dataHandler->backgroundThread, L"GameBackgroundThread");
 		}
+
+		// Patch: Async voiceover loading. Eliminates the main-thread MP3 decode
+		// spike when NPCs greet the player. Installed here (rather than in
+		// installPatches) so DataHandler::get() is valid when the worker thread
+		// first acquires criticalSectionAudioEvents.
+		voice::install();
 	}
 
 	//

--- a/MWSE/PatchUtil.h
+++ b/MWSE/PatchUtil.h
@@ -5,5 +5,7 @@ namespace mwse::patch {
 	void installPostLuaPatches();
 	void installPostInitializationPatches();
 
+	void uninstallPatches();
+
 	bool installMiniDumpHook();
 }

--- a/MWSE/TES3AudioController.cpp
+++ b/MWSE/TES3AudioController.cpp
@@ -47,6 +47,21 @@ namespace TES3 {
 		TES3_AudioController_unpauseMusic(this);
 	}
 
+	const auto TES3_AudioController_loadSoundFile = reinterpret_cast<SoundBuffer*(__thiscall*)(AudioController*, const char*, bool)>(0x401DB0);
+	SoundBuffer* AudioController::loadSoundFile(const char* filename, bool isPointSource) {
+		return TES3_AudioController_loadSoundFile(this, filename, isPointSource);
+	}
+
+	const auto TES3_AudioController_playSoundBuffer = reinterpret_cast<void(__thiscall*)(AudioController*, SoundBuffer*, int)>(0x402820);
+	void AudioController::playSoundBuffer(SoundBuffer* soundBuffer, int flags) {
+		TES3_AudioController_playSoundBuffer(this, soundBuffer, flags);
+	}
+
+	const auto TES3_AudioController_setSoundBufferMinMaxDistance = reinterpret_cast<int(__thiscall*)(AudioController*, SoundBuffer*, float, float)>(0x402AC0);
+	int AudioController::setSoundBufferMinMaxDistance(SoundBuffer* soundBuffer, float minDistance, float maxDistance) {
+		return TES3_AudioController_setSoundBufferMinMaxDistance(this, soundBuffer, minDistance, maxDistance);
+	}
+
 	bool AudioController::getAudioFlag(AudioFlag::Flag flag) const {
 		return (audioFlags & flag) != 0;
 	}

--- a/MWSE/TES3AudioController.h
+++ b/MWSE/TES3AudioController.h
@@ -96,6 +96,10 @@ namespace TES3 {
 		void pauseMusic();
 		void unpauseMusic();
 
+		SoundBuffer* loadSoundFile(const char* filename, bool isPointSource);
+		void playSoundBuffer(SoundBuffer* soundBuffer, int flags);
+		int setSoundBufferMinMaxDistance(SoundBuffer* soundBuffer, float minDistance, float maxDistance);
+
 		//
 		// Custom functions.
 		//

--- a/MWSE/TES3CriticalSection.h
+++ b/MWSE/TES3CriticalSection.h
@@ -16,6 +16,18 @@ namespace TES3 {
 		void enter(const char* id = "MWSE:Undefined");
 		void leave();
 
+		// RAII scope guard. Pair an enter() with a guaranteed leave() at scope
+		// exit; non-copyable, non-movable so the lifetime is unambiguous.
+		class Lock {
+			CriticalSection& cs;
+		public:
+			explicit Lock(CriticalSection& cs, const char* id = "MWSE:Undefined") : cs(cs) {
+				cs.enter(id);
+			}
+			~Lock() { cs.leave(); }
+			Lock(const Lock&) = delete;
+			Lock& operator=(const Lock&) = delete;
+		};
 	};
 	static_assert(sizeof(CriticalSection) == 0x24, "TES3::CriticalSection failed size validation");
 }

--- a/MWSE/TES3Sound.cpp
+++ b/MWSE/TES3Sound.cpp
@@ -3,6 +3,8 @@
 #include "TES3Util.h"
 #include "TES3WorldController.h"
 
+#include "MemoryUtil.h"
+
 #include "LuaUtil.h"
 
 #include "LuaSoundObjectPlayEvent.h"
@@ -10,6 +12,27 @@
 #include "LuaManager.h"
 
 namespace TES3 {
+	SoundBuffer::SoundBuffer() {
+		std::memset(this, 0, sizeof(SoundBuffer));
+	}
+
+	SoundBuffer::~SoundBuffer() {
+		// Mirrors the engine's inline destruction in ReleaseSoundBuffer (0x4027E0):
+		// release any DSound COM objects, free the rawAudio peak-envelope buffer.
+		// Operator delete handles the SoundBuffer struct itself.
+		if (lpSound3DBuffer) lpSound3DBuffer->Release();
+		if (lpSoundBuffer) lpSoundBuffer->Release();
+		if (rawAudio) mwse::tes3::_delete(rawAudio);
+	}
+
+	void* SoundBuffer::operator new(size_t size) {
+		return mwse::tes3::_new(size);
+	}
+
+	void SoundBuffer::operator delete(void* p) {
+		mwse::tes3::free(p);
+	}
+
 	Sound::Sound() {
 		ctor();
 	}

--- a/MWSE/TES3Sound.h
+++ b/MWSE/TES3Sound.h
@@ -16,20 +16,35 @@ namespace TES3 {
 	struct SoundBuffer {
 		IDirectSoundBuffer * lpSoundBuffer; // 0x0
 		IDirectSound3DBuffer * lpSound3DBuffer; // 0x4
-		char fileHeader[16];
-		short unknown_0x18;
+		// fileHeader is the in-place WAVEFORMATEX that bufferDescription.lpwfxFormat
+		// points at (set by LoadSoundFile). Bytes 0..15 hold WAVEFORMAT + wBitsPerSample,
+		// bytes 16..17 hold cbSize (always 0 for PCM, which is all the engine produces).
+		char fileHeader[18]; // 0x8
+		// 2 bytes implicit alignment padding here (0x1A..0x1B) to align the
+		// DSBUFFERDESC's first DWORD to 4 bytes.
 		DSBUFFERDESC bufferDescription; // 0x1C
 		bool isVoiceover; // 0x40
 		short* rawAudio; // 0x44
-		int unknown_0x48; // Volume related
+		int dBReduction; // 0x48 - distance attenuation in DSound dB units, set by SetSoundBufferPosition's 2D path and subtracted from volume.
 		unsigned char volume; // 0x4C
 		int minDistance; // 0x50
 		int maxDistance; // 0x58
 
 		static constexpr auto OBJECT_TYPE = ObjectType::Sound;
 
-		SoundBuffer() = delete;
-		~SoundBuffer() = delete;
+		// The engine has no separate ctor/dtor for SoundBuffer; LoadSoundFile
+		// and ReleaseSoundBuffer each inline their own setup/teardown. These
+		// match that behavior so MWSE can `new` / `delete` SoundBuffer objects
+		// (via the engine heap, see operator new/delete) without heap mismatch
+		// when those instances cross the engine boundary.
+		SoundBuffer();
+		~SoundBuffer();
+
+		// Class-specific operator new/delete that route through the engine
+		// heap (0x727692 / 0x727530). Required because instances allocated by
+		// MWSE may be released by engine code (and vice versa).
+		static void* operator new(size_t size);
+		static void operator delete(void* p);
 	};
 	static_assert(sizeof(SoundBuffer) == 0x58, "TES3::SoundBuffer failed size validation");
 	static_assert(sizeof(DSBUFFERDESC) == 0x24, "DSBUFFERDESC failed size validation");

--- a/MWSE/TES3VoiceStreamer.cpp
+++ b/MWSE/TES3VoiceStreamer.cpp
@@ -1,60 +1,38 @@
 #include "TES3VoiceStreamer.h"
 
-#include <windows.h>
 #include <dsound.h>
 
 #include "Log.h"
 #include "MemoryUtil.h"
+#include "WindowsUtil.h"
 
 #include "TES3AudioController.h"
 #include "TES3CriticalSection.h"
 #include "TES3DataHandler.h"
+#include "TES3GameSetting.h"
 #include "TES3Reference.h"
 #include "TES3Sound.h"
 #include "TES3WorldController.h"
 
 #include <atomic>
-#include <cmath>
 #include <condition_variable>
-#include <cstring>
 #include <deque>
 #include <memory>
-#include <mutex>
-#include <string>
 #include <thread>
-#include <unordered_map>
 
 namespace mwse::patch::voice {
 
 	namespace {
 
-		// ------------------------------------------------------------------
-		// Engine functions we call into directly (not replaced).
-		// ------------------------------------------------------------------
-
-		using LoadSoundFile_t   = TES3::SoundBuffer* (__thiscall*)(TES3::AudioController*, const char*, bool);
-		using PlaySoundBuffer_t = void              (__thiscall*)(TES3::AudioController*, TES3::SoundBuffer*, int);
-		using SetVolume_t       = void              (__thiscall*)(TES3::AudioController*, TES3::SoundBuffer*, unsigned char);
-		using SetMinMax_t       = int               (__thiscall*)(TES3::AudioController*, TES3::SoundBuffer*, float, float);
-
-		const auto LoadSoundFile_Orig   = reinterpret_cast<LoadSoundFile_t>(0x401DB0);
-		const auto PlaySoundBuffer_Orig = reinterpret_cast<PlaySoundBuffer_t>(0x402820);
-		const auto SetVolume_Orig       = reinterpret_cast<SetVolume_t>(0x4029F0);
-		const auto SetMinMax_Orig       = reinterpret_cast<SetMinMax_t>(0x402AC0);
-
-		// ------------------------------------------------------------------
-		// Stub representation
-		// ------------------------------------------------------------------
-		// A "pending" SoundBuffer is one whose decode hasn't finished. Encoded
-		// by bufferDescription.dwSize == 0 (the real value, set by LoadSoundFile,
-		// is sizeof(DSBUFFERDESC) == 36 — never 0 for a real buffer).
+		// A "pending" SoundBuffer is one whose decode hasn't finished. Encoded by
+		// bufferDescription.dwSize == 0 (the real value, set by LoadSoundFile, is
+		// sizeof(DSBUFFERDESC) == 36 — never 0 for a real buffer).
 		//
 		// All stub-awareness in MWSE lives in this file. The five leaf accessor
-		// replacements below check isPending() and short-circuit; everything
-		// else in the engine treats stubs as ordinary SoundBuffers.
-
+		// replacements below check isPending() and short-circuit; everything else
+		// in the engine treats stubs as ordinary SoundBuffers.
 		constexpr DWORD STUB_PENDING_SENTINEL = 0;
-		constexpr DWORD REAL_BUFFERDESC_SIZE  = sizeof(DSBUFFERDESC); // 36
+		constexpr DWORD REAL_BUFFERDESC_SIZE = sizeof(DSBUFFERDESC); // 36
 
 		bool isPending(const TES3::SoundBuffer* sb) {
 			return sb && sb->bufferDescription.dwSize == STUB_PENDING_SENTINEL;
@@ -69,59 +47,27 @@ namespace mwse::patch::voice {
 				|| std::strstr(filename, "VO\\") != nullptr;
 		}
 
-		// Allocate stubs from the engine heap so anything that frees them via
-		// the engine's normal `delete` works without heap-mismatch corruption.
+		// Allocate a stub via SoundBuffer's class-specific operator new (engine
+		// heap), then ctor-zero. We then set the field invariants we rely on
+		// across the leaf accessors:
+		// - dwFlags must NOT have DSBCAPS_CTRL3D set, so SetSoundBufferPosition
+		//   takes the 2D branch which is null-safe via our replacement.
+		// - lpwfxFormat must be non-null and point at zero-initialized memory
+		//   so SetSoundBufferFrequency reads nSamplesPerSec==0 and exits early.
+		// dwSize stays 0 (the STUB_PENDING_SENTINEL value) from the ctor's memset.
 		TES3::SoundBuffer* allocateStub() {
-			auto* sb = mwse::tes3::_new<TES3::SoundBuffer>();
-			std::memset(sb, 0, sizeof(TES3::SoundBuffer));
-
-			sb->lpSoundBuffer    = nullptr;
-			sb->lpSound3DBuffer  = nullptr;
-			sb->rawAudio         = nullptr;
-			sb->isVoiceover      = true;
-
-			// Field invariants we rely on across the leaf accessors:
-			// - dwFlags must NOT have DSBCAPS_CTRL3D set, so SetSoundBufferPosition
-			//   takes the 2D branch which is null-safe via our replacement.
-			// - lpwfxFormat must be non-null and point at zero-initialized memory
-			//   so SetSoundBufferFrequency reads nSamplesPerSec==0 and exits early.
-			sb->bufferDescription.dwFlags        = 0;
-			sb->bufferDescription.dwBufferBytes  = 0;
-			sb->bufferDescription.lpwfxFormat    = reinterpret_cast<WAVEFORMATEX*>(sb->fileHeader);
-
-			// Sentinel goes last so a partially-built stub never looks "real".
-			sb->bufferDescription.dwSize         = STUB_PENDING_SENTINEL;
+			auto* sb = new TES3::SoundBuffer();
+			sb->isVoiceover = true;
+			sb->bufferDescription.lpwfxFormat = reinterpret_cast<WAVEFORMATEX*>(sb->fileHeader);
 			return sb;
 		}
 
-		// Free what releaseRealSoundBuffer would, but for the stub case where
-		// lpSoundBuffer/lpSound3DBuffer/rawAudio are all null. Just release the
-		// SoundBuffer struct itself via the engine heap.
-		void deleteStub(TES3::SoundBuffer* sb) {
-			mwse::tes3::_delete(sb);
-		}
-
-		// What the engine's original ReleaseSoundBuffer does on a real buffer.
-		// Pulled out as a helper so the worker's "stub was reaped mid-decode" path
-		// and the replacement's "real buffer" branch share one implementation.
-		void releaseRealSoundBuffer(TES3::SoundBuffer* sb) {
-			if (!sb) return;
-			if (sb->lpSound3DBuffer) sb->lpSound3DBuffer->Release();
-			if (sb->lpSoundBuffer)   sb->lpSoundBuffer->Release();
-			if (sb->rawAudio)        mwse::tes3::_delete(sb->rawAudio);
-			mwse::tes3::_delete(sb);
-		}
-
-		// ------------------------------------------------------------------
-		// Stub refcount
-		// ------------------------------------------------------------------
 		// A stub may be referenced by both the SoundEvent (returned to the game)
 		// and the worker (still decoding). Whichever decrements last frees it.
 		// This is the only reason we hook ReleaseSoundBuffer at all — without it,
 		// the engine could free a stub while the worker is mid-decode.
-
-		std::mutex                                                   g_stubRefMutex;
-		std::unordered_map<TES3::SoundBuffer*, std::atomic<int>*>    g_stubRefcounts;
+		std::mutex g_stubRefMutex;
+		std::unordered_map<TES3::SoundBuffer*, std::atomic<int>*> g_stubRefcounts;
 
 		std::atomic<int>* acquireStubRef(TES3::SoundBuffer* stub) {
 			std::lock_guard lk(g_stubRefMutex);
@@ -137,27 +83,23 @@ namespace mwse::patch::voice {
 					g_stubRefcounts.erase(stub);
 				}
 				delete rc;
-				deleteStub(stub);
+				delete stub;
 			}
 		}
 
-		// ------------------------------------------------------------------
-		// Decode worker
-		// ------------------------------------------------------------------
-
 		struct DecodeTask {
-			std::string             path;
-			TES3::AudioController*  audio;
-			bool                    isPointSource;
-			TES3::SoundBuffer*      stub;
-			std::atomic<int>*       refcount;
+			std::string path;
+			TES3::AudioController* audio;
+			bool isPointSource;
+			TES3::SoundBuffer* stub;
+			std::atomic<int>* refcount;
 		};
 
-		std::mutex              g_queueMutex;
+		std::mutex g_queueMutex;
 		std::condition_variable g_queueCv;
-		std::deque<DecodeTask>  g_queue;
-		std::thread             g_worker;
-		std::atomic<bool>       g_running{ false };
+		std::deque<DecodeTask> g_queue;
+		std::thread g_worker;
+		std::atomic<bool> g_running{ false };
 
 		// RAII guard for the audio-lists critical section that addTempSound /
 		// updateSounds / sayDialogueVoice all share. Publishing the decoded
@@ -170,54 +112,41 @@ namespace mwse::patch::voice {
 		class AudioListsLock {
 			TES3::CriticalSection* cs;
 		public:
-			explicit AudioListsLock(const char* id)
-				: cs(TES3::DataHandler::get()->criticalSectionAudioEvents)
-			{
+			explicit AudioListsLock(const char* id) : cs(TES3::DataHandler::get()->criticalSectionAudioEvents) {
 				cs->enter(id);
 			}
 			~AudioListsLock() { cs->leave(); }
-			AudioListsLock(const AudioListsLock&)            = delete;
+			AudioListsLock(const AudioListsLock&) = delete;
 			AudioListsLock& operator=(const AudioListsLock&) = delete;
 		};
 
-		// Custom-deleter unique_ptr for engine-allocated SoundBuffers. Cleans up
-		// COM objects + rawAudio + the wrapper struct in one move, matching the
-		// engine's own ReleaseSoundBuffer (we route through our helper rather
-		// than calling the replacement, to avoid the stub-detection branch when
-		// we know we have a real buffer).
-		struct EngineSoundBufferDeleter {
-			void operator()(TES3::SoundBuffer* sb) const noexcept {
-				releaseRealSoundBuffer(sb);
-			}
-		};
-		using EngineSoundBufferPtr = std::unique_ptr<TES3::SoundBuffer, EngineSoundBufferDeleter>;
+		// std::default_delete<TES3::SoundBuffer> calls plain `delete sb`, which
+		// invokes SoundBuffer's dtor (Release COMs + free rawAudio) and then its
+		// class-specific operator delete (engine heap free).
+		using EngineSoundBufferPtr = std::unique_ptr<TES3::SoundBuffer>;
 
-		// Move decoded contents into the stub atomically; transition dwSize=0→36
-		// is the publish edge that flips the leaf accessors out of stub mode.
-		void publishDecodedBufferLocked(
-			TES3::AudioController* audio,
-			TES3::SoundBuffer*     stub,
-			TES3::SoundBuffer*     decoded)
-		{
-			stub->lpSoundBuffer       = decoded->lpSoundBuffer;
-			stub->lpSound3DBuffer     = decoded->lpSound3DBuffer;
-			stub->rawAudio            = decoded->rawAudio;
+		// Move decoded contents into the stub atomically; the dwSize=0→36
+		// transition is the publish edge that flips the leaf accessors out of
+		// stub mode.
+		void publishDecodedBufferLocked(TES3::AudioController* audio, TES3::SoundBuffer* stub, TES3::SoundBuffer* decoded) {
+			stub->lpSoundBuffer = decoded->lpSoundBuffer;
+			stub->lpSound3DBuffer = decoded->lpSound3DBuffer;
+			stub->rawAudio = decoded->rawAudio;
 			std::memcpy(stub->fileHeader, decoded->fileHeader, sizeof(stub->fileHeader));
-			stub->bufferDescription   = decoded->bufferDescription; // dwSize becomes 36 here
+			stub->bufferDescription = decoded->bufferDescription; // dwSize becomes 36 here
 
 			// lpwfxFormat is an INTERNAL pointer (decoded->fileHeader, inside
 			// decoded's own struct that we're about to free). Redirect to
 			// stub->fileHeader, where we just memcpy'd the WAVEFORMATEX bytes.
-			// Without this, SetSoundBufferFrequency (or any later wfx read)
-			// is a use-after-free.
-			stub->bufferDescription.lpwfxFormat =
-				reinterpret_cast<WAVEFORMATEX*>(stub->fileHeader);
+			// Without this, SetSoundBufferFrequency (or any later wfx read) is a
+			// use-after-free.
+			stub->bufferDescription.lpwfxFormat = reinterpret_cast<WAVEFORMATEX*>(stub->fileHeader);
 
-			stub->isVoiceover         = true;
+			stub->isVoiceover = true;
 
 			// Do NOT touch stub->volume here. addTempSound already called
-			// SetSoundBufferVolume(stub, vol) while the stub was pending,
-			// which writes the volume field even though it skips the DSound call
+			// SetSoundBufferVolume(stub, vol) while the stub was pending, which
+			// writes the volume field even though it skips the DSound call
 			// (lpSoundBuffer was null at the time). decoded->volume is
 			// uninitialized from operator new — clobbering with it would set
 			// volume to 0 and produce a -10000 dB attenuation (silent) on the
@@ -225,39 +154,40 @@ namespace mwse::patch::voice {
 
 			// Null out decoded's resource fields — DSound objects + rawAudio now
 			// belong to the stub. The caller's EngineSoundBufferPtr will then
-			// invoke releaseRealSoundBuffer on the husk; with all resource fields
-			// null, that just frees the wrapper struct.
-			decoded->lpSoundBuffer    = nullptr;
-			decoded->lpSound3DBuffer  = nullptr;
-			decoded->rawAudio         = nullptr;
+			// `delete` the husk; with all resource fields null, the SoundBuffer
+			// dtor is a no-op and only the wrapper struct gets freed.
+			decoded->lpSoundBuffer = nullptr;
+			decoded->lpSound3DBuffer = nullptr;
+			decoded->rawAudio = nullptr;
 
 			// Apply Volume and Min/Max distance to the now-real buffer.
 			// addTempSound called both setters on the pending stub; the wrappers
 			// wrote the fields but skipped the COM calls (lpSoundBuffer /
 			// lpSound3DBuffer were null at the time). Without re-applying:
-			//   - 3D mode (lpSound3DBuffer non-null): DSound uses defaults
-			//     DS3D_DEFAULTMINDISTANCE=1m / DS3D_DEFAULTMAXDISTANCE=1e9m,
-			//     attenuating to silence at any sane game distance. updateSounds
-			//     only calls SetPosition each frame — it never re-applies
-			//     min/max — so the attenuation stays buried forever.
-			//   - 2D mode: lpSoundBuffer is at 0 dB max from LoadSoundFile_Orig's
-			//     finalizer; SetVolume here corrects the brief loud frame before
-			//     updateSounds re-applies via SetSoundBufferPosition's 2D path.
+			//   - 3D mode: DSound uses defaults DS3D_DEFAULTMINDISTANCE=1m /
+			//     DS3D_DEFAULTMAXDISTANCE=1e9m, attenuating to silence at any
+			//     sane game distance. updateSounds only calls SetPosition each
+			//     frame — never re-applies min/max — so attenuation stays buried.
+			//   - 2D mode: lpSoundBuffer is at 0 dB max from loadSoundFile's
+			//     finalizer; setSoundBufferVolume here corrects the brief loud
+			//     frame before updateSounds re-applies via SetSoundBufferPosition's
+			//     2D path.
 			//
-			// stub->minDistance/maxDistance are typed `int` in MWSE's struct but
+			// stub->minDistance/maxDistance are typed int in MWSE's struct but
 			// the engine stores float bit patterns there (see decompilation of
 			// SetSoundBufferMinMaxDistance's else branch). Re-cast to float.
-			SetVolume_Orig(audio, stub, stub->volume);
+			audio->setSoundBufferVolume(stub, stub->volume);
 
 			float minD = 0.0f, maxD = 0.0f;
 			std::memcpy(&minD, &stub->minDistance, sizeof(float));
 			std::memcpy(&maxD, &stub->maxDistance, sizeof(float));
-			SetMinMax_Orig(audio, stub, minD, maxD);
+			audio->setSoundBufferMinMaxDistance(stub, minD, maxD);
 
-			// addTempSound's PlaySoundBuffer earlier was a no-op (lpSoundBuffer null);
-			// now that the buffer is real, kick off playback. updateSounds will
-			// reposition the stub on its next tick from the SoundEvent's reference.
-			PlaySoundBuffer_Orig(audio, stub, /*flags*/ 0);
+			// addTempSound's PlaySoundBuffer earlier was a no-op (lpSoundBuffer
+			// null); now that the buffer is real, kick off playback. updateSounds
+			// will reposition the stub on its next tick from the SoundEvent's
+			// reference.
+			audio->playSoundBuffer(stub, 0);
 		}
 
 		void workerLoop() {
@@ -271,27 +201,26 @@ namespace mwse::patch::voice {
 					g_queue.pop_front();
 				}
 
-				// 1. Decode off the main thread, no engine lock held. Wrap in
-				//    a unique_ptr so any early return correctly releases the
-				//    engine-allocated buffer + its COM resources via the deleter.
-				EngineSoundBufferPtr decoded(
-					LoadSoundFile_Orig(task.audio, task.path.c_str(), task.isPointSource));
+				// Decode off the main thread, no engine lock held. Wrap in a
+				// unique_ptr so any early return correctly releases the
+				// engine-allocated buffer + its COM resources via the deleter.
+				EngineSoundBufferPtr decoded(task.audio->loadSoundFile(task.path.c_str(), task.isPointSource));
 
-				// 2. Re-enter the engine to publish. RAII lock scope = the rest
-				//    of this iteration; auto-release on every continue path.
+				// Re-enter the engine to publish. RAII lock scope = the rest of
+				// this iteration; auto-release on every continue path.
 				{
 					AudioListsLock lk("MWSE:VoiceStreamer");
 
 					// Stub was released while we were decoding (cell change, killSounds).
 					if (task.refcount->load() <= 1) {
 						decRef(task.stub, task.refcount);
-						continue;  // unique_ptr drops decoded; AudioListsLock leaves
+						continue; // unique_ptr drops decoded; AudioListsLock leaves
 					}
 
 					// Decode failed (file missing, bad format, OOM). Flip dwSize so
 					// updateSounds reaps the SoundEvent — its status check will now
-					// hit the real-buffer path and find lpSoundBuffer null. The
-					// leaf replacements all guard against that.
+					// hit the real-buffer path and find lpSoundBuffer null. The leaf
+					// replacements all guard against that.
 					if (!decoded) {
 						task.stub->bufferDescription.dwSize = REAL_BUFFERDESC_SIZE;
 						decRef(task.stub, task.refcount);
@@ -299,9 +228,8 @@ namespace mwse::patch::voice {
 					}
 
 					// Publish: move decoded fields into stub, then null decoded's
-					// pointers so the unique_ptr's deleter only frees the husk
-					// (releaseRealSoundBuffer's NULL checks make it a no-op for
-					// the resource fields).
+					// pointers so the unique_ptr's `delete` invokes a no-op dtor
+					// (resource fields all null) and only frees the husk.
 					publishDecodedBufferLocked(task.audio, task.stub, decoded.get());
 				}
 
@@ -309,63 +237,113 @@ namespace mwse::patch::voice {
 			}
 		}
 
-		// ==================================================================
-		// Function-prologue REPLACEMENTS for the five leaf accessors.
+		// Function-prologue replacements for the five SoundBuffer leaf accessors.
+		// Each is a full C++ reimplementation of the engine function with an
+		// isPending() short-circuit. All installed via genJumpUnprotected, which
+		// replaces the engine's first 5 bytes.
 		//
-		// Four are full reimplementations with an isPending() short-circuit
-		// (Get/SetCurrentPosition/LipSync/Release). The fifth (SetPosition)
-		// uses a trampoline because its body is too math-heavy to reimplement.
-		// All installed via genJumpUnprotected, replacing the engine's first
-		// 5 bytes.
-		//
-		// The engine's 35+ existing call sites stay completely untouched:
-		// they still call 0x402B50 / 0x402E90 / 0x4029A0 / 0x402EC0 / 0x4027E0
-		// exactly as before. Those addresses just route to our C++ now.
-		// ==================================================================
+		// The engine's existing call sites stay completely untouched — they still
+		// call 0x402B50 / 0x402E90 / 0x4029A0 / 0x402EC0 / 0x4027E0 exactly as
+		// before. Those addresses just route to our C++ now.
 
-		// Replaces 0x402B50 AudioController::SetSoundBufferPosition.
-		// This one CANNOT be a full reimpl — too much trig/distance/dB math.
-		// Instead, function-prologue JMP + trampoline: trampoline reproduces
-		// the 5 bytes we overwrite and then `push ret`s into 0x402B55, so the
-		// rest of the function executes verbatim.
-		//
-		// Verified: bytes at 0x402B50 are `83 EC 08 55 56` = sub esp,8; push ebp;
-		// push esi. Clean 5-byte boundary. The 2D path's early `SetPan` and the
-		// 3D path's `SetPosition` both dereference lpSoundBuffer / lpSound3DBuffer
-		// without a null guard, hence the isPending and lpSoundBuffer guards in
-		// the wrapper before we hand off to the trampoline.
-		__declspec(naked) void __fastcall setSoundBufferPosition_trampoline(
-			TES3::AudioController* /*self*/,
-			void* /*edx*/,
-			TES3::SoundBuffer*   /*sb*/,
-			TES3::Vector3*       /*pos*/)
-		{
-			__asm {
-				sub esp, 8           // reproduce 0x402B50..54
-				push ebp
-				push esi
-				push 0x402B55        // push-ret avoids a rel32 jmp whose offset
-				ret                  // depends on where MSVC places this function
-			}
-		}
-
-		void __fastcall setSoundBufferPosition_replacement(
-			TES3::AudioController* self,
-			void* /*edx*/,
-			TES3::SoundBuffer* sb,
-			TES3::Vector3* pos)
-		{
-			if (isPending(sb)) return;             // pending stub
+		// Replaces 0x402B50 AudioController::SetSoundBufferPosition. Faithful
+		// C++ reimplementation of the engine's body. Constants and quadrant
+		// logic match the original (which has its own conventions — including
+		// a deliberately-imprecise "pi" of 3.1400001 — so positional audio
+		// behaves bit-for-bit the same).
+		void __fastcall setSoundBufferPosition_replacement(TES3::AudioController* self, void* /*edx*/, TES3::SoundBuffer* sb, TES3::Vector3* position) {
+			if (isPending(sb)) return;
 			if (!sb || !sb->lpSoundBuffer) return; // decode-fail stub
-			setSoundBufferPosition_trampoline(self, nullptr, sb, pos);
+			if (!self->dsound3DCommitted) return;
+
+			constexpr float k_pi = 3.1400001f;
+			constexpr float k_2pi = 6.2800002f;
+			constexpr float k_volume_to_dB = -13.070588f;
+
+			// Listener-relative deltas + 3D distance.
+			const float dx = position->x - self->listenerPosition.x;
+			const float dy = position->y - self->listenerPosition.y;
+			const float dz = position->z - self->listenerPosition.z;
+			const float dist = std::sqrt(dx * dx + dy * dy + dz * dz);
+
+			// Bearing in [0, 2π). Quadrant logic mirrors 0x402BB6..0x402CB3 —
+			// each branch reproduces a labeled block of the disassembly.
+			float bearing = 0.0f;
+			if (dx < 0.0f) {
+				if (dy < 0.0f) {
+					bearing = k_pi - std::atan2(-dx / -dy, 1.0f);
+				} else if (dy > 0.0f) {
+					bearing = std::atan2(-dx / dy, 1.0f);
+				}
+			} else if (dx > 0.0f) {
+				if (dy > 0.0f) {
+					bearing = k_2pi - std::atan2(dx / dy, 1.0f);
+				} else if (dy < 0.0f) {
+					bearing = std::atan2(dx / -dy, 1.0f) + k_pi;
+				}
+			}
+
+			const float angle = self->yawAxis - bearing;
+
+			if ((sb->bufferDescription.dwFlags & DSBCAPS_CTRL3D) != 0) {
+				// 3D path: position the buffer in listener-relative space.
+				const D3DVALUE x_3d = std::sin(angle) * dist;
+				const D3DVALUE z_3d = std::cos(angle) * dist;
+				sb->lpSound3DBuffer->SetPosition(x_3d, dz, z_3d, DS3D_IMMEDIATE);
+				self->dsound3DChanged = true;
+				return;
+			}
+
+			// 2D path: pan + distance attenuation + volume.
+			if (dist <= 0.1f) {
+				sb->lpSoundBuffer->SetPan(0);
+			} else {
+				const float s = std::sin(angle);
+				const float pan = (s < 0.0f ? -(s * s) : (s * s)) * 5000.0f;
+				sb->lpSoundBuffer->SetPan(static_cast<LONG>(pan));
+			}
+
+			// Distance attenuation -> dBReduction. maxDistance is stored as a
+			// float bit pattern in an int slot (engine convention).
+			float maxDistAsFloat;
+			std::memcpy(&maxDistAsFloat, &sb->maxDistance, sizeof(float));
+			const auto* ndd = TES3::DataHandler::get()->nonDynamicData;
+			const float scaled = maxDistAsFloat / ndd->GMSTs[TES3::GMST::fAudioMaxDistanceMult]->value.asFloat;
+
+			if (scaled > 200.0f) {
+				sb->dBReduction = 0;
+			} else if (scaled > 99.0f) {
+				sb->dBReduction = static_cast<int>(dist * 0.5f);
+			} else if (scaled < 10.0f) {
+				sb->dBReduction = static_cast<int>(dist * 6.0f);
+			} else if (scaled >= 50.0f) {
+				sb->dBReduction = static_cast<int>(dist * 3.0f);
+			} else {
+				sb->dBReduction = static_cast<int>(dist * 4.0f);
+			}
+
+			// DSound's IDirectSoundBuffer::SetVolume takes a value in hundredths
+			// of a decibel (range [-10000, 0] = [-100 dB, 0 dB]). Formula matches
+			// the engine: -3333 + (volume × 13.07) - dBReduction, clamped.
+			// volume==0 short-circuits to fully silent.
+			const unsigned char vol = sb->volume;
+			int v24;
+			if (vol == 0) {
+				v24 = -10000;
+			} else {
+				v24 = -3333 - static_cast<int>(static_cast<float>(vol) * k_volume_to_dB);
+			}
+			if (vol < 253) {
+				v24 -= sb->dBReduction;
+			}
+			int v25 = (v24 >= 0) ? 0 : v24;
+			if (v25 < -10000) v25 = -10000;
+			sb->lpSoundBuffer->SetVolume(v25);
+			self->dsound3DChanged = true;
 		}
 
 		// Replaces 0x402E90 AudioController::GetSoundBufferStatus.
-		unsigned char __fastcall getSoundBufferStatus_replacement(
-			TES3::AudioController* /*audio*/,
-			void* /*edx*/,
-			TES3::SoundBuffer* sb)
-		{
+		unsigned char __fastcall getSoundBufferStatus_replacement(TES3::AudioController* /*audio*/, void* /*edx*/, TES3::SoundBuffer* sb) {
 			if (isPending(sb)) return DSBSTATUS_PLAYING;
 			// Decode-fail or any other path that leaves a real-state SoundBuffer
 			// with null lpSoundBuffer. Returning 0 (not playing) lets updateSounds
@@ -377,55 +355,43 @@ namespace mwse::patch::voice {
 		}
 
 		// Replaces 0x4029A0 AudioController::SetSoundBufferCurrentPosition.
-		void __fastcall setSoundBufferCurrentPosition_replacement(
-			TES3::AudioController* /*audio*/,
-			void* /*edx*/,
-			TES3::SoundBuffer* sb,
-			float position)
-		{
+		void __fastcall setSoundBufferCurrentPosition_replacement(TES3::AudioController* /*audio*/, void* /*edx*/, TES3::SoundBuffer* sb, float position) {
 			if (isPending(sb)) return;
 			if (!sb || !sb->lpSoundBuffer) return;
 			if (position < 0.0f) return;
+			// Engine global written (but never read, per IDA xref) by the original
+			// at this point. Preserved for byte-for-byte parity; some future engine
+			// patch could conceivably read it.
+			using gLastSetSoundBufferBytePos = mwse::ExternalGlobal<DWORD, 0x7C5F20>;
 			DWORD bytes = static_cast<DWORD>(sb->bufferDescription.dwBufferBytes * position) & ~3u;
-			// Engine global at 0x7C5F20: preserved for byte-for-byte parity with
-			// the original. Some other engine code reads the most-recently-set
-			// playback byte position from this address.
-			*reinterpret_cast<DWORD*>(0x7C5F20) = bytes;
+			gLastSetSoundBufferBytePos::set(bytes);
 			sb->lpSoundBuffer->SetCurrentPosition(bytes);
 		}
 
 		// Replaces 0x402EC0 AudioController::GetSoundBufferLipSyncLevel.
-		float __fastcall getSoundBufferLipSyncLevel_replacement(
-			TES3::AudioController* /*audio*/,
-			void* /*edx*/,
-			TES3::SoundBuffer* sb)
-		{
+		float __fastcall getSoundBufferLipSyncLevel_replacement(TES3::AudioController* /*audio*/, void* /*edx*/, TES3::SoundBuffer* sb) {
 			// Mouth stays closed during the decode window. The original would have
 			// returned 0.5 (rawAudio==null path) which produced a frozen yawn.
-			if (isPending(sb))    return 0.0f;
+			if (isPending(sb)) return 0.0f;
 
 			// Real buffer path — verbatim original behavior.
-			if (!sb->rawAudio)    return 0.5f;
+			if (!sb->rawAudio) return 0.5f;
 			if (!sb->lpSoundBuffer) return 0.5f; // defensive; rawAudio without DSound buffer shouldn't occur
 
 			DWORD status = 0;
 			sb->lpSoundBuffer->GetStatus(&status);
-			if (!(status & 5))    return 0.0f;
+			if (!(status & 5)) return 0.0f;
 
 			DWORD pos = 0;
 			if (FAILED(sb->lpSoundBuffer->GetCurrentPosition(&pos, nullptr))) return 0.5f;
 
 			short sample = sb->rawAudio[pos / 0x900];
-			int   absSample = std::abs(static_cast<int>(sample));
+			int absSample = std::abs(static_cast<int>(sample));
 			return absSample * (1.0f / 32768.0f);
 		}
 
 		// Replaces 0x4027E0 AudioController::ReleaseSoundBuffer.
-		void __fastcall releaseSoundBuffer_replacement(
-			TES3::AudioController* /*audio*/,
-			void* /*edx*/,
-			TES3::SoundBuffer* sb)
-		{
+		void __fastcall releaseSoundBuffer_replacement(TES3::AudioController* /*audio*/, void* /*edx*/, TES3::SoundBuffer* sb) {
 			if (!sb) return;
 
 			if (isPending(sb)) {
@@ -437,82 +403,62 @@ namespace mwse::patch::voice {
 					if (it != g_stubRefcounts.end()) rc = it->second;
 				}
 				if (rc) decRef(sb, rc);
-				else    deleteStub(sb);  // unknown stub (refcount table missed it); free directly
+				else delete sb; // unknown stub (refcount table missed it); free directly
 				return;
 			}
 
-			releaseRealSoundBuffer(sb);
+			delete sb;
 		}
 
-		// ==================================================================
-		// asyncLoadSoundFile — the only call-site divert. Replaces the call
-		// at addTempSound 0x48C369 (originally calling 0x401DB0).
-		// ==================================================================
-
-		TES3::SoundBuffer* __fastcall asyncLoadSoundFile(
-			TES3::AudioController* audio,
-			void* /*edx*/,
-			const char* filename,
-			bool isPointSource)
-		{
+		// Replaces the call to LoadSoundFile inside addTempSound (0x48C369). For
+		// non-voiceover paths, falls straight through to the engine's loadSoundFile.
+		// For voiceover paths, allocates a pending stub and queues the actual decode
+		// onto the worker thread.
+		TES3::SoundBuffer* __fastcall asyncLoadSoundFile(TES3::AudioController* audio, void* /*edx*/, const char* filename, bool isPointSource) {
 			if (!isVoiceoverPath(filename)) {
-				return LoadSoundFile_Orig(audio, filename, isPointSource);
+				return audio->loadSoundFile(filename, isPointSource);
 			}
 
-			// Voiceover: stub now, decode on worker.
 			auto* stub = allocateStub();
-			auto* rc   = acquireStubRef(stub);
+			auto* rc = acquireStubRef(stub);
 
 			{
 				std::lock_guard lk(g_queueMutex);
-				g_queue.push_back(DecodeTask{
-					filename,
-					audio,
-					isPointSource,
-					stub,
-					rc,
-				});
+				g_queue.push_back(DecodeTask{ filename, audio, isPointSource, stub, rc });
 			}
 			g_queueCv.notify_one();
 			return stub;
 		}
 
-	}  // anonymous namespace
-
-	// ----------------------------------------------------------------------
-	// Public install / shutdown
-	// ----------------------------------------------------------------------
+	} // anonymous namespace
 
 	void install() {
-		// 1. Divert addTempSound's call to LoadSoundFile.
-		//    The two other LoadSoundFile call sites (0x51083F, 0x510859 in
-		//    Sound::set3DParams) are for permanent Sound records and never see
-		//    voiceover paths — leave them alone.
+		// Divert addTempSound's call to LoadSoundFile. The two other call sites
+		// of LoadSoundFile (Sound::set3DParams at 0x51083F / 0x510859) are for
+		// permanent Sound records and never see voiceover paths — leave them.
 		//
-		// The call instruction is at 0x48C369 (5-byte E8 rel32). Verified via
-		// read_memory_bytes: the 5 bytes are E8 42 5A F7 FF (call 0x401DB0).
-		// genCallEnforced returns false silently if the byte pattern doesn't
-		// match — we log on failure so the streamer never silently no-ops.
+		// The call instruction is at 0x48C369 (5-byte E8 rel32). Verified bytes:
+		// E8 42 5A F7 FF (= call 0x401DB0). genCallEnforced returns false silently
+		// on byte-pattern mismatch — log on failure so the streamer never silently
+		// no-ops.
 		if (!genCallEnforced(0x48C369, 0x401DB0, reinterpret_cast<DWORD>(&asyncLoadSoundFile))) {
-			log::getLog() << "Voice streamer: call-site patch at 0x48C369 failed "
-			                 "(byte pattern mismatch). Streamer is INACTIVE.\n";
+			log::getLog() << "Voice streamer: call-site patch at 0x48C369 failed (byte pattern mismatch). Streamer is INACTIVE.\n";
 			return;
 		}
 
-		// 2. Replace the leaf SoundBuffer accessors at their function prologues.
-		//    The engine's 35+ existing call sites stay completely untouched —
-		//    they still call these addresses, which now route to our C++.
-		//    All stub-awareness is encapsulated in the five replacements.
+		// Replace the leaf SoundBuffer accessors at their function prologues. The
+		// engine's existing call sites stay untouched; they still call these
+		// addresses, which now route to our C++. All stub-awareness is encapsulated
+		// in the five replacements.
 		genJumpUnprotected(0x402E90, reinterpret_cast<DWORD>(&getSoundBufferStatus_replacement));
 		genJumpUnprotected(0x4029A0, reinterpret_cast<DWORD>(&setSoundBufferCurrentPosition_replacement));
 		genJumpUnprotected(0x402EC0, reinterpret_cast<DWORD>(&getSoundBufferLipSyncLevel_replacement));
 		genJumpUnprotected(0x4027E0, reinterpret_cast<DWORD>(&releaseSoundBuffer_replacement));
-		// Trampoline-based replacement; see setSoundBufferPosition_trampoline above.
 		genJumpUnprotected(0x402B50, reinterpret_cast<DWORD>(&setSoundBufferPosition_replacement));
 
-		// 3. Spin up the decode worker.
 		g_running.store(true, std::memory_order_release);
 		g_worker = std::thread(&workerLoop);
+		mwse::windows::SetThreadDescription(g_worker.native_handle(), L"MWSEVoiceDecoder");
 	}
 
 	void shutdown() {
@@ -521,4 +467,4 @@ namespace mwse::patch::voice {
 		if (g_worker.joinable()) g_worker.join();
 	}
 
-}  // namespace mwse::patch::voice
+} // namespace mwse::patch::voice

--- a/MWSE/TES3VoiceStreamer.cpp
+++ b/MWSE/TES3VoiceStreamer.cpp
@@ -1,0 +1,524 @@
+#include "TES3VoiceStreamer.h"
+
+#include <windows.h>
+#include <dsound.h>
+
+#include "Log.h"
+#include "MemoryUtil.h"
+
+#include "TES3AudioController.h"
+#include "TES3CriticalSection.h"
+#include "TES3DataHandler.h"
+#include "TES3Reference.h"
+#include "TES3Sound.h"
+#include "TES3WorldController.h"
+
+#include <atomic>
+#include <cmath>
+#include <condition_variable>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+namespace mwse::patch::voice {
+
+	namespace {
+
+		// ------------------------------------------------------------------
+		// Engine functions we call into directly (not replaced).
+		// ------------------------------------------------------------------
+
+		using LoadSoundFile_t   = TES3::SoundBuffer* (__thiscall*)(TES3::AudioController*, const char*, bool);
+		using PlaySoundBuffer_t = void              (__thiscall*)(TES3::AudioController*, TES3::SoundBuffer*, int);
+		using SetVolume_t       = void              (__thiscall*)(TES3::AudioController*, TES3::SoundBuffer*, unsigned char);
+		using SetMinMax_t       = int               (__thiscall*)(TES3::AudioController*, TES3::SoundBuffer*, float, float);
+
+		const auto LoadSoundFile_Orig   = reinterpret_cast<LoadSoundFile_t>(0x401DB0);
+		const auto PlaySoundBuffer_Orig = reinterpret_cast<PlaySoundBuffer_t>(0x402820);
+		const auto SetVolume_Orig       = reinterpret_cast<SetVolume_t>(0x4029F0);
+		const auto SetMinMax_Orig       = reinterpret_cast<SetMinMax_t>(0x402AC0);
+
+		// ------------------------------------------------------------------
+		// Stub representation
+		// ------------------------------------------------------------------
+		// A "pending" SoundBuffer is one whose decode hasn't finished. Encoded
+		// by bufferDescription.dwSize == 0 (the real value, set by LoadSoundFile,
+		// is sizeof(DSBUFFERDESC) == 36 — never 0 for a real buffer).
+		//
+		// All stub-awareness in MWSE lives in this file. The five leaf accessor
+		// replacements below check isPending() and short-circuit; everything
+		// else in the engine treats stubs as ordinary SoundBuffers.
+
+		constexpr DWORD STUB_PENDING_SENTINEL = 0;
+		constexpr DWORD REAL_BUFFERDESC_SIZE  = sizeof(DSBUFFERDESC); // 36
+
+		bool isPending(const TES3::SoundBuffer* sb) {
+			return sb && sb->bufferDescription.dwSize == STUB_PENDING_SENTINEL;
+		}
+
+		bool isVoiceoverPath(const char* filename) {
+			if (!filename) return false;
+			// Match the engine's own case-insensitive probe at 0x48C5F3.
+			return std::strstr(filename, "vo\\") != nullptr
+				|| std::strstr(filename, "Vo\\") != nullptr
+				|| std::strstr(filename, "vO\\") != nullptr
+				|| std::strstr(filename, "VO\\") != nullptr;
+		}
+
+		// Allocate stubs from the engine heap so anything that frees them via
+		// the engine's normal `delete` works without heap-mismatch corruption.
+		TES3::SoundBuffer* allocateStub() {
+			auto* sb = mwse::tes3::_new<TES3::SoundBuffer>();
+			std::memset(sb, 0, sizeof(TES3::SoundBuffer));
+
+			sb->lpSoundBuffer    = nullptr;
+			sb->lpSound3DBuffer  = nullptr;
+			sb->rawAudio         = nullptr;
+			sb->isVoiceover      = true;
+
+			// Field invariants we rely on across the leaf accessors:
+			// - dwFlags must NOT have DSBCAPS_CTRL3D set, so SetSoundBufferPosition
+			//   takes the 2D branch which is null-safe via our replacement.
+			// - lpwfxFormat must be non-null and point at zero-initialized memory
+			//   so SetSoundBufferFrequency reads nSamplesPerSec==0 and exits early.
+			sb->bufferDescription.dwFlags        = 0;
+			sb->bufferDescription.dwBufferBytes  = 0;
+			sb->bufferDescription.lpwfxFormat    = reinterpret_cast<WAVEFORMATEX*>(sb->fileHeader);
+
+			// Sentinel goes last so a partially-built stub never looks "real".
+			sb->bufferDescription.dwSize         = STUB_PENDING_SENTINEL;
+			return sb;
+		}
+
+		// Free what releaseRealSoundBuffer would, but for the stub case where
+		// lpSoundBuffer/lpSound3DBuffer/rawAudio are all null. Just release the
+		// SoundBuffer struct itself via the engine heap.
+		void deleteStub(TES3::SoundBuffer* sb) {
+			mwse::tes3::_delete(sb);
+		}
+
+		// What the engine's original ReleaseSoundBuffer does on a real buffer.
+		// Pulled out as a helper so the worker's "stub was reaped mid-decode" path
+		// and the replacement's "real buffer" branch share one implementation.
+		void releaseRealSoundBuffer(TES3::SoundBuffer* sb) {
+			if (!sb) return;
+			if (sb->lpSound3DBuffer) sb->lpSound3DBuffer->Release();
+			if (sb->lpSoundBuffer)   sb->lpSoundBuffer->Release();
+			if (sb->rawAudio)        mwse::tes3::_delete(sb->rawAudio);
+			mwse::tes3::_delete(sb);
+		}
+
+		// ------------------------------------------------------------------
+		// Stub refcount
+		// ------------------------------------------------------------------
+		// A stub may be referenced by both the SoundEvent (returned to the game)
+		// and the worker (still decoding). Whichever decrements last frees it.
+		// This is the only reason we hook ReleaseSoundBuffer at all — without it,
+		// the engine could free a stub while the worker is mid-decode.
+
+		std::mutex                                                   g_stubRefMutex;
+		std::unordered_map<TES3::SoundBuffer*, std::atomic<int>*>    g_stubRefcounts;
+
+		std::atomic<int>* acquireStubRef(TES3::SoundBuffer* stub) {
+			std::lock_guard lk(g_stubRefMutex);
+			auto* rc = new std::atomic<int>(2); // SoundEvent + worker
+			g_stubRefcounts[stub] = rc;
+			return rc;
+		}
+
+		void decRef(TES3::SoundBuffer* stub, std::atomic<int>* rc) {
+			if (rc->fetch_sub(1) == 1) {
+				{
+					std::lock_guard lk(g_stubRefMutex);
+					g_stubRefcounts.erase(stub);
+				}
+				delete rc;
+				deleteStub(stub);
+			}
+		}
+
+		// ------------------------------------------------------------------
+		// Decode worker
+		// ------------------------------------------------------------------
+
+		struct DecodeTask {
+			std::string             path;
+			TES3::AudioController*  audio;
+			bool                    isPointSource;
+			TES3::SoundBuffer*      stub;
+			std::atomic<int>*       refcount;
+		};
+
+		std::mutex              g_queueMutex;
+		std::condition_variable g_queueCv;
+		std::deque<DecodeTask>  g_queue;
+		std::thread             g_worker;
+		std::atomic<bool>       g_running{ false };
+
+		// RAII guard for the audio-lists critical section that addTempSound /
+		// updateSounds / sayDialogueVoice all share. Publishing the decoded
+		// buffer must not race with the main thread iterating tempSoundEvents.
+		//
+		// Verified: addTempSound at 0x48C326 reads `mov ecx, [ebp+0xB534]` then
+		// calls NiCriticalSection::Lock — i.e. dh->criticalSectionAudioEvents.
+		// We go through MWSE's enter()/leave() wrappers so we hit the same
+		// NiCriticalSection::Lock path the engine itself uses.
+		class AudioListsLock {
+			TES3::CriticalSection* cs;
+		public:
+			explicit AudioListsLock(const char* id)
+				: cs(TES3::DataHandler::get()->criticalSectionAudioEvents)
+			{
+				cs->enter(id);
+			}
+			~AudioListsLock() { cs->leave(); }
+			AudioListsLock(const AudioListsLock&)            = delete;
+			AudioListsLock& operator=(const AudioListsLock&) = delete;
+		};
+
+		// Custom-deleter unique_ptr for engine-allocated SoundBuffers. Cleans up
+		// COM objects + rawAudio + the wrapper struct in one move, matching the
+		// engine's own ReleaseSoundBuffer (we route through our helper rather
+		// than calling the replacement, to avoid the stub-detection branch when
+		// we know we have a real buffer).
+		struct EngineSoundBufferDeleter {
+			void operator()(TES3::SoundBuffer* sb) const noexcept {
+				releaseRealSoundBuffer(sb);
+			}
+		};
+		using EngineSoundBufferPtr = std::unique_ptr<TES3::SoundBuffer, EngineSoundBufferDeleter>;
+
+		// Move decoded contents into the stub atomically; transition dwSize=0→36
+		// is the publish edge that flips the leaf accessors out of stub mode.
+		void publishDecodedBufferLocked(
+			TES3::AudioController* audio,
+			TES3::SoundBuffer*     stub,
+			TES3::SoundBuffer*     decoded)
+		{
+			stub->lpSoundBuffer       = decoded->lpSoundBuffer;
+			stub->lpSound3DBuffer     = decoded->lpSound3DBuffer;
+			stub->rawAudio            = decoded->rawAudio;
+			std::memcpy(stub->fileHeader, decoded->fileHeader, sizeof(stub->fileHeader));
+			stub->bufferDescription   = decoded->bufferDescription; // dwSize becomes 36 here
+
+			// lpwfxFormat is an INTERNAL pointer (decoded->fileHeader, inside
+			// decoded's own struct that we're about to free). Redirect to
+			// stub->fileHeader, where we just memcpy'd the WAVEFORMATEX bytes.
+			// Without this, SetSoundBufferFrequency (or any later wfx read)
+			// is a use-after-free.
+			stub->bufferDescription.lpwfxFormat =
+				reinterpret_cast<WAVEFORMATEX*>(stub->fileHeader);
+
+			stub->isVoiceover         = true;
+
+			// Do NOT touch stub->volume here. addTempSound already called
+			// SetSoundBufferVolume(stub, vol) while the stub was pending,
+			// which writes the volume field even though it skips the DSound call
+			// (lpSoundBuffer was null at the time). decoded->volume is
+			// uninitialized from operator new — clobbering with it would set
+			// volume to 0 and produce a -10000 dB attenuation (silent) on the
+			// next updateSounds tick.
+
+			// Null out decoded's resource fields — DSound objects + rawAudio now
+			// belong to the stub. The caller's EngineSoundBufferPtr will then
+			// invoke releaseRealSoundBuffer on the husk; with all resource fields
+			// null, that just frees the wrapper struct.
+			decoded->lpSoundBuffer    = nullptr;
+			decoded->lpSound3DBuffer  = nullptr;
+			decoded->rawAudio         = nullptr;
+
+			// Apply Volume and Min/Max distance to the now-real buffer.
+			// addTempSound called both setters on the pending stub; the wrappers
+			// wrote the fields but skipped the COM calls (lpSoundBuffer /
+			// lpSound3DBuffer were null at the time). Without re-applying:
+			//   - 3D mode (lpSound3DBuffer non-null): DSound uses defaults
+			//     DS3D_DEFAULTMINDISTANCE=1m / DS3D_DEFAULTMAXDISTANCE=1e9m,
+			//     attenuating to silence at any sane game distance. updateSounds
+			//     only calls SetPosition each frame — it never re-applies
+			//     min/max — so the attenuation stays buried forever.
+			//   - 2D mode: lpSoundBuffer is at 0 dB max from LoadSoundFile_Orig's
+			//     finalizer; SetVolume here corrects the brief loud frame before
+			//     updateSounds re-applies via SetSoundBufferPosition's 2D path.
+			//
+			// stub->minDistance/maxDistance are typed `int` in MWSE's struct but
+			// the engine stores float bit patterns there (see decompilation of
+			// SetSoundBufferMinMaxDistance's else branch). Re-cast to float.
+			SetVolume_Orig(audio, stub, stub->volume);
+
+			float minD = 0.0f, maxD = 0.0f;
+			std::memcpy(&minD, &stub->minDistance, sizeof(float));
+			std::memcpy(&maxD, &stub->maxDistance, sizeof(float));
+			SetMinMax_Orig(audio, stub, minD, maxD);
+
+			// addTempSound's PlaySoundBuffer earlier was a no-op (lpSoundBuffer null);
+			// now that the buffer is real, kick off playback. updateSounds will
+			// reposition the stub on its next tick from the SoundEvent's reference.
+			PlaySoundBuffer_Orig(audio, stub, /*flags*/ 0);
+		}
+
+		void workerLoop() {
+			while (g_running.load(std::memory_order_acquire)) {
+				DecodeTask task;
+				{
+					std::unique_lock lk(g_queueMutex);
+					g_queueCv.wait(lk, [] { return !g_queue.empty() || !g_running.load(); });
+					if (!g_running.load()) break;
+					task = std::move(g_queue.front());
+					g_queue.pop_front();
+				}
+
+				// 1. Decode off the main thread, no engine lock held. Wrap in
+				//    a unique_ptr so any early return correctly releases the
+				//    engine-allocated buffer + its COM resources via the deleter.
+				EngineSoundBufferPtr decoded(
+					LoadSoundFile_Orig(task.audio, task.path.c_str(), task.isPointSource));
+
+				// 2. Re-enter the engine to publish. RAII lock scope = the rest
+				//    of this iteration; auto-release on every continue path.
+				{
+					AudioListsLock lk("MWSE:VoiceStreamer");
+
+					// Stub was released while we were decoding (cell change, killSounds).
+					if (task.refcount->load() <= 1) {
+						decRef(task.stub, task.refcount);
+						continue;  // unique_ptr drops decoded; AudioListsLock leaves
+					}
+
+					// Decode failed (file missing, bad format, OOM). Flip dwSize so
+					// updateSounds reaps the SoundEvent — its status check will now
+					// hit the real-buffer path and find lpSoundBuffer null. The
+					// leaf replacements all guard against that.
+					if (!decoded) {
+						task.stub->bufferDescription.dwSize = REAL_BUFFERDESC_SIZE;
+						decRef(task.stub, task.refcount);
+						continue;
+					}
+
+					// Publish: move decoded fields into stub, then null decoded's
+					// pointers so the unique_ptr's deleter only frees the husk
+					// (releaseRealSoundBuffer's NULL checks make it a no-op for
+					// the resource fields).
+					publishDecodedBufferLocked(task.audio, task.stub, decoded.get());
+				}
+
+				decRef(task.stub, task.refcount);
+			}
+		}
+
+		// ==================================================================
+		// Function-prologue REPLACEMENTS for the five leaf accessors.
+		//
+		// Four are full reimplementations with an isPending() short-circuit
+		// (Get/SetCurrentPosition/LipSync/Release). The fifth (SetPosition)
+		// uses a trampoline because its body is too math-heavy to reimplement.
+		// All installed via genJumpUnprotected, replacing the engine's first
+		// 5 bytes.
+		//
+		// The engine's 35+ existing call sites stay completely untouched:
+		// they still call 0x402B50 / 0x402E90 / 0x4029A0 / 0x402EC0 / 0x4027E0
+		// exactly as before. Those addresses just route to our C++ now.
+		// ==================================================================
+
+		// Replaces 0x402B50 AudioController::SetSoundBufferPosition.
+		// This one CANNOT be a full reimpl — too much trig/distance/dB math.
+		// Instead, function-prologue JMP + trampoline: trampoline reproduces
+		// the 5 bytes we overwrite and then `push ret`s into 0x402B55, so the
+		// rest of the function executes verbatim.
+		//
+		// Verified: bytes at 0x402B50 are `83 EC 08 55 56` = sub esp,8; push ebp;
+		// push esi. Clean 5-byte boundary. The 2D path's early `SetPan` and the
+		// 3D path's `SetPosition` both dereference lpSoundBuffer / lpSound3DBuffer
+		// without a null guard, hence the isPending and lpSoundBuffer guards in
+		// the wrapper before we hand off to the trampoline.
+		__declspec(naked) void __fastcall setSoundBufferPosition_trampoline(
+			TES3::AudioController* /*self*/,
+			void* /*edx*/,
+			TES3::SoundBuffer*   /*sb*/,
+			TES3::Vector3*       /*pos*/)
+		{
+			__asm {
+				sub esp, 8           // reproduce 0x402B50..54
+				push ebp
+				push esi
+				push 0x402B55        // push-ret avoids a rel32 jmp whose offset
+				ret                  // depends on where MSVC places this function
+			}
+		}
+
+		void __fastcall setSoundBufferPosition_replacement(
+			TES3::AudioController* self,
+			void* /*edx*/,
+			TES3::SoundBuffer* sb,
+			TES3::Vector3* pos)
+		{
+			if (isPending(sb)) return;             // pending stub
+			if (!sb || !sb->lpSoundBuffer) return; // decode-fail stub
+			setSoundBufferPosition_trampoline(self, nullptr, sb, pos);
+		}
+
+		// Replaces 0x402E90 AudioController::GetSoundBufferStatus.
+		unsigned char __fastcall getSoundBufferStatus_replacement(
+			TES3::AudioController* /*audio*/,
+			void* /*edx*/,
+			TES3::SoundBuffer* sb)
+		{
+			if (isPending(sb)) return DSBSTATUS_PLAYING;
+			// Decode-fail or any other path that leaves a real-state SoundBuffer
+			// with null lpSoundBuffer. Returning 0 (not playing) lets updateSounds
+			// reap the SoundEvent normally instead of crashing here.
+			if (!sb || !sb->lpSoundBuffer) return 0;
+			DWORD status = 0;
+			sb->lpSoundBuffer->GetStatus(&status);
+			return static_cast<unsigned char>(status);
+		}
+
+		// Replaces 0x4029A0 AudioController::SetSoundBufferCurrentPosition.
+		void __fastcall setSoundBufferCurrentPosition_replacement(
+			TES3::AudioController* /*audio*/,
+			void* /*edx*/,
+			TES3::SoundBuffer* sb,
+			float position)
+		{
+			if (isPending(sb)) return;
+			if (!sb || !sb->lpSoundBuffer) return;
+			if (position < 0.0f) return;
+			DWORD bytes = static_cast<DWORD>(sb->bufferDescription.dwBufferBytes * position) & ~3u;
+			// Engine global at 0x7C5F20: preserved for byte-for-byte parity with
+			// the original. Some other engine code reads the most-recently-set
+			// playback byte position from this address.
+			*reinterpret_cast<DWORD*>(0x7C5F20) = bytes;
+			sb->lpSoundBuffer->SetCurrentPosition(bytes);
+		}
+
+		// Replaces 0x402EC0 AudioController::GetSoundBufferLipSyncLevel.
+		float __fastcall getSoundBufferLipSyncLevel_replacement(
+			TES3::AudioController* /*audio*/,
+			void* /*edx*/,
+			TES3::SoundBuffer* sb)
+		{
+			// Mouth stays closed during the decode window. The original would have
+			// returned 0.5 (rawAudio==null path) which produced a frozen yawn.
+			if (isPending(sb))    return 0.0f;
+
+			// Real buffer path — verbatim original behavior.
+			if (!sb->rawAudio)    return 0.5f;
+			if (!sb->lpSoundBuffer) return 0.5f; // defensive; rawAudio without DSound buffer shouldn't occur
+
+			DWORD status = 0;
+			sb->lpSoundBuffer->GetStatus(&status);
+			if (!(status & 5))    return 0.0f;
+
+			DWORD pos = 0;
+			if (FAILED(sb->lpSoundBuffer->GetCurrentPosition(&pos, nullptr))) return 0.5f;
+
+			short sample = sb->rawAudio[pos / 0x900];
+			int   absSample = std::abs(static_cast<int>(sample));
+			return absSample * (1.0f / 32768.0f);
+		}
+
+		// Replaces 0x4027E0 AudioController::ReleaseSoundBuffer.
+		void __fastcall releaseSoundBuffer_replacement(
+			TES3::AudioController* /*audio*/,
+			void* /*edx*/,
+			TES3::SoundBuffer* sb)
+		{
+			if (!sb) return;
+
+			if (isPending(sb)) {
+				// Worker may still hold a reference. Refcount; whoever zeros it deletes.
+				std::atomic<int>* rc = nullptr;
+				{
+					std::lock_guard lk(g_stubRefMutex);
+					auto it = g_stubRefcounts.find(sb);
+					if (it != g_stubRefcounts.end()) rc = it->second;
+				}
+				if (rc) decRef(sb, rc);
+				else    deleteStub(sb);  // unknown stub (refcount table missed it); free directly
+				return;
+			}
+
+			releaseRealSoundBuffer(sb);
+		}
+
+		// ==================================================================
+		// asyncLoadSoundFile — the only call-site divert. Replaces the call
+		// at addTempSound 0x48C369 (originally calling 0x401DB0).
+		// ==================================================================
+
+		TES3::SoundBuffer* __fastcall asyncLoadSoundFile(
+			TES3::AudioController* audio,
+			void* /*edx*/,
+			const char* filename,
+			bool isPointSource)
+		{
+			if (!isVoiceoverPath(filename)) {
+				return LoadSoundFile_Orig(audio, filename, isPointSource);
+			}
+
+			// Voiceover: stub now, decode on worker.
+			auto* stub = allocateStub();
+			auto* rc   = acquireStubRef(stub);
+
+			{
+				std::lock_guard lk(g_queueMutex);
+				g_queue.push_back(DecodeTask{
+					filename,
+					audio,
+					isPointSource,
+					stub,
+					rc,
+				});
+			}
+			g_queueCv.notify_one();
+			return stub;
+		}
+
+	}  // anonymous namespace
+
+	// ----------------------------------------------------------------------
+	// Public install / shutdown
+	// ----------------------------------------------------------------------
+
+	void install() {
+		// 1. Divert addTempSound's call to LoadSoundFile.
+		//    The two other LoadSoundFile call sites (0x51083F, 0x510859 in
+		//    Sound::set3DParams) are for permanent Sound records and never see
+		//    voiceover paths — leave them alone.
+		//
+		// The call instruction is at 0x48C369 (5-byte E8 rel32). Verified via
+		// read_memory_bytes: the 5 bytes are E8 42 5A F7 FF (call 0x401DB0).
+		// genCallEnforced returns false silently if the byte pattern doesn't
+		// match — we log on failure so the streamer never silently no-ops.
+		if (!genCallEnforced(0x48C369, 0x401DB0, reinterpret_cast<DWORD>(&asyncLoadSoundFile))) {
+			log::getLog() << "Voice streamer: call-site patch at 0x48C369 failed "
+			                 "(byte pattern mismatch). Streamer is INACTIVE.\n";
+			return;
+		}
+
+		// 2. Replace the leaf SoundBuffer accessors at their function prologues.
+		//    The engine's 35+ existing call sites stay completely untouched —
+		//    they still call these addresses, which now route to our C++.
+		//    All stub-awareness is encapsulated in the five replacements.
+		genJumpUnprotected(0x402E90, reinterpret_cast<DWORD>(&getSoundBufferStatus_replacement));
+		genJumpUnprotected(0x4029A0, reinterpret_cast<DWORD>(&setSoundBufferCurrentPosition_replacement));
+		genJumpUnprotected(0x402EC0, reinterpret_cast<DWORD>(&getSoundBufferLipSyncLevel_replacement));
+		genJumpUnprotected(0x4027E0, reinterpret_cast<DWORD>(&releaseSoundBuffer_replacement));
+		// Trampoline-based replacement; see setSoundBufferPosition_trampoline above.
+		genJumpUnprotected(0x402B50, reinterpret_cast<DWORD>(&setSoundBufferPosition_replacement));
+
+		// 3. Spin up the decode worker.
+		g_running.store(true, std::memory_order_release);
+		g_worker = std::thread(&workerLoop);
+	}
+
+	void shutdown() {
+		g_running.store(false, std::memory_order_release);
+		g_queueCv.notify_all();
+		if (g_worker.joinable()) g_worker.join();
+	}
+
+}  // namespace mwse::patch::voice

--- a/MWSE/TES3VoiceStreamer.cpp
+++ b/MWSE/TES3VoiceStreamer.cpp
@@ -1,7 +1,5 @@
 #include "TES3VoiceStreamer.h"
 
-#include <dsound.h>
-
 #include "Log.h"
 #include "MemoryUtil.h"
 #include "WindowsUtil.h"
@@ -13,12 +11,6 @@
 #include "TES3Reference.h"
 #include "TES3Sound.h"
 #include "TES3WorldController.h"
-
-#include <atomic>
-#include <condition_variable>
-#include <deque>
-#include <memory>
-#include <thread>
 
 namespace mwse::patch::voice {
 

--- a/MWSE/TES3VoiceStreamer.cpp
+++ b/MWSE/TES3VoiceStreamer.cpp
@@ -101,25 +101,6 @@ namespace mwse::patch::voice {
 		std::thread g_worker;
 		std::atomic<bool> g_running{ false };
 
-		// RAII guard for the audio-lists critical section that addTempSound /
-		// updateSounds / sayDialogueVoice all share. Publishing the decoded
-		// buffer must not race with the main thread iterating tempSoundEvents.
-		//
-		// Verified: addTempSound at 0x48C326 reads `mov ecx, [ebp+0xB534]` then
-		// calls NiCriticalSection::Lock — i.e. dh->criticalSectionAudioEvents.
-		// We go through MWSE's enter()/leave() wrappers so we hit the same
-		// NiCriticalSection::Lock path the engine itself uses.
-		class AudioListsLock {
-			TES3::CriticalSection* cs;
-		public:
-			explicit AudioListsLock(const char* id) : cs(TES3::DataHandler::get()->criticalSectionAudioEvents) {
-				cs->enter(id);
-			}
-			~AudioListsLock() { cs->leave(); }
-			AudioListsLock(const AudioListsLock&) = delete;
-			AudioListsLock& operator=(const AudioListsLock&) = delete;
-		};
-
 		// std::default_delete<TES3::SoundBuffer> calls plain `delete sb`, which
 		// invokes SoundBuffer's dtor (Release COMs + free rawAudio) and then its
 		// class-specific operator delete (engine heap free).
@@ -206,10 +187,18 @@ namespace mwse::patch::voice {
 				// engine-allocated buffer + its COM resources via the deleter.
 				EngineSoundBufferPtr decoded(task.audio->loadSoundFile(task.path.c_str(), task.isPointSource));
 
-				// Re-enter the engine to publish. RAII lock scope = the rest of
-				// this iteration; auto-release on every continue path.
+				// Re-enter the engine to publish. We acquire the audio-lists CS
+				// that addTempSound / updateSounds / sayDialogueVoice all share
+				// so the field write below can't race with the main thread
+				// iterating tempSoundEvents.
+				//
+				// Verified offset: addTempSound at 0x48C326 reads
+				// `mov ecx, [ebp+0xB534]` then calls NiCriticalSection::Lock,
+				// i.e. dh->criticalSectionAudioEvents. We go through MWSE's
+				// enter()/leave() wrappers (via CriticalSection::Lock) so we
+				// hit the same NiCriticalSection::Lock path the engine uses.
 				{
-					AudioListsLock lk("MWSE:VoiceStreamer");
+					TES3::CriticalSection::Lock lk(*TES3::DataHandler::get()->criticalSectionAudioEvents, "MWSE:VoiceStreamer");
 
 					// Stub was released while we were decoding (cell change, killSounds).
 					if (task.refcount->load() <= 1) {

--- a/MWSE/TES3VoiceStreamer.h
+++ b/MWSE/TES3VoiceStreamer.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace mwse::patch::voice {
+
+	// Install voice-streamer patches: the addTempSound LoadSoundFile divert and
+	// the function-prologue replacements for the SoundBuffer leaf accessors.
+	// Call from PatchUtil::installPatches().
+	void install();
+
+	// Stop the decode worker and join it. Call on game shutdown.
+	void shutdown();
+
+}

--- a/MWSE/main.cpp
+++ b/MWSE/main.cpp
@@ -6,6 +6,7 @@
 #include "TES3Util.h"
 #include "CodePatchUtil.h"
 #include "PatchUtil.h"
+#include "TES3VoiceStreamer.h"
 #include "MWSEDefs.h"
 #include "BuildDate.h"
 
@@ -184,6 +185,11 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
 		// Do thread-specific cleanup.
 		break;
 	case DLL_PROCESS_DETACH:
+		// Stop the voice-decode worker before the engine starts tearing down
+		// DSound / DataHandler — otherwise an in-flight LoadSoundFile_Orig on
+		// the worker can fault on its way out.
+		mwse::patch::voice::shutdown();
+
 		// Unhook Lua interface.
 		mwse::lua::LuaManager::getInstance().cleanup();
 		break;

--- a/MWSE/main.cpp
+++ b/MWSE/main.cpp
@@ -6,7 +6,6 @@
 #include "TES3Util.h"
 #include "CodePatchUtil.h"
 #include "PatchUtil.h"
-#include "TES3VoiceStreamer.h"
 #include "MWSEDefs.h"
 #include "BuildDate.h"
 
@@ -185,10 +184,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved) {
 		// Do thread-specific cleanup.
 		break;
 	case DLL_PROCESS_DETACH:
-		// Stop the voice-decode worker before the engine starts tearing down
-		// DSound / DataHandler — otherwise an in-flight LoadSoundFile_Orig on
-		// the worker can fault on its way out.
-		mwse::patch::voice::shutdown();
+		// Tear down patches that need orderly shutdown before the engine
+		// starts unloading DSound / DataHandler.
+		mwse::patch::uninstallPatches();
 
 		// Unhook Lua interface.
 		mwse::lua::LuaManager::getInstance().cleanup();


### PR DESCRIPTION
Eliminates the main-thread MP3 decode spike when NPCs greet the player. The vanilla path (sayDialogueVoice -> addTempSound -> LoadSoundFile) synchronously decodes the entire MP3 to PCM on the main thread under the audio-lists critical section, blocking both the game loop and the audio mixer for 5-15 ms per greeting.

The new TES3VoiceStreamer module diverts addTempSound's call to LoadSoundFile (call site at 0x48C369) into asyncLoadSoundFile, which returns a "pending stub" SoundBuffer instantly and queues the actual decode onto a worker thread. When the worker finishes, it acquires the same audio-lists CS the engine uses and atomically transmutes the stub into a real DSound buffer (populating lpSoundBuffer / lpSound3DBuffer / rawAudio, fixing up the internal lpwfxFormat pointer, applying volume and 3D min/max distance to the COM-side buffer, then PlaySoundBuffer).

Five engine accessors are replaced at their function prologues via genJumpUnprotected so all 35+ existing engine call sites can treat stubs transparently:

  GetSoundBufferStatus            (0x402E90) -> isPending? PLAYING.
  SetSoundBufferCurrentPosition   (0x4029A0) -> isPending? no-op.
  GetSoundBufferLipSyncLevel      (0x402EC0) -> isPending? 0.0 (mouth closed).
  ReleaseSoundBuffer              (0x4027E0) -> isPending? refcount, drop one.
  SetSoundBufferPosition          (0x402B50) -> isPending? no-op; else
                                                trampoline into the engine
                                                body (too math-heavy to
                                                reimplement faithfully).

A small refcount table (g_stubRefcounts) keeps a stub alive across the worker/SoundEvent ownership window: the engine and the worker each hold one reference, whichever decrements last frees the stub. This is the only piece of state stub-awareness leaks into - everywhere else the engine sees an ordinary SoundBuffer.

voice::install() runs from installPostInitializationPatches (DataHandler must be alive before the worker first touches criticalSectionAudioEvents). voice::shutdown() runs from DLL_PROCESS_DETACH ahead of LuaManager cleanup, joining the worker so any in-flight LoadSoundFile_Orig finishes before DSound starts tearing down.

Result on a Morrowind75 profile (Intel 14700KF, ~50 NPC greetings): main-thread cost per greeting drops from ~5 ms to ~8 us, a ~600x reduction; the visible frame stutter on dialogue start disappears.