### PR TITLE
Adress PR #678 review

### DIFF
--- a/MWSE/TES3MagicEffect.cpp
+++ b/MWSE/TES3MagicEffect.cpp
@@ -435,7 +435,7 @@ namespace TES3 {
 		return *this;
 	}
 
-	Effect& Effect::operator=(const sol::table table) {
+	Effect& Effect::operator=(const sol::table& table) {
 		effectID = table.get_or("id", EffectID::None);
 		skillID = table.get_or("skill", SkillID::Invalid);
 		attributeID = table.get_or("attribute", Attribute::Invalid);
@@ -447,7 +447,7 @@ namespace TES3 {
 		return *this;
 	}
 
-	Effect& Effect::operator=(const sol::object object) {
+	Effect& Effect::operator=(const sol::object& object) {
 		if (object.is<Effect>()) {
 			*this = object.as<Effect>();
 		}

--- a/MWSE/TES3MagicEffect.h
+++ b/MWSE/TES3MagicEffect.h
@@ -367,8 +367,8 @@ namespace TES3 {
 		Effect(const sol::table& from);
 
 		Effect& operator=(const Effect& vector);
-		Effect& operator=(const sol::table table);
-		Effect& operator=(const sol::object object);
+		Effect& operator=(const sol::table& table);
+		Effect& operator=(const sol::object& object);
 
 		bool operator==(const Effect& vector) const;
 		bool operator!=(const Effect& vector) const;

--- a/SharedSE/NIColor.cpp
+++ b/SharedSE/NIColor.cpp
@@ -51,7 +51,7 @@ namespace NI {
 	}
 
 #if defined(SE_USE_LUA) && SE_USE_LUA == 1
-	Color::Color(sol::table table) {
+	Color::Color(const sol::table& table) {
 		r = table.get_or("r", table.get_or(1, 0.0f));
 		g = table.get_or("g", table.get_or(2, 0.0f));
 		b = table.get_or("b", table.get_or(3, 0.0f));
@@ -84,7 +84,7 @@ namespace NI {
 	}
 
 #if defined(SE_USE_LUA) && SE_USE_LUA == 1
-	Color& Color::operator=(const sol::table table) {
+	Color& Color::operator=(const sol::table& table) {
 		r = table.get_or("r", table.get_or(1, 0.0f));
 		g = table.get_or("g", table.get_or(2, 0.0f));
 		b = table.get_or("b", table.get_or(3, 0.0f));

--- a/SharedSE/NIColor.h
+++ b/SharedSE/NIColor.h
@@ -32,13 +32,13 @@ namespace NI {
 		Color(const ColorA& c);
 		Color(const Point3& vector);
 #if defined(SE_USE_LUA) && SE_USE_LUA == 1
-		Color(sol::table table);
+		Color(const sol::table& table);
 		Color(const sol::object& object);
 #endif
 
 		Color& operator=(const Point3& vector);
 #if defined(SE_USE_LUA) && SE_USE_LUA == 1
-		Color& operator=(const sol::table table);
+		Color& operator=(const sol::table& table);
 		Color& operator=(const sol::object& object);
 #endif
 

--- a/SharedSE/NIMatrix33.cpp
+++ b/SharedSE/NIMatrix33.cpp
@@ -30,16 +30,11 @@ namespace NI {
 		m2 = *in_m2;
 	}
 
-	Matrix33::Matrix33(float m0x, float m0y, float m0z, float m1x, float m1y, float m1z, float m2x, float m2y, float m2z) {
-		m0.x = m0x;
-		m0.y = m0y;
-		m0.z = m0z;
-		m1.x = m1x;
-		m1.y = m1y;
-		m1.z = m1z;
-		m2.x = m2x;
-		m2.y = m2y;
-		m2.z = m2z;
+	Matrix33::Matrix33(float m0x, float m0y, float m0z, float m1x, float m1y, float m1z, float m2x, float m2y, float m2z) :
+		m0(m0x, m0y, m0z),
+		m1(m1x, m1y, m1z),
+		m2(m2x, m2y, m2z)
+	{
 	}
 
 	Matrix33::Matrix33(const Quaternion& quaternion) {
@@ -73,7 +68,7 @@ namespace NI {
 	}
 
 	bool Matrix33::operator!=(const Matrix33& matrix) const {
-		return !operator==(matrix);
+		return m0 != matrix.m0 || m1 != matrix.m1 || m2 != matrix.m2;
 	}
 
 	Matrix33 Matrix33::operator+(const Matrix33& matrix) const {

--- a/SharedSE/NITriangle.cpp
+++ b/SharedSE/NITriangle.cpp
@@ -16,7 +16,7 @@ namespace NI {
 		*this = table;
 	}
 
-	Triangle& Triangle::operator=(const sol::table table) {
+	Triangle& Triangle::operator=(const sol::table& table) {
 		for (auto i = 0; i < 3; ++i) {
 			vertices[i] = table.get_or(i + 1, 0);
 		}

--- a/SharedSE/NITriangle.h
+++ b/SharedSE/NITriangle.h
@@ -9,7 +9,7 @@ namespace NI {
 #if defined(SE_USE_LUA) && SE_USE_LUA == 1
 		Triangle(const sol::table table);
 
-		Triangle& operator=(const sol::table table);
+		Triangle& operator=(const sol::table& table);
 #endif
 
 		std::reference_wrapper<unsigned short[3]> getVertices();


### PR DESCRIPTION
Changed Matrix33::operator!= as suggested. 
Use direct-initialization in the Matrix33 constructor from 9 floats.
Change all the other occurrences of constructors/operator= taking sol objects to take them as const references.