### PR TITLE
Fix ni tristrips lua dispatch

### DIFF
--- a/MWSE/NIObject.cpp
+++ b/MWSE/NIObject.cpp
@@ -314,6 +314,21 @@ namespace NI {
 			case RTTIStaticPtr::NiTriShape:
 				ref = sol::make_object_userdata(L, Pointer(static_cast<TriShape*>(this)));
 				break;
+			// Geometry hierarchy: dispatch to the most specific MWSE binding
+			// available. niGeometry and niTriBasedGeometry are abstract types
+			// (per the autocomplete docs); their bindings live in
+			// NIObjectLua.cpp and inherit AVObject's method surface.
+			// Without these cases, a NiTriStrips hit (very common in
+			// Morrowind landscape) walks RTTI all the way down to base
+			// NI::Object, whose metatable lacks getProperty and friends, and
+			// mod-side `rayhit.object:getProperty(...)` errors out.
+			case RTTIStaticPtr::NiTriStrips:
+			case RTTIStaticPtr::NiTriBasedGeom:
+				ref = sol::make_object_userdata(L, Pointer(static_cast<TriBasedGeometry*>(this)));
+				break;
+			case RTTIStaticPtr::NiGeometry:
+				ref = sol::make_object_userdata(L, Pointer(static_cast<Geometry*>(this)));
+				break;
 			case RTTIStaticPtr::NiVertexColorProperty:
 				ref = sol::make_object_userdata(L, Pointer(static_cast<VertexColorProperty*>(this)));
 				break;

--- a/MWSE/NIObjectLua.cpp
+++ b/MWSE/NIObjectLua.cpp
@@ -6,10 +6,12 @@
 #include "NIDefines.h"
 #include "NIAVObject.h"
 #include "NIDynamicEffect.h"
+#include "NIGeometry.h"
 #include "NINode.h"
 #include "NIObject.h"
 #include "NIObjectNET.h"
 #include "NIRTTI.h"
+#include "NITriBasedGeometry.h"
 
 namespace mwse::lua {
 	void bindNIObject() {
@@ -59,6 +61,30 @@ namespace mwse::lua {
 			// Define inheritance structures. These must be defined in order from top to bottom. The complete chain must be defined.
 			usertypeDefinition[sol::base_classes] = sol::bases<NI::ObjectNET, NI::Object>();
 			setUserdataForNIAVObject(usertypeDefinition);
+		}
+
+		// Binding for NI::Geometry. Abstract; matches autocomplete docs that
+		// declare niGeometry as an isAbstract = true class inheriting from
+		// niAVObject. Without this binding, Geometry-derived engine objects
+		// that lack a more specific case in Object::getOrCreateLuaObject
+		// (notably NiTriStrips, used heavily for Morrowind landscape) would
+		// fall all the way through the RTTI walk to base NI::Object userdata,
+		// whose metatable lacks getProperty and other AVObject methods.
+		{
+			auto usertypeDefinition = state.new_usertype<NI::Geometry>("niGeometry");
+			usertypeDefinition["new"] = sol::no_constructor;
+
+			usertypeDefinition[sol::base_classes] = sol::bases<NI::AVObject, NI::ObjectNET, NI::Object>();
+			setUserdataForNIGeometry(usertypeDefinition);
+		}
+
+		// Binding for NI::TriBasedGeometry. Abstract; matches autocomplete docs.
+		{
+			auto usertypeDefinition = state.new_usertype<NI::TriBasedGeometry>("niTriBasedGeometry");
+			usertypeDefinition["new"] = sol::no_constructor;
+
+			usertypeDefinition[sol::base_classes] = sol::bases<NI::Geometry, NI::AVObject, NI::ObjectNET, NI::Object>();
+			setUserdataForNITriBasedGeometry(usertypeDefinition);
 		}
 
 		// Binding for NI::DynamicEffectLinkedList.

--- a/MWSE/NIObjectLua.h
+++ b/MWSE/NIObjectLua.h
@@ -116,5 +116,19 @@ namespace mwse::lua {
 		usertypeDefinition["updateNodeEffects"] = &NI::AVObject::updateEffects;
 	}
 
+	// Speed-optimized binding for NI::Geometry. Abstract class -- no own
+	// members; just chains to AVObject so derived bindings reach AVObject's
+	// surface via the helper (mirrors the autocomplete-documented hierarchy).
+	template <typename T>
+	void setUserdataForNIGeometry(sol::usertype<T>& usertypeDefinition) {
+		setUserdataForNIAVObject(usertypeDefinition);
+	}
+
+	// Speed-optimized binding for NI::TriBasedGeometry. Abstract class.
+	template <typename T>
+	void setUserdataForNITriBasedGeometry(sol::usertype<T>& usertypeDefinition) {
+		setUserdataForNIGeometry(usertypeDefinition);
+	}
+
 	void bindNIObject();
 }

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -1241,6 +1241,69 @@ namespace mwse::patch {
 	const size_t PatchNIDX8Renderer_RenderShape_size = 0x8;
 
 	//
+	// Patch: Fix NiDX8TexturePass::setCTPipelineState always setting the base map
+	// texture coordinate index to 0 instead of reading it from the NIF property.
+	//
+	// Bug at 0x6B42AC: `mov [edi+28h], ebp` hardcodes ebp (=0) into
+	// NiDX8TextureStage::sourceTexcoordIndex (+0x28) for stage[0]. Every other
+	// map type (detail, glow, dark, decal, bump, gloss) correctly reads
+	// NiTexturingProperty::Map::texCoordSet (+0x10) and clamps it to
+	// [0, textureSetCount-1]. The base map skips that read entirely.
+	//
+	// Fix: a 5-byte CALL replaces the buggy 3-byte mov plus the first 2 bytes of
+	// the following `mov [edi+48h], ebp`. A single NOP covers the leftover byte
+	// at 0x6B42B1. The hook reads baseMap->texCoordSet, clamps it, writes it to
+	// stage[0].sourceTexcoordIndex, and replicates the clobbered [edi+48h]=0 write.
+	//
+	// Stack layout on entry (ecx/thiscall frame of 0x6B41B0):
+	//   sub esp,38h + push ebx/ebp/esi/edi → 0x48 total frame
+	//   [esp+0x2C] = NiTexturingProperty*  (var_1C in IDA; caller saved to stack)
+	//   [esp+0x58] = textureSetCount       (arg_10, 5th explicit parameter)
+	// After the CALL at 0x6B42AC pushes a return address (+4):
+	//   [esp+0x30] = NiTexturingProperty*
+	//   [esp+0x5C] = textureSetCount
+	//
+	// NiTexturingProperty::TArray<Map*> maps is at prop+0x1C.
+	// TArray.storage (pointer to element array) is at TArray+0x4 → prop+0x20.
+	// maps.storage[0] is the base Map*; Map::texCoordSet is at Map+0x10.
+	//
+	__declspec(naked) void PatchNiDX8TexturePass_BaseMapTexcoord() {
+		__asm {
+			// edi = NiDX8TextureStage* (stage[0], always valid at this call site)
+			// ebp = 0
+
+			// --- Fix: read baseMap->texCoordSet and clamp ---
+			mov  eax, [esp+0x30]    // eax = NiTexturingProperty* (caller's var_1C)
+			mov  eax, [eax+0x20]    // eax = maps.storage pointer (TArray.storage at prop+0x20)
+			mov  eax, [eax]         // eax = maps.storage[0] = baseMap*
+			test eax, eax
+			jz   use_zero           // baseMap == nullptr → default to 0
+
+			mov  eax, [eax+0x10]    // eax = baseMap->texCoordSet
+
+			// Clamp: if texCoordSet >= textureSetCount, use textureSetCount-1
+			mov  ecx, [esp+0x5C]    // ecx = textureSetCount (caller's arg_10)
+			test ecx, ecx
+			jz   use_zero           // textureSetCount == 0 → clamp to 0
+			cmp  eax, ecx
+			jb   write_index        // texCoordSet < textureSetCount → no clamp needed
+			lea  eax, [ecx-1]       // eax = textureSetCount - 1
+			jmp  write_index
+
+		use_zero:
+			xor  eax, eax
+
+		write_index:
+			mov  [edi+0x28], eax    // stage[0].sourceTexcoordIndex = texCoordSet
+
+			// --- Replicate clobbered instruction: mov [edi+48h], ebp (= 0) ---
+			mov  [edi+0x48], ebp
+
+			ret
+		}
+	}
+
+	//
 	// Patch: Fix cure spells incorrectly triggering MagicEffectState_Ending for magic that hasn't taken effect yet.
 	//
 
@@ -2082,6 +2145,11 @@ namespace mwse::patch {
 		genCallEnforced(0x6E54C5, 0x6F15B0, reinterpret_cast<DWORD>(PatchNITriShapeCopyMembers));
 		writePatchCodeUnprotected(0x6ACF1F, (BYTE*)&PatchNIDX8Renderer_RenderShape, PatchNIDX8Renderer_RenderShape_size);
 		overrideVirtualTableEnforced(0x7508B0, offsetof(NI::TriShape_vTable, NI::TriShape_vTable::linkObject), 0x6E56D0, *reinterpret_cast<DWORD*>(&TriShape_linkObject));
+
+		// Patch: Fix base map texture coordinate index hardcoded to 0 in NiDX8TexturePass::setCTPipelineState.
+		// 0x6B42AC: `mov [edi+28h], ebp` — replace with CALL + NOP the leftover byte at 0x6B42B1.
+		genNOPUnprotected(0x6B42B1, 1);
+		genCallUnprotected(0x6B42AC, reinterpret_cast<DWORD>(PatchNiDX8TexturePass_BaseMapTexcoord));
 
 		// Patch: Fix cure spells incorrectly triggering MagicEffectState_Ending for magic that hasn't taken effect yet.
 		genCallUnprotected(0x4559B2, reinterpret_cast<DWORD>(PatchRemoveMagicsByEffect), 0x8);

--- a/misc/package/Data Files/MWSE/core/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/lib/event.lua
@@ -156,7 +156,7 @@ function this.unregister(eventType, callback, options)
 
 	-- Handle the special case where `doOnce` was used.
 	if doOnceCallbacks[callback] then
-		callback = doOnceCallbacks[callback] 
+		callback = doOnceCallbacks[callback]
 		doOnceCallbacks[callback] = nil -- Won't be needing this anymore.
 	end
 
@@ -192,7 +192,7 @@ function this.isRegistered(eventType, callback, options)
 
 	-- Handle the special case where `doOnce` was used.
 	if doOnceCallbacks[callback] then
-		callback = doOnceCallbacks[callback] 
+		callback = doOnceCallbacks[callback]
 	end
 
 	-- Make sure options is an empty table if nothing else.
@@ -376,25 +376,34 @@ function this.trigger(eventType, payload, options)
 	payload.eventType = eventType
 	payload.eventFilter = options.filter
 
-	local callbacks = table.copy(getEventTable(eventType, options.filter))
-	for _, callback in pairs(callbacks) do
-		-- Inform error notifier of current eventType.
-		errorNotifier.eventType = eventType
+	local t
+	if options.filter ~= nil then
+		local ft = filteredEvents[eventType]
+		t = ft and ft[options.filter]
+	else
+		t = generalEvents[eventType]
+	end
+	local callbacks = t and table.copy(t)
+	if callbacks then
+		for _, callback in pairs(callbacks) do
+			-- Inform error notifier of current eventType.
+			errorNotifier.eventType = eventType
 
-		local status, result = xpcall(callback, onEventError, payload)
-		if (status == false) then
-			result = nil
-		end
+			local status, result = xpcall(callback, onEventError, payload)
+			if (status == false) then
+				result = nil
+			end
 
-		-- Returning non-nil from the callback claims/blocks the event.
-		if (result ~= nil) then
-			payload.claim = true
-			payload.block = true
-		end
+			-- Returning non-nil from the callback claims/blocks the event.
+			if (result ~= nil) then
+				payload.claim = true
+				payload.block = true
+			end
 
-		-- If the event is claimed, do not excute any further events.
-		if (payload.claim) then
-			return payload
+			-- If the event is claimed, do not excute any further events.
+			if (payload.claim) then
+				return payload
+			end
 		end
 	end
 

--- a/misc/package/Data Files/MWSE/core/lib/event.lua
+++ b/misc/package/Data Files/MWSE/core/lib/event.lua
@@ -376,15 +376,10 @@ function this.trigger(eventType, payload, options)
 	payload.eventType = eventType
 	payload.eventFilter = options.filter
 
-	local t
-	if options.filter ~= nil then
-		local ft = filteredEvents[eventType]
-		t = ft and ft[options.filter]
-	else
-		t = generalEvents[eventType]
-	end
-	local callbacks = t and table.copy(t)
-	if callbacks then
+	local filteredCallbacks = getEventTable(eventType, options.filter)
+	-- If events have registered a filter, then run them now. Otherwise, skip this section.
+	if #filteredCallbacks > 0 then
+		local callbacks = table.copy(filteredCallbacks)
 		for _, callback in pairs(callbacks) do
 			-- Inform error notifier of current eventType.
 			errorNotifier.eventType = eventType


### PR DESCRIPTION
[MWSE] Fix lua dispatch for NiTriStrips, add niGeometry/niTriBasedGeometry sol bindings
NI::Object::getOrCreateLuaObject walks the engine RTTI chain looking
for a known type to wrap as a sol userdata. The dispatch table covered
NiTriShape and NiLines but not NiTriStrips -- which Morrowind uses
heavily for landscape and many static meshes.

When tes3.rayTest hit a NiTriStrips, the RTTI walk would fall all the
way to base NI::Object (because none of NiTriStrips, NiTriBasedGeom,
NiGeometry have explicit cases). The base NI::Object metatable lacks
getProperty / name / parent / etc., so mods doing standard pick-result
processing -- e.g. Character Sound Overhaul's getFloorTexture's
`rayhit.object:getProperty(0x4)`, or Ashfall's activator detection --
errored out with "attempt to index field 'object' (a userdata value)"
on every landscape pick. ~37-46% of raycasts produced this error in a
mid-density urban scene.

The autocomplete docs declare niGeometry and niTriBasedGeometry as
abstract classes (isAbstract = true) inheriting niAVObject, but
neither was registered as a sol usertype -- a silent docs/bindings
inconsistency. Fix it properly so the dispatch can land on the most
specific bound parent:

- NIObjectLua.h: add setUserdataForNIGeometry / setUserdataForNITriBasedGeometry
  helpers that chain through to setUserdataForNIAVObject (no own members,
  matching the docs' abstract status).
- NIObjectLua.cpp: register new_usertype<NI::Geometry>("niGeometry") and
  new_usertype<NI::TriBasedGeometry>("niTriBasedGeometry") with the
  correct sol::base_classes chains.
- NIObject.cpp: dispatch NiGeometry -> Geometry*, NiTriStrips/NiTriBasedGeom
  -> TriBasedGeometry*. Lua callers now get the most specific bound type
  for any geometry hit (instead of falling through to base Object).

Also re-establishes MWSE/NIPick.h as a shim to ../SharedSE/NIPick.h --
the prior commit had inadvertently captured an intermediate diagnostic-
revert state of that file.

Pre-existing on master; surfaced cleanly during Phase E.B.3 smoke
testing. Independent of the SharedSE NI unification work.