### PR TITLE
Fix channel order in pixelData from niRenderer::takeScreenshot

### DIFF
--- a/SharedSE/NIRenderer.cpp
+++ b/SharedSE/NIRenderer.cpp
@@ -1,5 +1,7 @@
 #include "NIRenderer.h"
 
+#include "NIPixelData.h"
+
 namespace NI {
 	char* Renderer::getDriverInfo() {
 		return vTable.asRenderer->getDriverInfo(this);
@@ -26,7 +28,24 @@ namespace NI {
 	}
 
 	PixelData* Renderer::takeScreenshot(const Rect<unsigned int>* bounds) {
-		return vTable.asRenderer->takeScreenshot(this, bounds);
+		auto pixelData = vTable.asRenderer->takeScreenshot(this, bounds);
+		if (pixelData == nullptr) {
+			return nullptr;
+		}
+		const auto desiredFormat = pixelData->pixelFormat.getD3DFormat();
+
+		// For some reason the game needs to swap B and R pixels.
+		// See paper doll code, or around 0x42F939.
+		if (desiredFormat == D3DFMT_X8R8G8B8) {
+			const auto pixels = reinterpret_cast<PixelRGBA*>(pixelData->pixels);
+			const auto pixelCount = pixelData->getWidth() * pixelData->getHeight();
+			for (auto i = 0u; i < pixelCount; ++i) {
+				auto& pixel = pixels[i];
+				std::swap(pixel.r, pixel.b);
+			}
+		}
+
+		return pixelData;
 	}
 
 	bool Renderer::getTextureMemoryStats(unsigned int& total, unsigned int& available) {

--- a/SharedSE/NIRenderer.cpp
+++ b/SharedSE/NIRenderer.cpp
@@ -29,6 +29,8 @@ namespace NI {
 
 	PixelData* Renderer::takeScreenshot(const Rect<unsigned int>* bounds) {
 		auto pixelData = vTable.asRenderer->takeScreenshot(this, bounds);
+
+#if defined(SE_IS_MWSE)
 		if (pixelData == nullptr) {
 			return nullptr;
 		}
@@ -44,7 +46,7 @@ namespace NI {
 				std::swap(pixel.r, pixel.b);
 			}
 		}
-
+#endif
 		return pixelData;
 	}
 

--- a/SharedSE/NIRenderer.cpp
+++ b/SharedSE/NIRenderer.cpp
@@ -30,7 +30,7 @@ namespace NI {
 	PixelData* Renderer::takeScreenshot(const Rect<unsigned int>* bounds) {
 		auto pixelData = vTable.asRenderer->takeScreenshot(this, bounds);
 
-#if defined(SE_IS_MWSE)
+#if defined(SE_IS_MWSE) && SE_IS_MWSE == 1
 		if (pixelData == nullptr) {
 			return nullptr;
 		}


### PR DESCRIPTION
The actual RGBA data that the engine receives from DX is in a different order than assumed. The color channel order is now fixed before returning new pixel data.

Refer to https://github.com/MWSE/MWSE/commit/683f5947858d8a1cf32021722b3c7806be7d9f76 and #646 for more info.