### PR TITLE
Updates to node traverse method

### DIFF
--- a/MWSE/NINodeLua.cpp
+++ b/MWSE/NINodeLua.cpp
@@ -4,13 +4,30 @@
 #include "LuaUtil.h"
 #include "StringUtil.h"
 
+#include "NIAVObject.h"
 #include "NIBillboardNode.h"
 #include "NIDefines.h"
 #include "NINode.h"
 #include "NISortAdjustNode.h"
 
+namespace {
+	bool passesTraverseFilters(const NI::AVObject* object, const std::unordered_set<unsigned int>& typeFilters, std::string_view prefix) {
+		bool passesFilter = typeFilters.empty() ? true : false;
+		if (!passesFilter) {
+			for (const auto type : typeFilters) {
+				if (object->isInstanceOfType((uintptr_t)type)) {
+					passesFilter = true;
+					break;
+				}
+			}
+		}
+		bool passesPrefix = prefix.empty() ? true : object->name && se::string::starts_with(object->name, prefix);
+		return passesFilter && passesPrefix;
+	}
+}
+
 namespace mwse::lua {
-	std::function<NI::Pointer<NI::AVObject>()> traverse(const NI::Node* self, sol::optional<sol::table> param) {
+	std::function<NI::Pointer<NI::AVObject>()> traverse(NI::Node* self, sol::optional<sol::table> param) {
 		bool recursive = getOptionalParam(param, "recursive", true);
 		std::string prefix = getOptionalParam(param, "prefix", std::string(""));
 		std::unordered_set<unsigned int> filters;
@@ -42,49 +59,20 @@ namespace mwse::lua {
 			}
 
 			const auto asNode = static_cast<const NI::Node*>(object);
-			for (auto& nodeChild : asNode->children) {
-				if (!nodeChild) {
-					continue;
-				}
-				bool passesFilter = filters.empty() ? true : false;
-				if (!passesFilter) {
-					for (const auto type : filters) {
-						if (nodeChild->isInstanceOfType((uintptr_t)type)) {
-							passesFilter = true;
-							break;
-						}
-					}
-				}
-				bool passesPrefix = prefix.empty() ? true : nodeChild->name && se::string::starts_with(nodeChild->name, prefix);
-				if (passesFilter && passesPrefix) {
+			for (const auto& nodeChild : asNode->children) {
+				if (passesTraverseFilters(nodeChild, filters, prefix)) {
 					queue.push(nodeChild);
 				}
-
-				traverseChild(nodeChild);
-			}
-			};
-
-		for (auto& child : self->children) {
-			if (!child) {
-				continue;
-			}
-			bool passesFilter = filters.empty() ? true : false;
-			if (!passesFilter) {
-				for (const auto type : filters) {
-					if (child->isInstanceOfType((uintptr_t)type)) {
-						passesFilter = true;
-						break;
-					}
+				if (recursive) {
+					traverseChild(nodeChild);
 				}
 			}
-			bool passesPrefix = prefix.empty() ? true : child->name && se::string::starts_with(child->name, prefix);
-			if (passesFilter && passesPrefix) {
-				queue.push(child);
-			}
-			if (recursive) {
-				traverseChild(child);
-			}
+		};
+
+		if (passesTraverseFilters(self, filters, prefix)) {
+			queue.push(self);
 		}
+		traverseChild(self);
 
 		return [queue]() mutable -> NI::Pointer<NI::AVObject> {
 			if (queue.empty()) {
@@ -93,7 +81,7 @@ namespace mwse::lua {
 			auto ret = queue.front();
 			queue.pop();
 			return ret;
-			};
+		};
 	}
 
 	void bindNINode() {

--- a/MWSE/NINodeLua.cpp
+++ b/MWSE/NINodeLua.cpp
@@ -1,89 +1,13 @@
 #include "NINodeLua.h"
 
 #include "LuaManager.h"
-#include "LuaUtil.h"
-#include "StringUtil.h"
 
 #include "NIAVObject.h"
 #include "NIBillboardNode.h"
-#include "NIDefines.h"
 #include "NINode.h"
 #include "NISortAdjustNode.h"
 
-namespace {
-	bool passesTraverseFilters(const NI::AVObject* object, const std::unordered_set<unsigned int>& typeFilters, std::string_view prefix) {
-		bool passesFilter = typeFilters.empty() ? true : false;
-		if (!passesFilter) {
-			for (const auto type : typeFilters) {
-				if (object->isInstanceOfType((uintptr_t)type)) {
-					passesFilter = true;
-					break;
-				}
-			}
-		}
-		bool passesPrefix = prefix.empty() ? true : object->name && se::string::starts_with(object->name, prefix);
-		return passesFilter && passesPrefix;
-	}
-}
-
 namespace mwse::lua {
-	std::function<NI::Pointer<NI::AVObject>()> traverse(NI::Node* self, sol::optional<sol::table> param) {
-		bool recursive = getOptionalParam(param, "recursive", true);
-		std::string prefix = getOptionalParam(param, "prefix", std::string(""));
-		std::unordered_set<unsigned int> filters;
-
-		if (param) {
-			sol::table paramTable = param.value().as<sol::table>();
-			sol::object maybeValue = paramTable["type"];
-			if (maybeValue.valid()) {
-				if (maybeValue.is<unsigned int>()) {
-					filters.insert(maybeValue.as<unsigned int>());
-				}
-				else if (maybeValue.is<sol::table>()) {
-					sol::table filterTable = maybeValue.as<sol::table>();
-					for (auto [_, value] : filterTable) {
-						filters.insert(value.as<unsigned int>());
-					}
-				}
-				else {
-					throw std::invalid_argument("Iteration can only be filtered by a NI object type, or a table of object types.");
-				}
-			}
-		}
-
-
-		std::queue<NI::Pointer<NI::AVObject>> queue;
-		std::function<void(const NI::AVObject*)> traverseChild = [&](const NI::AVObject* object) {
-			if (!object->isInstanceOfType(NI::RTTIStaticPtr::NiNode)) {
-				return;
-			}
-
-			const auto asNode = static_cast<const NI::Node*>(object);
-			for (const auto& nodeChild : asNode->children) {
-				if (passesTraverseFilters(nodeChild, filters, prefix)) {
-					queue.push(nodeChild);
-				}
-				if (recursive) {
-					traverseChild(nodeChild);
-				}
-			}
-		};
-
-		if (passesTraverseFilters(self, filters, prefix)) {
-			queue.push(self);
-		}
-		traverseChild(self);
-
-		return [queue]() mutable -> NI::Pointer<NI::AVObject> {
-			if (queue.empty()) {
-				return nullptr;
-			}
-			auto ret = queue.front();
-			queue.pop();
-			return ret;
-		};
-	}
-
 	void bindNINode() {
 		// Get our lua state.
 		const auto stateHandle = LuaManager::getInstance().getThreadSafeStateHandle();

--- a/MWSE/NINodeLua.h
+++ b/MWSE/NINodeLua.h
@@ -4,8 +4,6 @@
 #include "NIDynamicEffect.h"
 
 namespace mwse::lua {
-	std::function<NI::Pointer<NI::AVObject>()> traverse(NI::Node* self, sol::optional<sol::table> param);
-
 	template <typename T>
 	void setUserdataForNINode(sol::usertype<T>& usertypeDefinition) {
 		setUserdataForNIAVObject(usertypeDefinition);
@@ -24,7 +22,6 @@ namespace mwse::lua {
 		usertypeDefinition["detachChildAt"] = &NI::Node::detachChildAt_lua;
 		usertypeDefinition["detachEffect"] = &NI::Node::detachEffect;
 		usertypeDefinition["getEffect"] = &NI::Node::getEffect;
-		usertypeDefinition["traverse"] = traverse;
 	}
 
 	void bindNINode();

--- a/MWSE/NINodeLua.h
+++ b/MWSE/NINodeLua.h
@@ -4,7 +4,7 @@
 #include "NIDynamicEffect.h"
 
 namespace mwse::lua {
-	std::function<NI::Pointer<NI::AVObject>()> traverse(const NI::Node* self, sol::optional<sol::table> param);
+	std::function<NI::Pointer<NI::AVObject>()> traverse(NI::Node* self, sol::optional<sol::table> param);
 
 	template <typename T>
 	void setUserdataForNINode(sol::usertype<T>& usertypeDefinition) {

--- a/MWSE/NIObjectLua.cpp
+++ b/MWSE/NIObjectLua.cpp
@@ -11,7 +11,83 @@
 #include "NIObjectNET.h"
 #include "NIRTTI.h"
 
+#include "StringUtil.h"
+
+
+namespace {
+	bool passesTraverseFilters(const NI::AVObject* object, const std::unordered_set<unsigned int>& typeFilters, std::string_view prefix) {
+		bool passesFilter = typeFilters.empty() ? true : false;
+		if (!passesFilter) {
+			for (const auto type : typeFilters) {
+				if (object->isInstanceOfType((uintptr_t)type)) {
+					passesFilter = true;
+					break;
+				}
+			}
+		}
+		bool passesPrefix = prefix.empty() ? true : object->name && se::string::starts_with(object->name, prefix);
+		return passesFilter && passesPrefix;
+	}
+}
+
 namespace mwse::lua {
+	std::function<NI::Pointer<NI::AVObject>()> traverse(NI::AVObject* self, sol::optional<sol::table> param) {
+		bool recursive = getOptionalParam(param, "recursive", true);
+		std::string prefix = getOptionalParam(param, "prefix", std::string(""));
+		std::unordered_set<unsigned int> filters;
+
+		if (param) {
+			sol::table paramTable = param.value().as<sol::table>();
+			sol::object maybeValue = paramTable["type"];
+			if (maybeValue.valid()) {
+				if (maybeValue.is<unsigned int>()) {
+					filters.insert(maybeValue.as<unsigned int>());
+				}
+				else if (maybeValue.is<sol::table>()) {
+					sol::table filterTable = maybeValue.as<sol::table>();
+					for (auto [_, value] : filterTable) {
+						filters.insert(value.as<unsigned int>());
+					}
+				}
+				else {
+					throw std::invalid_argument("Iteration can only be filtered by a NI object type, or a table of object types.");
+				}
+			}
+		}
+
+
+		std::queue<NI::Pointer<NI::AVObject>> queue;
+		std::function<void(const NI::AVObject*)> traverseChild = [&](const NI::AVObject* object) {
+			if (!object->isInstanceOfType(NI::RTTIStaticPtr::NiNode)) {
+				return;
+			}
+
+			const auto asNode = static_cast<const NI::Node*>(object);
+			for (const auto& nodeChild : asNode->children) {
+				if (passesTraverseFilters(nodeChild, filters, prefix)) {
+					queue.push(nodeChild);
+				}
+				if (recursive) {
+					traverseChild(nodeChild);
+				}
+			}
+		};
+
+		if (passesTraverseFilters(self, filters, prefix)) {
+			queue.push(self);
+		}
+		traverseChild(self);
+
+		return [queue]() mutable -> NI::Pointer<NI::AVObject> {
+			if (queue.empty()) {
+				return nullptr;
+			}
+			auto ret = queue.front();
+			queue.pop();
+			return ret;
+		};
+	}
+
 	void bindNIObject() {
 		// Get our lua state.
 		const auto stateHandle = LuaManager::getInstance().getThreadSafeStateHandle();

--- a/MWSE/NIObjectLua.cpp
+++ b/MWSE/NIObjectLua.cpp
@@ -25,7 +25,7 @@ namespace {
 				}
 			}
 		}
-		bool passesPrefix = prefix.empty() ? true : object->name && se::string::starts_with(object->name, prefix);
+		bool passesPrefix = prefix.empty() ? true : object->name && se::string::istarts_with(object->name, prefix);
 		return passesFilter && passesPrefix;
 	}
 }

--- a/MWSE/NIObjectLua.h
+++ b/MWSE/NIObjectLua.h
@@ -8,6 +8,8 @@
 #include "TES3Reference.h"
 
 namespace mwse::lua {
+	std::function<NI::Pointer<NI::AVObject>()> traverse(NI::AVObject* self, sol::optional<sol::table> param);
+
 	// Speed-optimized binding for NI::Object.
 	template <typename T>
 	void setUserdataForNIObject(sol::usertype<T>& usertypeDefinition) {
@@ -83,6 +85,7 @@ namespace mwse::lua {
 		usertypeDefinition["updateEffects"] = &NI::AVObject::updateEffects;
 		usertypeDefinition["updateProperties"] = &NI::AVObject::updateProperties;
 		usertypeDefinition["setFlag"] = &NI::AVObject::setFlag;
+		usertypeDefinition["traverse"] = traverse;
 
 		// Functions that need their results wrapped.
 		usertypeDefinition["getObjectByName"] = &NI::AVObject::getObjectByName;

--- a/SharedSE/StringUtil.cpp
+++ b/SharedSE/StringUtil.cpp
@@ -85,6 +85,20 @@ namespace se::string {
 		return std::equal(a.begin(), a.begin() + maxCount, b.begin(), b.begin() + maxCount, ciequal);
 	}
 
+	bool istarts_with(std::string_view string, std::string_view substring) {
+		if (substring.size() > string.size()) {
+			return false;
+		}
+		size_t i = 0;
+		for (auto c : substring) {
+			if (!ciequal(string[i], c)) {
+				return false;
+			}
+			++i;
+		}
+		return true;
+	}
+
 	bool starts_with(const std::string_view& string, const std::string_view& substring) {
 		if (substring.size() >= string.size()) {
 			return false;

--- a/SharedSE/StringUtil.h
+++ b/SharedSE/StringUtil.h
@@ -33,6 +33,7 @@ namespace se::string {
 	// Returns true if a == b, case insensitive, only compares maxCount characters.
 	bool niequal(std::string_view a, std::string_view b, size_t maxCount);
 
+	bool istarts_with(std::string_view string, std::string_view substring);
 	bool starts_with(const std::string_view& string, const std::string_view& substring);
 	bool ends_with(const std::string_view& string, const std::string_view& substring);
 


### PR DESCRIPTION
Based on input from Greatness7:

- Refactored to reduce the amount of code duplication.
- Moved the method to niAVObject so it can be safely called on any kind of object in the scene graph.
- Made prefix check case-insensitive.