### PR TITLE
Fix bsanim teardown uaf guard

### DIFF
--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -36,7 +36,9 @@
 #include "TES3VFXManager.h"
 #include "TES3WorldController.h"
 
+#include "BSAnimationManager.h"
 #include "NIAVObject.h"
+#include "NIBSAnimationNode.h"
 #include "NICollisionSwitch.h"
 #include "NIFlipController.h"
 #include "NILinesData.h"
@@ -1697,6 +1699,88 @@ namespace mwse::patch {
 		Sleep(Configuration::BackgroundLoadPollIntervalMs);
 	}
 
+	// Defensive validation for a pointer that's about to be dereferenced as
+	// an NI::Object during BSAnimationManager teardown. Returns true if the
+	// pointer + its (presumed) vtable + the first vtable entry all live in
+	// committed, readable, code-bearing memory. The use-after-free we're
+	// guarding against tends to leave the first 4 bytes (vtable pointer)
+	// looking valid while later fields are garbage; a deeper check on
+	// vtable[0] catches the worst cases.
+	static bool IsLiveNIObjectPointer(const void* ptr) {
+		if (!ptr) return false;
+
+		MEMORY_BASIC_INFORMATION mbi = {};
+		if (VirtualQuery(ptr, &mbi, sizeof(mbi)) == 0) return false;
+		if (mbi.State != MEM_COMMIT) return false;
+		if (mbi.Protect & (PAGE_NOACCESS | PAGE_GUARD)) return false;
+
+		const auto vtbl = *reinterpret_cast<const DWORD*>(ptr);
+		if (VirtualQuery(reinterpret_cast<void*>(vtbl), &mbi, sizeof(mbi)) == 0) return false;
+		if (mbi.State != MEM_COMMIT) return false;
+		if (mbi.Protect & (PAGE_NOACCESS | PAGE_GUARD)) return false;
+
+		// vtable[0] (deleting_dtor) should sit in Morrowind.exe's .text
+		// segment (roughly 0x00400000-0x00800000). A heap-residing value
+		// here means the slot was overwritten and the indirect call would
+		// jump into garbage.
+		const auto vtblEntry0 = *reinterpret_cast<const DWORD*>(vtbl);
+		return vtblEntry0 >= 0x400000 && vtblEntry0 < 0x800000;
+	}
+
+	// Defensive replacement for the deleting_dtor of NI::BSAnimationManager.
+	//
+	// Engine bug: BSAnimationManager.managedNodes (TArray<Pointer<BSAnimationNode>>)
+	// can hold dangling pointers to BSAnimationNodes that were already freed
+	// elsewhere during cell-unload. The stock dtor at 0x6EE2A0 walks the array,
+	// decrements refcount via [node+0x4], and if it hits zero calls the node's
+	// virtual deleting_dtor via [node][0]. Both reads happen without
+	// validation -- if `node` is freed memory whose first 4 bytes happen to
+	// resolve to a known NI vtable but whose later fields are garbage,
+	// the indirect call jumps to a corrupt slot and we crash on
+	// EXCEPTION_ACCESS_VIOLATION inside the GameBackgroundThread cell-unload
+	// path. Reproduces especially with cells holding animated flora
+	// (kelp, etc.) that participate in the BSAnimationManager.
+	//
+	// We pre-walk the array under VirtualQuery validation:
+	//   - Live nodes get the standard refcount-decrement + deleting_dtor.
+	//   - Dead nodes are logged and skipped (better to leak the engine
+	//     side's tracking entry than crash the process).
+	// Either way, we NULL the slot so that when the engine's own dtor runs
+	// after our pass it sees the array as already-cleaned and proceeds
+	// cleanly to the TArray storage free + NiNode::dtor parent + delete.
+	static void __fastcall PatchedBSAnimationManagerDeletingDtor(NI::BSAnimationManager* self, DWORD edx_unused, char flags) {
+		auto& nodes = self->managedNodes;
+		for (size_t i = 0; i < nodes.endIndex; ++i) {
+			NI::BSAnimationNode* node = nodes.storage[i].get();
+			if (!node) continue;
+
+			if (IsLiveNIObjectPointer(node)) {
+				if (--node->refCount == 0) {
+					node->vTable.asObject->destructor(node, 1);
+				}
+			}
+			else {
+				log::getLog() << "[MWSE] BSAnimationManager::dtor: skipping freed managed node 0x"
+					<< std::hex << reinterpret_cast<DWORD>(node)
+					<< " (likely use-after-free during cell unload)" << std::endl;
+			}
+			// Bypass Pointer<>::operator= refcount semantics -- the node was
+			// either properly released above or is dead memory we can't touch.
+			// Either way we need the slot zeroed without re-decrementing.
+			*reinterpret_cast<DWORD*>(&nodes.storage[i]) = 0;
+		}
+		nodes.endIndex = 0;
+		nodes.filledCount = 0;
+
+		// Hand off to the engine's stock deleting_dtor. Its managedNodes
+		// loops are no-ops now (count fields zeroed, slots nulled), so it
+		// proceeds to the safe parts: TArray storage free, NiNode::dtor
+		// parent, and the conditional `delete this` based on `flags & 1`.
+		const auto BSAnimationManager_orig_deleting_dtor =
+			reinterpret_cast<void(__thiscall*)(NI::BSAnimationManager*, char)>(0x6EE280);
+		BSAnimationManager_orig_deleting_dtor(self, flags);
+	}
+
 	//
 	// Install all the patches.
 	//
@@ -1758,6 +1842,11 @@ namespace mwse::patch {
 		// Patch: Fix NiLinesData binary loading.
 		auto NiLinesData_loadBinary = &NI::LinesData::loadBinary;
 		overrideVirtualTableEnforced(0x7501E0, offsetof(NI::Object_vTable, loadBinary), 0x6DA410, *reinterpret_cast<DWORD*>(&NiLinesData_loadBinary));
+
+		// Patch: defensive guard around BSAnimationManager teardown. See
+		// PatchedBSAnimationManagerDeletingDtor for the engine-bug context.
+		// Override deleting_dtor (vtable[0]) on vtbl_sg_BSAnimationManager.
+		overrideVirtualTableEnforced(0x750BD8, 0, 0x6EE280, reinterpret_cast<DWORD>(PatchedBSAnimationManagerDeletingDtor));
 
 		// Patch: Try to catch bogus collisions.
 		auto MobileObject_Collision_clone = &TES3::MobileObject::Collision::clone;

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -1241,6 +1241,69 @@ namespace mwse::patch {
 	const size_t PatchNIDX8Renderer_RenderShape_size = 0x8;
 
 	//
+	// Patch: Fix NiDX8TexturePass::setCTPipelineState always setting the base map
+	// texture coordinate index to 0 instead of reading it from the NIF property.
+	//
+	// Bug at 0x6B42AC: `mov [edi+28h], ebp` hardcodes ebp (=0) into
+	// NiDX8TextureStage::sourceTexcoordIndex (+0x28) for stage[0]. Every other
+	// map type (detail, glow, dark, decal, bump, gloss) correctly reads
+	// NiTexturingProperty::Map::texCoordSet (+0x10) and clamps it to
+	// [0, textureSetCount-1]. The base map skips that read entirely.
+	//
+	// Fix: a 5-byte CALL replaces the buggy 3-byte mov plus the first 2 bytes of
+	// the following `mov [edi+48h], ebp`. A single NOP covers the leftover byte
+	// at 0x6B42B1. The hook reads baseMap->texCoordSet, clamps it, writes it to
+	// stage[0].sourceTexcoordIndex, and replicates the clobbered [edi+48h]=0 write.
+	//
+	// Stack layout on entry (ecx/thiscall frame of 0x6B41B0):
+	//   sub esp,38h + push ebx/ebp/esi/edi → 0x48 total frame
+	//   [esp+0x2C] = NiTexturingProperty*  (var_1C in IDA; caller saved to stack)
+	//   [esp+0x58] = textureSetCount       (arg_10, 5th explicit parameter)
+	// After the CALL at 0x6B42AC pushes a return address (+4):
+	//   [esp+0x30] = NiTexturingProperty*
+	//   [esp+0x5C] = textureSetCount
+	//
+	// NiTexturingProperty::TArray<Map*> maps is at prop+0x1C.
+	// TArray.storage (pointer to element array) is at TArray+0x4 → prop+0x20.
+	// maps.storage[0] is the base Map*; Map::texCoordSet is at Map+0x10.
+	//
+	__declspec(naked) void PatchNiDX8TexturePass_BaseMapTexcoord() {
+		__asm {
+			// edi = NiDX8TextureStage* (stage[0], always valid at this call site)
+			// ebp = 0
+
+			// --- Fix: read baseMap->texCoordSet and clamp ---
+			mov  eax, [esp+0x30]    // eax = NiTexturingProperty* (caller's var_1C)
+			mov  eax, [eax+0x20]    // eax = maps.storage pointer (TArray.storage at prop+0x20)
+			mov  eax, [eax]         // eax = maps.storage[0] = baseMap*
+			test eax, eax
+			jz   use_zero           // baseMap == nullptr → default to 0
+
+			mov  eax, [eax+0x10]    // eax = baseMap->texCoordSet
+
+			// Clamp: if texCoordSet >= textureSetCount, use textureSetCount-1
+			mov  ecx, [esp+0x5C]    // ecx = textureSetCount (caller's arg_10)
+			test ecx, ecx
+			jz   use_zero           // textureSetCount == 0 → clamp to 0
+			cmp  eax, ecx
+			jb   write_index        // texCoordSet < textureSetCount → no clamp needed
+			lea  eax, [ecx-1]       // eax = textureSetCount - 1
+			jmp  write_index
+
+		use_zero:
+			xor  eax, eax
+
+		write_index:
+			mov  [edi+0x28], eax    // stage[0].sourceTexcoordIndex = texCoordSet
+
+			// --- Replicate clobbered instruction: mov [edi+48h], ebp (= 0) ---
+			mov  [edi+0x48], ebp
+
+			ret
+		}
+	}
+
+	//
 	// Patch: Fix cure spells incorrectly triggering MagicEffectState_Ending for magic that hasn't taken effect yet.
 	//
 
@@ -2082,6 +2145,11 @@ namespace mwse::patch {
 		genCallEnforced(0x6E54C5, 0x6F15B0, reinterpret_cast<DWORD>(PatchNITriShapeCopyMembers));
 		writePatchCodeUnprotected(0x6ACF1F, (BYTE*)&PatchNIDX8Renderer_RenderShape, PatchNIDX8Renderer_RenderShape_size);
 		overrideVirtualTableEnforced(0x7508B0, offsetof(NI::TriShape_vTable, NI::TriShape_vTable::linkObject), 0x6E56D0, *reinterpret_cast<DWORD*>(&TriShape_linkObject));
+
+		// Patch: Fix base map texture coordinate index hardcoded to 0 in NiDX8TexturePass::setCTPipelineState.
+		// 0x6B42AC: `mov [edi+28h], ebp` — replace with CALL + NOP the leftover byte at 0x6B42B1.
+		genNOPUnprotected(0x6B42B1, 1);
+		genCallUnprotected(0x6B42AC, reinterpret_cast<DWORD>(PatchNiDX8TexturePass_BaseMapTexcoord));
 
 		// Patch: Fix cure spells incorrectly triggering MagicEffectState_Ending for magic that hasn't taken effect yet.
 		genCallUnprotected(0x4559B2, reinterpret_cast<DWORD>(PatchRemoveMagicsByEffect), 0x8);

--- a/misc/package/Data Files/MWSE/core/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/lib/event.lua
@@ -156,7 +156,7 @@ function this.unregister(eventType, callback, options)
 
 	-- Handle the special case where `doOnce` was used.
 	if doOnceCallbacks[callback] then
-		callback = doOnceCallbacks[callback] 
+		callback = doOnceCallbacks[callback]
 		doOnceCallbacks[callback] = nil -- Won't be needing this anymore.
 	end
 
@@ -192,7 +192,7 @@ function this.isRegistered(eventType, callback, options)
 
 	-- Handle the special case where `doOnce` was used.
 	if doOnceCallbacks[callback] then
-		callback = doOnceCallbacks[callback] 
+		callback = doOnceCallbacks[callback]
 	end
 
 	-- Make sure options is an empty table if nothing else.
@@ -376,25 +376,34 @@ function this.trigger(eventType, payload, options)
 	payload.eventType = eventType
 	payload.eventFilter = options.filter
 
-	local callbacks = table.copy(getEventTable(eventType, options.filter))
-	for _, callback in pairs(callbacks) do
-		-- Inform error notifier of current eventType.
-		errorNotifier.eventType = eventType
+	local t
+	if options.filter ~= nil then
+		local ft = filteredEvents[eventType]
+		t = ft and ft[options.filter]
+	else
+		t = generalEvents[eventType]
+	end
+	local callbacks = t and table.copy(t)
+	if callbacks then
+		for _, callback in pairs(callbacks) do
+			-- Inform error notifier of current eventType.
+			errorNotifier.eventType = eventType
 
-		local status, result = xpcall(callback, onEventError, payload)
-		if (status == false) then
-			result = nil
-		end
+			local status, result = xpcall(callback, onEventError, payload)
+			if (status == false) then
+				result = nil
+			end
 
-		-- Returning non-nil from the callback claims/blocks the event.
-		if (result ~= nil) then
-			payload.claim = true
-			payload.block = true
-		end
+			-- Returning non-nil from the callback claims/blocks the event.
+			if (result ~= nil) then
+				payload.claim = true
+				payload.block = true
+			end
 
-		-- If the event is claimed, do not excute any further events.
-		if (payload.claim) then
-			return payload
+			-- If the event is claimed, do not excute any further events.
+			if (payload.claim) then
+				return payload
+			end
 		end
 	end
 

--- a/misc/package/Data Files/MWSE/core/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/lib/event.lua
@@ -376,15 +376,10 @@ function this.trigger(eventType, payload, options)
 	payload.eventType = eventType
 	payload.eventFilter = options.filter
 
-	local t
-	if options.filter ~= nil then
-		local ft = filteredEvents[eventType]
-		t = ft and ft[options.filter]
-	else
-		t = generalEvents[eventType]
-	end
-	local callbacks = t and table.copy(t)
-	if callbacks then
+	local filteredCallbacks = getEventTable(eventType, options.filter)
+	-- If events have registered a filter, then run them now. Otherwise, skip this section.
+	if #filteredCallbacks > 0 then
+		local callbacks = table.copy(filteredCallbacks)
 		for _, callback in pairs(callbacks) do
 			-- Inform error notifier of current eventType.
 			errorNotifier.eventType = eventType


### PR DESCRIPTION
[MWSE] Defensive guard around BSAnimationManager teardown
Engine bug: NI::BSAnimationManager::dtor (0x6EE2A0) walks its
managedNodes TArray<Pointer<BSAnimationNode>> and, for each entry,
decrements refcount via [node+0x4] then calls the virtual
deleting_dtor via [node][0]. Both reads happen without validation.

If a managed BSAnimationNode is freed elsewhere (e.g. by another
arm of the cell-unload teardown) before the BSAnimationManager
itself is destroyed, the slot becomes a dangling pointer. The first
4 bytes (vtable pointer) often survive intact in the freed heap
chunk -- enough for refcount-decrement to look valid -- but the
indirect call into vtable[0] dereferences either freed-and-reused
memory or land on a corrupt slot. Result: EXCEPTION_ACCESS_VIOLATION
on GameBackgroundThread, eip in heap address space.
Symptom in MWSE crash logs:
  Thread: GameBackgroundThread
  Exception: EXCEPTION_ACCESS_VIOLATION (C0000005)
  Stack[0] dereferences to "BSAnimationManager: Unable to dereference"
  edx -> EntityStatic::deleting_dtor (cell unload path)
  Common reference: animated flora (e.g. Flora_kelp_02 with sway)

Fix: override vtbl_sg_BSAnimationManager[0] (deleting_dtor) with
PatchedBSAnimationManagerDeletingDtor, which:

1. Pre-walks managedNodes under VirtualQuery validation. Each entry
   gets a 3-stage check:
     - the node pointer points to committed, readable memory
     - the node's vtable pointer points to committed, readable memory
     - vtable[0] (deleting_dtor) lands in Morrowind.exe's .text range
       (0x00400000-0x00800000), not heap

2. Live nodes get the standard refcount-decrement + virtual
   deleting_dtor.
3. Dead nodes are logged ("skipping freed managed node 0x..., likely
   use-after-free during cell unload") and skipped -- leaking the
   tracking entry rather than crashing the process.
4. Either way, slot is zeroed via direct DWORD write (bypasses
   Pointer<>::operator= so no second decrement attempt on the
   already-handled or known-dead memory).
5. Hand off to the engine's stock deleting_dtor at 0x6EE280 with the
   array's count fields zeroed -- engine sees an already-cleaned
   array and proceeds safely to TArray storage free, NiNode::dtor
   parent, and conditional `delete this`.

Conservative defensive patch -- masks an engine bug rather than fixes
it. Skipping a managed node leaks a small NiPointer entry inside the
BSAnimationManager (already being torn down anyway). The tradeoff
(rare leak vs reliable crash on cell unload near animated flora) is
heavily in our favor.

Diagnosed via IDA against Morrowind.exe at 0x4F0CA0 (Entity::dtor)
and 0x6EE2A0 (BSAnimationManager::dtor).