### PR TITLE
Fix `Spell::calculateBasePurchaseCost` spelling

### DIFF
--- a/MWSE/TES3Spell.cpp
+++ b/MWSE/TES3Spell.cpp
@@ -254,7 +254,7 @@ namespace TES3 {
 		return getFirstIndexOfEffect(effectId) != -1;
 	}
 
-	int Spell::calculateBasePuchaseCost() const {
+	int Spell::calculateBasePurchaseCost() const {
 		return int(magickaCost * TES3::DataHandler::get()->nonDynamicData->GMSTs[TES3::GMST::fSpellValueMult]->value.asFloat);
 	}
 

--- a/MWSE/TES3Spell.cpp
+++ b/MWSE/TES3Spell.cpp
@@ -254,10 +254,6 @@ namespace TES3 {
 		return getFirstIndexOfEffect(effectId) != -1;
 	}
 
-	int Spell::calculateBasePurchaseCost() const {
-		return int(magickaCost * TES3::DataHandler::get()->nonDynamicData->GMSTs[TES3::GMST::fSpellValueMult]->value.asFloat);
-	}
-
 	float Spell::calculateCastChance_lua(sol::table params) {
 		bool checkMagicka = mwse::lua::getOptionalParam<bool>(params, "checkMagicka", true);
 		sol::object caster = params["caster"];

--- a/MWSE/TES3Spell.h
+++ b/MWSE/TES3Spell.h
@@ -105,7 +105,7 @@ namespace TES3 {
 		int getFirstIndexOfEffect(int effectId) const;
 		bool hasEffect(int effectId) const;
 
-		int calculateBasePuchaseCost() const;
+		int calculateBasePurchaseCost() const;
 		float calculateCastChance_lua(sol::table params);
 		int getAutoCalcMagickaCost() const;
 

--- a/MWSE/TES3Spell.h
+++ b/MWSE/TES3Spell.h
@@ -105,7 +105,6 @@ namespace TES3 {
 		int getFirstIndexOfEffect(int effectId) const;
 		bool hasEffect(int effectId) const;
 
-		int calculateBasePurchaseCost() const;
 		float calculateCastChance_lua(sol::table params);
 		int getAutoCalcMagickaCost() const;
 

--- a/MWSE/TES3SpellLua.cpp
+++ b/MWSE/TES3SpellLua.cpp
@@ -75,7 +75,7 @@ namespace mwse::lua {
 		setUserdataForTES3Object(usertypeDefinition);
 
 		// Basic property binding.
-		usertypeDefinition["basePurchaseCost"] = sol::readonly_property(&TES3::Spell::calculateBasePuchaseCost);
+		usertypeDefinition["basePurchaseCost"] = sol::readonly_property(&TES3::Spell::calculateBasePurchaseCost);
 		usertypeDefinition["castType"] = &TES3::Spell::castType;
 		usertypeDefinition["effects"] = sol::readonly_property(&TES3::Spell::getEffects);
 		usertypeDefinition["flags"] = &TES3::Spell::spellFlags;

--- a/MWSE/TES3SpellLua.cpp
+++ b/MWSE/TES3SpellLua.cpp
@@ -75,7 +75,7 @@ namespace mwse::lua {
 		setUserdataForTES3Object(usertypeDefinition);
 
 		// Basic property binding.
-		usertypeDefinition["basePurchaseCost"] = sol::readonly_property(&TES3::Spell::calculateBasePurchaseCost);
+		usertypeDefinition["basePurchaseCost"] = sol::readonly_property(&TES3::Spell::getValue);
 		usertypeDefinition["castType"] = &TES3::Spell::castType;
 		usertypeDefinition["effects"] = sol::readonly_property(&TES3::Spell::getEffects);
 		usertypeDefinition["flags"] = &TES3::Spell::spellFlags;


### PR DESCRIPTION
Unrelated, this method is the same as `Spell::getValue`