### PR TITLE
Silencing compiler warning C4244

### DIFF
--- a/MWSE/ArrayUtil.cpp
+++ b/MWSE/ArrayUtil.cpp
@@ -38,8 +38,8 @@ namespace mwse {
 		return value;
 	}
 
-	long Arrays::setValue(std::string const& caller, size_t const id, size_t const index, ArrayItem_t const value) {
-		long success = 0;
+	short Arrays::setValue(std::string const& caller, size_t const id, size_t const index, ArrayItem_t const value) {
+		short success = 0;
 		if (id > 0 && id <= arrays.size()) {
 			if (index >= 0) {
 				ContainedArray_t& a = arrays[id - 1];

--- a/MWSE/ArrayUtil.h
+++ b/MWSE/ArrayUtil.h
@@ -13,7 +13,7 @@ namespace mwse {
 
 		ArrayItem_t getValue(std::string const& caller, size_t const id, size_t const index);
 
-		long setValue(std::string const& caller, size_t const id, size_t const index, ArrayItem_t const value);
+		short setValue(std::string const& caller, size_t const id, size_t const index, ArrayItem_t const value);
 
 		size_t getSize(std::string const& caller, size_t const id);
 

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -746,7 +746,7 @@ namespace mwse::lua {
 		// Update compatibility globals.
 		const auto mwseBuildGlobal = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable("MWSE_BUILD");
 		if (mwseBuildGlobal) {
-			mwseBuildGlobal->value = Configuration::BuildNumber;
+			mwseBuildGlobal->value = static_cast<float>(Configuration::BuildNumber);
 		}
 
 		// Trigger initialization.
@@ -979,7 +979,7 @@ namespace mwse::lua {
 		// Update compatibility globals.
 		const auto mwseBuildGlobal = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable("MWSE_BUILD");
 		if (mwseBuildGlobal) {
-			mwseBuildGlobal->value = Configuration::BuildNumber;
+			mwseBuildGlobal->value = static_cast<float>(Configuration::BuildNumber);
 		}
 	}
 

--- a/MWSE/NIPointLight.cpp
+++ b/MWSE/NIPointLight.cpp
@@ -40,7 +40,7 @@ namespace NI {
 
 	unsigned int PointLight::getRadius() const {
 		// Morrowind keeps this in the specular for some reason.
-		return specular.r;
+		return static_cast<unsigned int>(specular.r);
 	}
 
 	void PointLight::setRadius(unsigned int radius) {

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -1042,7 +1042,7 @@ namespace mwse::patch {
 			log::getLog() << "[MWSE] Warning: Pathgrid in cell '" << pathGrid->parentCell->getEditorName() <<
 				"' has mismatching path node count. nodeCount=" << pathGrid->nodeCount << ", node data count=" << pathGrid->nodes.count << std::endl;
 
-			pathGrid->nodeCount = pathGrid->nodes.count;
+			pathGrid->nodeCount = static_cast<unsigned short>(pathGrid->nodes.count);
 		}
 
 		// Perform overwritten code.

--- a/MWSE/Push.cpp
+++ b/MWSE/Push.cpp
@@ -47,7 +47,7 @@ namespace mwse {
 	}
 
 	float PushB::execute(mwse::VMExecuteInterface& virtualMachine) {
-		Stack::getInstance().pushByte(pushData);
+		Stack::getInstance().pushByte(static_cast<char>(pushData));
 		return 0.0f;
 	}
 	//----------------------------------------
@@ -71,7 +71,7 @@ namespace mwse {
 	}
 
 	float PushS::execute(mwse::VMExecuteInterface& virtualMachine) {
-		Stack::getInstance().pushShort(pushData);
+		Stack::getInstance().pushShort(static_cast<short>(pushData));
 		return 0.0f;
 	}
 	//----------------------------------------

--- a/MWSE/RngUtil.cpp
+++ b/MWSE/RngUtil.cpp
@@ -1,7 +1,7 @@
 #include "RngUtil.h"
 
 namespace mwse::rng {
-	static std::mt19937 mwse_rng_mt19937(std::time(0));
+	static std::mt19937 mwse_rng_mt19937(static_cast<unsigned int>(std::time(0)));
 
 	long getRandomLong(long min, long max) {
 		if (min > max) {

--- a/MWSE/ScriptUtil.cpp
+++ b/MWSE/ScriptUtil.cpp
@@ -328,7 +328,7 @@ namespace mwse::mwscript {
 	}
 
 	int GetButtonPressed(TES3::Script* script, TES3::Reference* reference) {
-		return RunOriginalOpCode(script, reference, OpCode::GetButtonPressed);
+		return static_cast<int>(RunOriginalOpCode(script, reference, OpCode::GetButtonPressed));
 	}
 
 	bool HasItemEquipped(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* itemTemplate) {
@@ -383,7 +383,7 @@ namespace mwse::mwscript {
 
 		// Prepare variables and run original opcode.
 		setScriptSecondObject(itemTemplate);
-		long value = RunOriginalOpCode(script, reference, OpCode::GetItemCount);
+		long value = static_cast<long>(RunOriginalOpCode(script, reference, OpCode::GetItemCount));
 
 		// Restore original script variables.
 		setScriptSecondObject(cachedSecondObject);

--- a/MWSE/StringUtilLua.cpp
+++ b/MWSE/StringUtilLua.cpp
@@ -36,7 +36,7 @@ namespace mwse::lua {
 
 		state["mwse"]["string"]["get"] = [](double value) -> sol::optional<std::string> {
 			try {
-				return { mwse::string::store::get(value).c_str() };
+				return { mwse::string::store::get(static_cast<long>(value)).c_str() };
 			}
 			catch (std::exception&) {
 				return {};

--- a/MWSE/TES3AlchemyLua.cpp
+++ b/MWSE/TES3AlchemyLua.cpp
@@ -50,8 +50,8 @@ namespace mwse::lua {
 
 		// Get other simple values.
 		alchemy->objectFlags = getOptionalParam<unsigned int>(params, "objectFlags", alchemy->objectFlags);
-		alchemy->weight = getOptionalParam<double>(params, "weight", alchemy->weight);
-		alchemy->value = getOptionalParam<double>(params, "value", alchemy->value);
+		alchemy->weight = getOptionalParam<float>(params, "weight", alchemy->weight);
+		alchemy->value = getOptionalParam<unsigned short>(params, "value", alchemy->value);
 		alchemy->flags = getOptionalParam<unsigned short>(params, "flags", alchemy->flags);
 
 		// Flag the object as modified.

--- a/MWSE/TES3AudioController.cpp
+++ b/MWSE/TES3AudioController.cpp
@@ -143,6 +143,10 @@ namespace TES3 {
 		return volume;
 	}
 
+	unsigned char AudioController::getMixVolumeRaw(AudioMixType mixType) const {
+		return static_cast<unsigned char>(getMixVolume(mixType) * 250);
+	}
+
 	float AudioController::getNormalizedMasterVolume() const {
 		return 0.004f * volumeMaster;
 	}

--- a/MWSE/TES3AudioController.h
+++ b/MWSE/TES3AudioController.h
@@ -125,6 +125,7 @@ namespace TES3 {
 		void setNextMusicFilePath(const char* path);
 
 		float getMixVolume(AudioMixType mixType) const;
+		unsigned char getMixVolumeRaw(AudioMixType mixType) const;
 
 		float getMusicVolume() const;
 

--- a/MWSE/TES3Cell.cpp
+++ b/MWSE/TES3Cell.cpp
@@ -123,7 +123,7 @@ namespace TES3 {
 
 	std::optional<float> Cell::getWaterLevel() const {
 		if (getIsOrBehavesAsExterior()) {
-			return 0.0;
+			return 0.0f;
 		}
 		else if (getHasWater()) {
 			return waterLevelOrRegion.waterLevel;

--- a/MWSE/TES3DataHandler.cpp
+++ b/MWSE/TES3DataHandler.cpp
@@ -246,7 +246,7 @@ namespace TES3 {
 		// Update compatibility globals.
 		const auto mwseBuildGlobal = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable("MWSE_BUILD");
 		if (mwseBuildGlobal) {
-			mwseBuildGlobal->value = mwse::Configuration::BuildNumber;
+			mwseBuildGlobal->value = static_cast<float>(mwse::Configuration::BuildNumber);
 		}
 
 		return loaded ? LoadGameResult::Success : LoadGameResult::Failure;
@@ -290,7 +290,7 @@ namespace TES3 {
 		// Update compatibility globals.
 		const auto mwseBuildGlobal = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable("MWSE_BUILD");
 		if (mwseBuildGlobal) {
-			mwseBuildGlobal->value = mwse::Configuration::BuildNumber;
+			mwseBuildGlobal->value = static_cast<float>(mwse::Configuration::BuildNumber);
 		}
 
 		return loaded ? LoadGameResult::Success : LoadGameResult::Failure;

--- a/MWSE/TES3DialogueFilterContext.cpp
+++ b/MWSE/TES3DialogueFilterContext.cpp
@@ -110,7 +110,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = faction->getLowestJoinedReaction();
+		context->compareValue = static_cast<float>(faction->getLowestJoinedReaction());
 	}
 
 	void loadFunctionReactionHigh(DialogueFilterContext::ConditionalContext* context) {
@@ -130,7 +130,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = faction->getHighestJoinedReaction();
+		context->compareValue = static_cast<float>(faction->getHighestJoinedReaction());
 	}
 
 	void loadFunctionRankRequirement(DialogueFilterContext::ConditionalContext* context) {
@@ -163,7 +163,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = speaker->getReputation();
+		context->compareValue = static_cast<float>(speaker->getReputation());
 	}
 
 	void loadFunctionHealthPercent(DialogueFilterContext::ConditionalContext* context) {
@@ -196,7 +196,7 @@ namespace TES3 {
 		}
 
 		const auto macp = WorldController::get()->getMobilePlayer();
-		context->compareValue = macp->npcInstance->getLevel();
+		context->compareValue = static_cast<float>(macp->npcInstance->getLevel());
 	}
 
 	void loadFunctionPCHealthPercent(DialogueFilterContext::ConditionalContext* context) {
@@ -306,7 +306,7 @@ namespace TES3 {
 		}
 
 		const auto macp = WorldController::get()->getMobilePlayer();
-		context->compareValue = macp->npcInstance->getEquipmentValue(false);
+		context->compareValue = static_cast<float>(macp->npcInstance->getEquipmentValue(false));
 	}
 
 	void loadFunctionPCCrimeLevel(DialogueFilterContext::ConditionalContext* context) {
@@ -316,7 +316,7 @@ namespace TES3 {
 		}
 
 		const auto macp = WorldController::get()->getMobilePlayer();
-		context->compareValue = macp->getBounty();
+		context->compareValue = static_cast<float>(macp->getBounty());
 	}
 
 	void loadFunctionSameSex(DialogueFilterContext::ConditionalContext* context) {
@@ -376,7 +376,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = faction->getEffectivePlayerRank() - speakerBase->getFactionRank();
+		context->compareValue = static_cast<float>(faction->getEffectivePlayerRank() - speakerBase->getFactionRank());
 	}
 
 	void loadFunctionDetected(DialogueFilterContext::ConditionalContext* context) {
@@ -418,7 +418,7 @@ namespace TES3 {
 		if (mwse::mcp::getFeatureEnabled(mwse::mcp::feature::ServiceRefusalFiltering)) {
 			const auto source = context->parentContext->source;
 			if (source > DialogueInfo::FilterSource::MCP_Offset) {
-				context->compareValue = int(source) - int(DialogueInfo::FilterSource::MCP_Offset);
+				context->compareValue = static_cast<float>(int(source) - int(DialogueInfo::FilterSource::MCP_Offset));
 				return;
 			}
 		}
@@ -435,7 +435,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = answer;
+		context->compareValue = static_cast<float>(answer);
 	}
 
 	void loadFunctionPCIntelligence(DialogueFilterContext::ConditionalContext* context) {
@@ -529,7 +529,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = WorldController::get()->weatherController->getCurrentWeatherIndex();
+		context->compareValue = static_cast<float>(WorldController::get()->weatherController->getCurrentWeatherIndex());
 	}
 
 	void loadFunctionPCVampire(DialogueFilterContext::ConditionalContext* context) {
@@ -548,7 +548,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = context->parentContext->speakerBaseActor->getLevel();
+		context->compareValue = static_cast<float>(context->parentContext->speakerBaseActor->getLevel());
 	}
 
 	void loadFunctionAttacked(DialogueFilterContext::ConditionalContext* context) {
@@ -593,13 +593,13 @@ namespace TES3 {
 		}
 
 		if (target->actorType == MobileActorType::Creature) {
-			context->compareValue = 1;
+			context->compareValue = 1.0f;
 		}
 		else if (target->getIsWerewolf()) {
-			context->compareValue = 2;
+			context->compareValue = 2.0f;
 		}
 		else {
-			context->compareValue = 0;
+			context->compareValue = 0.0f;
 		}
 	}
 
@@ -618,7 +618,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = context->parentContext->speakerMobile->fight;
+		context->compareValue = static_cast<float>(context->parentContext->speakerMobile->fight);
 	}
 
 	void loadFunctionHello(DialogueFilterContext::ConditionalContext* context) {
@@ -627,7 +627,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = context->parentContext->speakerMobile->hello;
+		context->compareValue = static_cast<float>(context->parentContext->speakerMobile->hello);
 	}
 
 	void loadFunctionAlarm(DialogueFilterContext::ConditionalContext* context) {
@@ -636,7 +636,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = context->parentContext->speakerMobile->alarm;
+		context->compareValue = static_cast<float>(context->parentContext->speakerMobile->alarm);
 	}
 
 	void loadFunctionFlee(DialogueFilterContext::ConditionalContext* context) {
@@ -645,7 +645,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = context->parentContext->speakerMobile->flee;
+		context->compareValue = static_cast<float>(context->parentContext->speakerMobile->flee);
 	}
 
 	void loadFunctionShouldAttack(DialogueFilterContext::ConditionalContext* context) {
@@ -675,7 +675,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = WorldController::get()->playerKills->werewolfKills;
+		context->compareValue = static_cast<float>(WorldController::get()->playerKills->werewolfKills);
 	}
 
 	ConditionalLoadFunction loadFunctionFunction(DialogueConditional* conditional) {
@@ -799,7 +799,7 @@ namespace TES3 {
 			context->compareValue = variables->floatVarValues[index];
 			break;
 		case 'l':
-			context->compareValue = variables->longVarValues[index];
+			context->compareValue = static_cast<float>(variables->longVarValues[index]);
 			break;
 		case 's':
 			context->compareValue = variables->shortVarValues[index];
@@ -816,7 +816,7 @@ namespace TES3 {
 			context->resultOverride = true;
 			return;
 		}
-		context->compareValue = context->conditional->journal->journalIndex;
+		context->compareValue = static_cast<float>(context->conditional->journal->journalIndex);
 	}
 
 	void loadItemCount(DialogueFilterContext::ConditionalContext* context) {
@@ -837,7 +837,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = std::abs(playerInventory->getItemCount(item));
+		context->compareValue = static_cast<float>(std::abs(playerInventory->getItemCount(item)));
 	}
 
 	void loadDeadActorCount(DialogueFilterContext::ConditionalContext* context) {
@@ -847,7 +847,7 @@ namespace TES3 {
 			return;
 		}
 
-		context->compareValue = WorldController::get()->playerKills->getKillCount(context->conditional->actor);
+		context->compareValue = static_cast<float>(WorldController::get()->playerKills->getKillCount(context->conditional->actor));
 	}
 
 	void loadNotID(DialogueFilterContext::ConditionalContext* context) {

--- a/MWSE/TES3GameSetting.cpp
+++ b/MWSE/TES3GameSetting.cpp
@@ -82,10 +82,10 @@ namespace TES3 {
 		}
 		else if (v.is<double>()) {
 			if (type == 'i') {
-				value.asLong = v.as<double>();
+				value.asLong = static_cast<long>(v.as<double>());
 			}
 			else if (type == 'f') {
-				value.asFloat = v.as<double>();
+				value.asFloat = static_cast<float>(v.as<double>());
 			}
 		}
 	}

--- a/MWSE/TES3GlobalVariable.cpp
+++ b/MWSE/TES3GlobalVariable.cpp
@@ -4,7 +4,7 @@ namespace TES3 {
 	float GlobalVariable::getValue() const {
 		switch (tolower(valueType)) {
 		case 's': return short(value);
-		case 'l': return int(value);
+		case 'l': return float(int(value));
 		}
 		return value;
 	}

--- a/MWSE/TES3MagicEffect.cpp
+++ b/MWSE/TES3MagicEffect.cpp
@@ -484,7 +484,7 @@ namespace TES3 {
 
 	const auto TES3_Effect_calculateCost = reinterpret_cast<double(__cdecl*)(const Effect*)>(0x4AA700);
 	float Effect::calculateCost() const {
-		return TES3_Effect_calculateCost(this);
+		return static_cast<float>(TES3_Effect_calculateCost(this));
 	}
 
 	MagicEffect* Effect::getEffectData() const {

--- a/MWSE/TES3Misc.cpp
+++ b/MWSE/TES3Misc.cpp
@@ -46,9 +46,9 @@ namespace TES3 {
 		return mwse::tes3::isSoulGem(this);
 	}
 
-	int  Misc::getSoulGemCapacity() const {
+	int Misc::getSoulGemCapacity() const {
 		if (isSoulGem()) {
-			return value * TES3::DataHandler::get()->nonDynamicData->GMSTs[TES3::GMST::fSoulGemMult]->value.asFloat;
+			return static_cast<int>(value * TES3::DataHandler::get()->nonDynamicData->GMSTs[TES3::GMST::fSoulGemMult]->value.asFloat);
 		}
 		return 0;
 	}

--- a/MWSE/TES3MobManager.cpp
+++ b/MWSE/TES3MobManager.cpp
@@ -216,6 +216,6 @@ namespace TES3 {
 
 	void MobManager::setMaxClimbableSlope(float value) {
 		maxClimbableSlopeDegrees = value;
-		dotProductOfMaxClimbableSlope = cos(maxClimbableSlopeDegrees * mwse::math::M_PI / 180.0);
+		dotProductOfMaxClimbableSlope = cos(static_cast<float>(maxClimbableSlopeDegrees * mwse::math::M_PI / 180.0));
 	}
 }

--- a/MWSE/TES3MobileNPC.cpp
+++ b/MWSE/TES3MobileNPC.cpp
@@ -38,7 +38,7 @@ namespace TES3 {
 			adjustedDamage = fCombatArmorMinMult * damage;
 		}
 
-		auto armorDamage = damage - adjustedDamage;
+		auto armorDamage = static_cast<int>(damage - adjustedDamage);
 		if (adjustedDamage < 1.0f) {
 			adjustedDamage = 1.0f;
 		}

--- a/MWSE/TES3MobileNPC.cpp
+++ b/MWSE/TES3MobileNPC.cpp
@@ -127,8 +127,8 @@ namespace TES3 {
 
 		if (hitSound) {
 			// Calculate the hit volume based on the strength of the swing.
-			auto volume = (swing * 50.0f + 200.0f) * worldController->audioController->getMixVolume(AudioMixType::Effects);;
-			dataHandler->addSound(hitSound, reference, 0, volume);
+			auto volume = (swing * 50.0f + 200.0f) * worldController->audioController->getMixVolume(AudioMixType::Effects);
+			dataHandler->addSound(hitSound, reference, 0, static_cast<unsigned char>(volume));
 		}
 
 		if (actorType == TES3::MobileActorType::Player) {

--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -1037,9 +1037,9 @@ namespace TES3 {
 
 		// Recalculate rotation to always be between [0,2pi].
 		constexpr auto math2Pi = (mwse::math::M_PI * 2);
-		auto rotationInRadians = fmod(rotationInDegrees * (mwse::math::M_PI / 180.f), math2Pi);
+		auto rotationInRadians = static_cast<float>(fmod(rotationInDegrees * (mwse::math::M_PI / 180.f), math2Pi));
 		if (rotationInRadians < 0)
-			rotationInRadians += math2Pi;
+			rotationInRadians += static_cast<float>(math2Pi);
 
 		// Get reused variables.
 		auto dataHandler = TES3::DataHandler::get();
@@ -1169,7 +1169,7 @@ namespace TES3 {
 			sceneNode->localRotation->toEulerXYZ(&cachedOrientation);
 		}
 
-		relocate(cell, position, cachedOrientation.z * (180.0f / mwse::math::M_PI));
+		relocate(cell, position, static_cast<float>(cachedOrientation.z * (180.0f / mwse::math::M_PI)));
 
 		setOrientation(&cachedOrientation);
 	}

--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -777,7 +777,7 @@ namespace TES3 {
 
 			if (lockData && lockData->trap) {
 				if (chance <= 0 || chance <= (mwse::tes3::rand() % 100)) {
-					dataHandler->addSoundById("Disarm Trap Fail", this, 0, worldController->audioController->getMixVolume(AudioMixType::Effects) * 250);
+					dataHandler->addSoundById("Disarm Trap Fail", this, 0, worldController->audioController->getMixVolumeRaw(AudioMixType::Effects));
 					if (chance <= 0) {
 						TES3::UI::showMessageBox(ndd->GMSTs[GMST::sTrapImpossible]->value.asString);
 					}
@@ -789,7 +789,7 @@ namespace TES3 {
 					lockData->trap = nullptr;
 					setObjectModified(true);
 					Game::get()->clearTarget();
-					dataHandler->addSoundById("Disarm Trap", this, 0, worldController->audioController->getMixVolume(AudioMixType::Effects) * 250);
+					dataHandler->addSoundById("Disarm Trap", this, 0, worldController->audioController->getMixVolumeRaw(AudioMixType::Effects));
 
 					auto macp = worldController->getMobilePlayer();
 					if (macp == disarmer) {
@@ -837,7 +837,7 @@ namespace TES3 {
 
 			if (lockData && lockData->lockLevel > 0) {
 				if (chance <= 0 || chance <= (mwse::tes3::rand() % 100)) {
-					dataHandler->addSoundById("Open Lock Fail", this, 0, worldController->audioController->getMixVolume(AudioMixType::Effects) * 250);
+					dataHandler->addSoundById("Open Lock Fail", this, 0, worldController->audioController->getMixVolumeRaw(AudioMixType::Effects));
 					if (chance <= 0) {
 						TES3::UI::showMessageBox(ndd->GMSTs[GMST::sLockImpossible]->value.asString);
 					}
@@ -849,7 +849,7 @@ namespace TES3 {
 					lockData->locked = false;
 					setObjectModified(true);
 					Game::get()->clearTarget();
-					dataHandler->addSoundById("Open Lock", this, 0, worldController->audioController->getMixVolume(AudioMixType::Effects) * 250);
+					dataHandler->addSoundById("Open Lock", this, 0, worldController->audioController->getMixVolumeRaw(AudioMixType::Effects));
 
 					auto macp = worldController->getMobilePlayer();
 					if (macp == disarmer) {

--- a/MWSE/TES3ScriptLua.cpp
+++ b/MWSE/TES3ScriptLua.cpp
@@ -45,13 +45,13 @@ namespace mwse::lua {
 
 		switch (type) {
 		case 's':
-			vars->shortVarValues[index] = value.as<double>();
+			vars->shortVarValues[index] = static_cast<short>(value.as<double>());
 			break;
 		case 'l':
-			vars->longVarValues[index] = value.as<double>();
+			vars->longVarValues[index] = static_cast<long>(value.as<double>());
 			break;
 		case 'f':
-			vars->floatVarValues[index] = value.as<double>();
+			vars->floatVarValues[index] = static_cast<float>(value.as<double>());
 			break;
 		}
 	}

--- a/MWSE/TES3SoulGemData.cpp
+++ b/MWSE/TES3SoulGemData.cpp
@@ -48,7 +48,7 @@ namespace TES3 {
 			return item->getSoulGemCapacity();
 		}
 		else {
-			return value * TES3::DataHandler::get()->nonDynamicData->GMSTs[TES3::GMST::fSoulGemMult]->value.asFloat;
+			return static_cast<int>(value * TES3::DataHandler::get()->nonDynamicData->GMSTs[TES3::GMST::fSoulGemMult]->value.asFloat);
 		}
 	}
 }

--- a/MWSE/TES3Sound.cpp
+++ b/MWSE/TES3Sound.cpp
@@ -130,7 +130,7 @@ namespace TES3 {
 		if (value > 255.0 || value < 0.0) {
 			throw std::invalid_argument("tes3sound.setMinDistance: Value must be between 0 and 255.");
 		}
-		setMinDistance(value);
+		setMinDistance(static_cast<unsigned char>(value));
 	}
 
 	unsigned char Sound::getMaxDistance() const {
@@ -145,7 +145,7 @@ namespace TES3 {
 		if (value > 255.0 || value < 0.0) {
 			throw std::invalid_argument("tes3sound.setMaxDistance: Value must be between 0 and 255.");
 		}
-		setMaxDistance(value);
+		setMaxDistance(static_cast<unsigned char>(value));
 	}
 
 	float Sound::getVolume() {
@@ -180,7 +180,7 @@ namespace TES3 {
 		auto loop = mwse::lua::getOptionalParam(params, "loop", false);
 		auto volume = mwse::lua::getOptionalParam(params, "volume", 1.0f) * 250.0f;
 		auto pitch = mwse::lua::getOptionalParam(params, "pitch", 1.0f);
-		return play(loop ? TES3::SoundPlayFlags::Loop : 0, volume, pitch, true);
+		return play(loop ? TES3::SoundPlayFlags::Loop : 0, static_cast<unsigned char>(volume), pitch, true);
 	}
 }
 

--- a/MWSE/TES3Spell.cpp
+++ b/MWSE/TES3Spell.cpp
@@ -228,7 +228,7 @@ namespace TES3 {
 	}
 
 	int Spell::getValue() const {
-		return DataHandler::get()->nonDynamicData->GMSTs[GMST::fSpellValueMult]->value.asFloat * magickaCost;
+		return static_cast<int>(DataHandler::get()->nonDynamicData->GMSTs[GMST::fSpellValueMult]->value.asFloat * magickaCost);
 	}
 
 	size_t Spell::getActiveEffectCount() const {

--- a/MWSE/TES3UIManager.cpp
+++ b/MWSE/TES3UIManager.cpp
@@ -1159,7 +1159,10 @@ namespace TES3::UI {
 		}
 
 		auto font = TES3::WorldController::get()->fonts[fontIndex];
-		return { font->maxGlyphHeight, font->fontData->lineHeight };
+		return { 
+			static_cast<int>(font->maxGlyphHeight), 
+			static_cast<int>(font->fontData->lineHeight) 
+		};
 	}
 
 	const auto TES3_UI_Font_getTextExtent = reinterpret_cast<void(__thiscall*)(TES3::Font*, const char*, float*, float*, int, int, bool)>(0x40B190);
@@ -1186,7 +1189,11 @@ namespace TES3::UI {
 		// Calculated label height from text layout system.
 		float height = std::floor(verticalAdvance + font->maxGlyphHeight + 1.5f);
 
-		return { width, height, verticalAdvance };
+		return { 
+			static_cast<int>(width),
+			static_cast<int>(height),
+			static_cast<int>(verticalAdvance)
+		};
 	}
 
 	const auto TES3_UI_Font_wrapTextInPlace = reinterpret_cast<int(__thiscall*)(TES3::Font*, char*, unsigned int, bool, char)>(0x40BBC0);

--- a/MWSE/TES3Util.cpp
+++ b/MWSE/TES3Util.cpp
@@ -107,13 +107,13 @@ namespace mwse::tes3 {
 
 		// Set basic effect data.
 		TES3::Effect& effect = effects[index];
-		effect.effectID = effectId;
+		effect.effectID = static_cast<short>(effectId);
 		effect.rangeType = effectRange;
 		effect.radius = area;
 
 		// Set skill.
 		if (flags & TES3::EffectFlag::TargetSkill) {
-			effect.skillID = skillAttributeId;
+			effect.skillID = static_cast<TES3::SkillID::SkillID>(skillAttributeId);
 		}
 		else {
 			effect.skillID = TES3::SkillID::Invalid;
@@ -121,7 +121,7 @@ namespace mwse::tes3 {
 
 		// Set attribute.
 		if (flags & TES3::EffectFlag::TargetAttribute) {
-			effect.attributeID = skillAttributeId;
+			effect.attributeID = static_cast<TES3::Attribute::Attribute>(skillAttributeId);
 		}
 		else {
 			effect.attributeID = TES3::Attribute::Invalid;

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -346,7 +346,7 @@ namespace mwse::lua {
 
 		// Apply mix and rescale to 0-250
 		const auto worldController = TES3::WorldController::get();
-		volume *= 250.0 * worldController->audioController->getMixVolume(TES3::AudioMixType(mix));
+		volume *= worldController->audioController->getMixVolumeRaw(TES3::AudioMixType(mix));
 
 		// Only allow positional sounds if we are loaded in and have a player reference.
 		const auto mobilePlayer = worldController->getMobilePlayer();
@@ -365,7 +365,7 @@ namespace mwse::lua {
 		// Try to fall back on direct-playing a sound.
 		if (sound) {
 			const auto flags = loop ? TES3::SoundPlayFlags::Loop : NULL;
-			return sound->play(flags, volume, pitch, true);
+			return sound->play(flags, static_cast<unsigned char>(volume), pitch, true);
 		}
 
 		return false;
@@ -405,7 +405,7 @@ namespace mwse::lua {
 		volume = std::min(volume, 1.0);
 
 		// Apply mix and rescale to 0-250
-		volume *= 250.0 * TES3::WorldController::get()->audioController->getMixVolume(TES3::AudioMixType(mix));
+		volume *= TES3::WorldController::get()->audioController->getMixVolumeRaw(TES3::AudioMixType(mix));
 
 		TES3::DataHandler::get()->adjustSoundVolume(sound, reference, unsigned char(volume));
 	}
@@ -4395,7 +4395,7 @@ namespace mwse::lua {
 
 		// Apply volume, using mix channel and rescale to 0-250.
 		auto volume = std::clamp(getOptionalParam(params, "volume", 1.0), 0.0, 1.0);
-		volume *= 250.0 * worldController->audioController->getMixVolume(TES3::AudioMixType::Voice);
+		volume *= worldController->audioController->getMixVolumeRaw(TES3::AudioMixType::Voice);
 
 		// Show a messagebox.
 		if (worldController->showSubtitles || getOptionalParam(params, "forceSubtitle", false)) {

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -2475,7 +2475,7 @@ namespace mwse::lua {
 			std::swap(TES3::DataHandler::suppressThreadLoad, suppressThreadLoad);
 
 			if (userProvidedOrientation) {
-				reference->relocate(cell, &position.value(), orientation.value().z * (180.0f / math::M_PI));
+				reference->relocate(cell, &position.value(), static_cast<float>(orientation.value().z * (180.0f / math::M_PI)));
 			}
 			else {
 				reference->relocateNoRotation(cell, &position.value());

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -2248,7 +2248,7 @@ namespace mwse::lua {
 		}
 
 		if (temporary) {
-			// Only make temporary changes in the dialogue menu. 
+			// Only make temporary changes in the dialogue menu.
 			if (inDialogue) {
 				// Modify the NPC disposition, with clamping of effective disposition.
 				reference->baseObject->modDisposition(value.value());
@@ -6033,7 +6033,7 @@ namespace mwse::lua {
 
 		// Calculate base charge cost.
 		int charge = enchant->chargeCost;
-		int skill = mobile->getSkillValue(TES3::SkillID::Enchant);
+		int skill = int(mobile->getSkillValue(TES3::SkillID::Enchant));
 
 		// Check for enchantedItemRebalance patch to select correct charge calculation.
 		if (mcp::getFeatureEnabled(mcp::feature::EnchantedItemRebalance)) {
@@ -6048,14 +6048,14 @@ namespace mwse::lua {
 		if (event::EnchantChargeUseEvent::getEventEnabled()) {
 			const auto stateHandle = LuaManager::getInstance().getThreadSafeStateHandle();
 
-			sol::object eventResult = stateHandle.triggerEvent(new event::EnchantChargeUseEvent(enchant, mobile, nullptr, charge));
+			sol::object eventResult = stateHandle.triggerEvent(new event::EnchantChargeUseEvent(enchant, mobile, nullptr, float(charge)));
 
 			// Allow the event to modify charge.
 			if (eventResult.valid()) {
 				sol::table eventData = eventResult;
 				sol::optional<float> newCharge = eventData["charge"];
 				if (newCharge) {
-					charge = newCharge.value();
+					charge = int(newCharge.value());
 				}
 			}
 		}
@@ -6338,7 +6338,7 @@ namespace mwse::lua {
 			mobile->barterGold += cost;
 
 			// Extend refresh timeout for barterGold refresh system. This prevents the change from being overwritten immediately.
-			auto hourStamp = worldController->gvarDaysPassed->value * 24 + worldController->gvarGameHour->value;
+			auto hourStamp = static_cast<unsigned short>(worldController->gvarDaysPassed->value * 24 + worldController->gvarGameHour->value);
 			if (mobile->actionData.lastBarterHoursPassed == 0) {
 				mobile->actionData.lastBarterHoursPassed = hourStamp;
 			}

--- a/MWSE/TES3WorldController.cpp
+++ b/MWSE/TES3WorldController.cpp
@@ -382,10 +382,10 @@ namespace TES3 {
 		std::stringstream output;
 
 		// Build header.
-		int day = worldController->gvarDay->value;
-		const char* month = worldController->getNameForMonth(worldController->gvarMonth->value);
+		int day = static_cast<int>(worldController->gvarDay->value);
+		const char* month = worldController->getNameForMonth(static_cast<int>(worldController->gvarMonth->value));
 		const char* gmstDay = ndd->GMSTs[GMST::sDay]->value.asString;
-		int daysPassed = worldController->gvarDaysPassed->value;
+		int daysPassed = static_cast<int>(worldController->gvarDaysPassed->value);
 		output << "<FONT COLOR=\"9F0000\">";
 		output << day << " " << month;
 		output << " (" << gmstDay << " " << daysPassed << ")";
@@ -719,10 +719,10 @@ namespace TES3 {
 		bool respawnContainers = false;
 		while (gvarGameHour->value >= 24.0f) {
 			// Drop these values to integers to be later set back to the global values.
-			int day = gvarDay->value;
-			int daysPassed = gvarDaysPassed->value;
-			int month = gvarMonth->value;
-			int year = gvarYear->value;
+			int day = static_cast<int>(gvarDay->value);
+			int daysPassed = static_cast<int>(gvarDaysPassed->value);
+			int month = static_cast<int>(gvarMonth->value);
+			int year = static_cast<int>(gvarYear->value);
 
 			// Increment day count, reduce game hour by 24.
 			day++;
@@ -747,13 +747,13 @@ namespace TES3 {
 			// Do we need to respawn containers?
 			// mcp::ContainerRespawnTimescale modifies respawn cycle to use days.
 			if (advanceRespawn || mwse::mcp::getFeatureEnabled(mwse::mcp::feature::ContainerRespawnTimescale)) {
-				int monthsToRespawn = --gvarMonthsToRespawn->value;
+				int monthsToRespawn = static_cast<int>(--gvarMonthsToRespawn->value);
 				if (monthsToRespawn <= 0) {
 					respawnContainers = true;
-					gvarMonthsToRespawn->value = ndd->GMSTs[TES3::GMST::iMonthsToRespawn]->value.asLong;
+					gvarMonthsToRespawn->value = static_cast<float>(ndd->GMSTs[TES3::GMST::iMonthsToRespawn]->value.asLong);
 				}
 				else {
-					gvarMonthsToRespawn->value = monthsToRespawn;
+					gvarMonthsToRespawn->value = static_cast<float>(monthsToRespawn);
 				}
 			}
 
@@ -764,10 +764,10 @@ namespace TES3 {
 			}
 
 			// Update global variables.
-			gvarDay->value = day;
-			gvarDaysPassed->value = daysPassed;
-			gvarMonth->value = month;
-			gvarYear->value = year;
+			gvarDay->value = static_cast<float>(day);
+			gvarDaysPassed->value = static_cast<float>(daysPassed);
+			gvarMonth->value = static_cast<float>(month);
+			gvarYear->value = static_cast<float>(year);
 		}
 
 		if (respawnContainers) {

--- a/MWSE/VirtualMachine.cpp
+++ b/MWSE/VirtualMachine.cpp
@@ -382,7 +382,7 @@ void VirtualMachine::setLongGlobal(const char* id, long value)
 		return;
 	}
 
-	globalVar->value = value;
+	globalVar->value = static_cast<float>(value);
 }
 
 short VirtualMachine::getShortGlobal(const char* id)

--- a/MWSE/WindowsUtil.cpp
+++ b/MWSE/WindowsUtil.cpp
@@ -14,7 +14,7 @@ namespace mwse::lua {
 		int64_t elapsed = endingTime.QuadPart - startTimestamp;
 		// Conversion to microseconds, we do this first to avoid loss-of-precision during the next division
 		elapsed *= 1000000ll;
-		double t = elapsed / performanceFrequency;
+		double t = static_cast<double>(elapsed / performanceFrequency);
 		t /= 1000000;
 		return t;
 	}

--- a/MWSE/xDegRad.cpp
+++ b/MWSE/xDegRad.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 	float xDegRad::execute(mwse::VMExecuteInterface& virtualMachine) {
 		float param = mwse::Stack::getInstance().popFloat();
 
-		mwse::Stack::getInstance().pushFloat(param * math::M_PI / 180.0);
+		mwse::Stack::getInstance().pushFloat(static_cast<float>(param * math::M_PI / 180.0));
 		return 0.0f;
 	}
 }

--- a/MWSE/xFloatsToLong.cpp
+++ b/MWSE/xFloatsToLong.cpp
@@ -14,8 +14,8 @@ namespace mwse {
 	xFloatsToLong::xFloatsToLong() : mwse::InstructionInterface_t(OpCode::xFloatsToLong) {}
 
 	float xFloatsToLong::execute(mwse::VMExecuteInterface& virtualMachine) {
-		float param1 = mwse::Stack::getInstance().popFloat();
-		float param2 = mwse::Stack::getInstance().popFloat();
+		long param1 = static_cast<long>(mwse::Stack::getInstance().popFloat());
+		long param2 = static_cast<long>(mwse::Stack::getInstance().popFloat());
 
 		long high = 0;
 		long low = 0;

--- a/MWSE/xGetEnchant.cpp
+++ b/MWSE/xGetEnchant.cpp
@@ -51,7 +51,7 @@ namespace mwse {
 					currCharge = varNode->charge;
 				}
 				else {
-					currCharge = maxCharge;
+					currCharge = static_cast<float>(maxCharge);
 				}
 			}
 			else {

--- a/MWSE/xGetEncumbrance.cpp
+++ b/MWSE/xGetEncumbrance.cpp
@@ -84,7 +84,7 @@ namespace mwse {
 			encumbrance = round(encumbrance * 100.0) / 100.0;
 		}
 
-		mwse::Stack::getInstance().pushFloat(encumbrance);
+		mwse::Stack::getInstance().pushFloat(static_cast<float>(encumbrance));
 
 		return 0.0f;
 	}

--- a/MWSE/xLongToFloats.cpp
+++ b/MWSE/xLongToFloats.cpp
@@ -16,8 +16,8 @@ namespace mwse {
 	float xLongToFloats::execute(mwse::VMExecuteInterface& virtualMachine) {
 		long param = mwse::Stack::getInstance().popLong();
 
-		mwse::Stack::getInstance().pushFloat((param >> 16) + 0x10000);
-		mwse::Stack::getInstance().pushFloat(param & 0xFFFF);
+		mwse::Stack::getInstance().pushFloat(static_cast<float>((param >> 16) + 0x10000));
+		mwse::Stack::getInstance().pushFloat(static_cast<float>(param & 0xFFFF));
 
 		return 0.0f;
 	}

--- a/MWSE/xRadDeg.cpp
+++ b/MWSE/xRadDeg.cpp
@@ -16,7 +16,7 @@ namespace mwse {
 	xRadDeg::xRadDeg() : mwse::InstructionInterface_t(OpCode::xRadDeg) {}
 
 	float xRadDeg::execute(mwse::VMExecuteInterface& virtualMachine) {
-		mwse::Stack::getInstance().pushFloat(mwse::Stack::getInstance().popFloat() / math::M_PI * 180.0);
+		mwse::Stack::getInstance().pushFloat(static_cast<float>(mwse::Stack::getInstance().popFloat() / math::M_PI * 180.0));
 		return 0.0f;
 	}
 }

--- a/MWSE/xSetArrayValue.cpp
+++ b/MWSE/xSetArrayValue.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 		long index = mwse::Stack::getInstance().popLong();
 		long value = mwse::Stack::getInstance().popLong();
 
-		long status = mwse::Arrays::getInstance().setValue("xSetArrayValue", id, index, value);
+		short status = mwse::Arrays::getInstance().setValue("xSetArrayValue", id, index, value);
 
 		mwse::Stack::getInstance().pushShort(status);
 

--- a/MWSE/xSetEnchantInfo.cpp
+++ b/MWSE/xSetEnchantInfo.cpp
@@ -34,15 +34,6 @@ namespace mwse {
 			return false;
 		}
 
-		// Validate autocalc.
-		if (autocalc < 0 || autocalc > 1) {
-			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
-				mwse::log::getLog() << "xSetEnchantInfo: Autocalc value of range." << std::endl;
-			}
-			mwse::Stack::getInstance().pushLong(false);
-			return false;
-		}
-
 		const auto enchant = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Enchantment>(enchantId);
 		if (enchant == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {

--- a/MWSE/xSetEnchantInfo.cpp
+++ b/MWSE/xSetEnchantInfo.cpp
@@ -54,8 +54,8 @@ namespace mwse {
 
 		// Set values.
 		enchant->castType = static_cast<TES3::EnchantmentCastType>(type);
-		enchant->chargeCost = cost;
-		enchant->maxCharge = charge;
+		enchant->chargeCost = static_cast<unsigned short>(cost);
+		enchant->maxCharge = static_cast<unsigned short>(charge);
 		enchant->vTable.object->setAutoCalc(enchant, autocalc);
 
 		mwse::Stack::getInstance().pushLong(true);

--- a/MWSE/xSetMaxCharge.cpp
+++ b/MWSE/xSetMaxCharge.cpp
@@ -46,7 +46,7 @@ namespace mwse {
 		// If we found an enchantment record, set the max charge.
 		TES3::Enchantment* enchantment = object->vTable.object->getEnchantment(object);
 		if (enchantment) {
-			enchantment->maxCharge = maxCharge;
+			enchantment->maxCharge = static_cast<unsigned short>(maxCharge);
 
 			// If there's charge data in an attached node, update it.
 			auto varNode = reference->getAttachedItemData();

--- a/MWSE/xSetMaxCondition.cpp
+++ b/MWSE/xSetMaxCondition.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 	float xSetMaxCondition::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get parameter from the stack.
-		long maxCondition = mwse::Stack::getInstance().popLong();
+		int maxCondition = static_cast<int>(mwse::Stack::getInstance().popLong());
 		bool success = false;
 
 		// Get reference.

--- a/MWSE/xSetSpellInfo.cpp
+++ b/MWSE/xSetSpellInfo.cpp
@@ -91,7 +91,7 @@ namespace mwse {
 			//! TODO: Recalculate spell cost.
 		}
 		else if (!(flags & TES3::SpellFlag::AutoCalc)) {
-			spell->magickaCost = cost;
+			spell->magickaCost = static_cast<unsigned short>(cost);
 		}
 
 		// Set other information.

--- a/MWSE/xSetValue.cpp
+++ b/MWSE/xSetValue.cpp
@@ -76,7 +76,7 @@ namespace mwse {
 			break;
 		case TES3::ObjectType::Clothing:
 			// Clothing has the same offset as armor, but it's a short rather than a long.
-			reinterpret_cast<TES3::Clothing*>(record)->value = value;
+			reinterpret_cast<TES3::Clothing*>(record)->value = static_cast<unsigned short>(value);
 			setValue = true;
 			break;
 		case TES3::ObjectType::Apparatus:


### PR DESCRIPTION
Silences most of the C4244 conversion from 'type1' to 'type2', possible loss of data compiler warnings. These also make up most of the compiler warnings when compiling MWSE.

The PR is split into logical commits to be easier to review. In most cases, I use explicit casts where the cast was previously implicit. I left notes below where this wasn't the case.

