### PR TITLE
[MWSE] Fix lua dispatch for NiTriStrips, add niGeometry/niTriBasedGeometry sol bindings

### DIFF
--- a/MWSE/NIObject.cpp
+++ b/MWSE/NIObject.cpp
@@ -314,6 +314,21 @@ namespace NI {
 			case RTTIStaticPtr::NiTriShape:
 				ref = sol::make_object_userdata(L, Pointer(static_cast<TriShape*>(this)));
 				break;
+			// Geometry hierarchy: dispatch to the most specific MWSE binding
+			// available. niGeometry and niTriBasedGeometry are abstract types
+			// (per the autocomplete docs); their bindings live in
+			// NIObjectLua.cpp and inherit AVObject's method surface.
+			// Without these cases, a NiTriStrips hit (very common in
+			// Morrowind landscape) walks RTTI all the way down to base
+			// NI::Object, whose metatable lacks getProperty and friends, and
+			// mod-side `rayhit.object:getProperty(...)` errors out.
+			case RTTIStaticPtr::NiTriStrips:
+			case RTTIStaticPtr::NiTriBasedGeom:
+				ref = sol::make_object_userdata(L, Pointer(static_cast<TriBasedGeometry*>(this)));
+				break;
+			case RTTIStaticPtr::NiGeometry:
+				ref = sol::make_object_userdata(L, Pointer(static_cast<Geometry*>(this)));
+				break;
 			case RTTIStaticPtr::NiVertexColorProperty:
 				ref = sol::make_object_userdata(L, Pointer(static_cast<VertexColorProperty*>(this)));
 				break;

--- a/MWSE/NIObjectLua.cpp
+++ b/MWSE/NIObjectLua.cpp
@@ -6,10 +6,12 @@
 #include "NIDefines.h"
 #include "NIAVObject.h"
 #include "NIDynamicEffect.h"
+#include "NIGeometry.h"
 #include "NINode.h"
 #include "NIObject.h"
 #include "NIObjectNET.h"
 #include "NIRTTI.h"
+#include "NITriBasedGeometry.h"
 
 namespace mwse::lua {
 	void bindNIObject() {
@@ -59,6 +61,30 @@ namespace mwse::lua {
 			// Define inheritance structures. These must be defined in order from top to bottom. The complete chain must be defined.
 			usertypeDefinition[sol::base_classes] = sol::bases<NI::ObjectNET, NI::Object>();
 			setUserdataForNIAVObject(usertypeDefinition);
+		}
+
+		// Binding for NI::Geometry. Abstract; matches autocomplete docs that
+		// declare niGeometry as an isAbstract = true class inheriting from
+		// niAVObject. Without this binding, Geometry-derived engine objects
+		// that lack a more specific case in Object::getOrCreateLuaObject
+		// (notably NiTriStrips, used heavily for Morrowind landscape) would
+		// fall all the way through the RTTI walk to base NI::Object userdata,
+		// whose metatable lacks getProperty and other AVObject methods.
+		{
+			auto usertypeDefinition = state.new_usertype<NI::Geometry>("niGeometry");
+			usertypeDefinition["new"] = sol::no_constructor;
+
+			usertypeDefinition[sol::base_classes] = sol::bases<NI::AVObject, NI::ObjectNET, NI::Object>();
+			setUserdataForNIGeometry(usertypeDefinition);
+		}
+
+		// Binding for NI::TriBasedGeometry. Abstract; matches autocomplete docs.
+		{
+			auto usertypeDefinition = state.new_usertype<NI::TriBasedGeometry>("niTriBasedGeometry");
+			usertypeDefinition["new"] = sol::no_constructor;
+
+			usertypeDefinition[sol::base_classes] = sol::bases<NI::Geometry, NI::AVObject, NI::ObjectNET, NI::Object>();
+			setUserdataForNITriBasedGeometry(usertypeDefinition);
 		}
 
 		// Binding for NI::DynamicEffectLinkedList.

--- a/MWSE/NIObjectLua.h
+++ b/MWSE/NIObjectLua.h
@@ -116,5 +116,19 @@ namespace mwse::lua {
 		usertypeDefinition["updateNodeEffects"] = &NI::AVObject::updateEffects;
 	}
 
+	// Speed-optimized binding for NI::Geometry. Abstract class -- no own
+	// members; just chains to AVObject so derived bindings reach AVObject's
+	// surface via the helper (mirrors the autocomplete-documented hierarchy).
+	template <typename T>
+	void setUserdataForNIGeometry(sol::usertype<T>& usertypeDefinition) {
+		setUserdataForNIAVObject(usertypeDefinition);
+	}
+
+	// Speed-optimized binding for NI::TriBasedGeometry. Abstract class.
+	template <typename T>
+	void setUserdataForNITriBasedGeometry(sol::usertype<T>& usertypeDefinition) {
+		setUserdataForNIGeometry(usertypeDefinition);
+	}
+
 	void bindNIObject();
 }


### PR DESCRIPTION
NI::Object::getOrCreateLuaObject walks the engine RTTI chain looking
for a known type to wrap as a sol userdata. The dispatch table covered
NiTriShape and NiLines but not NiTriStrips -- which Morrowind uses
heavily for landscape and many static meshes.

When tes3.rayTest hit a NiTriStrips, the RTTI walk would fall all the
way to base NI::Object (because none of NiTriStrips, NiTriBasedGeom,
NiGeometry have explicit cases). The base NI::Object metatable lacks
getProperty / name / parent / etc., so mods doing standard pick-result
processing -- e.g. Character Sound Overhaul's getFloorTexture's
`rayhit.object:getProperty(0x4)`, or Ashfall's activator detection --
errored out with "attempt to index field 'object' (a userdata value)"
on every landscape pick. ~37-46% of raycasts produced this error in a
mid-density urban scene.

The autocomplete docs declare niGeometry and niTriBasedGeometry as
abstract classes (isAbstract = true) inheriting niAVObject, but
neither was registered as a sol usertype -- a silent docs/bindings
inconsistency. Fix it properly so the dispatch can land on the most
specific bound parent:

- NIObjectLua.h: add setUserdataForNIGeometry / setUserdataForNITriBasedGeometry
  helpers that chain through to setUserdataForNIAVObject (no own members,
  matching the docs' abstract status).
- NIObjectLua.cpp: register new_usertype<NI::Geometry>("niGeometry") and
  new_usertype<NI::TriBasedGeometry>("niTriBasedGeometry") with the
  correct sol::base_classes chains.
- NIObject.cpp: dispatch NiGeometry -> Geometry*, NiTriStrips/NiTriBasedGeom
  -> TriBasedGeometry*. Lua callers now get the most specific bound type
  for any geometry hit (instead of falling through to base Object).

Also re-establishes MWSE/NIPick.h as a shim to ../SharedSE/NIPick.h --
the prior commit had inadvertently captured an intermediate diagnostic-
revert state of that file.

Pre-existing on master; surfaced cleanly during Phase E.B.3 smoke
testing. Independent of the SharedSE NI unification work.
