### PR TITLE
sol_lua_push: add rvalue overloads for /permissive-

### DIFF
--- a/MWSE/TES3UIElement.cpp
+++ b/MWSE/TES3UIElement.cpp
@@ -1578,10 +1578,6 @@ namespace TES3::UI {
 
 }
 
-int sol_lua_push(sol::types<TES3::UI::Element>, lua_State* L, TES3::UI::Element& obj) {
-	return obj.getOrCreateLuaObject(L).push(L);
-}
-
 int sol_lua_push(sol::types<TES3::UI::Element*>, lua_State* L, TES3::UI::Element* obj) {
 	if (obj == nullptr) {
 		return sol::stack::push(L, sol::nil);

--- a/MWSE/TES3UIElement.h
+++ b/MWSE/TES3UIElement.h
@@ -14,7 +14,6 @@ namespace TES3::UI {
 	struct Element;
 }
 
-int sol_lua_push(sol::types<TES3::UI::Element>, lua_State* L, TES3::UI::Element& obj);
 int sol_lua_push(sol::types<TES3::UI::Element*>, lua_State* L, TES3::UI::Element* obj);
 
 namespace TES3::UI {

--- a/SharedSE/NIObject.h
+++ b/SharedSE/NIObject.h
@@ -6,19 +6,20 @@
 #include "NITArray.h"
 
 #if defined(SE_USE_LUA) && SE_USE_LUA == 1
-// Must be added to header files that declare Ni types that can be derived.
+// Pointer overloads only. `Pointer<T>` is returned by value from C++ APIs,
+// so the rvalue overload is required under /permissive- (lvalue ref alone
+// won't bind to prvalues, and sol2 silently falls back to base usertype).
 #define MWSE_SOL_CUSTOMIZED_PUSHER_DECLARE_NI(T) \
-int sol_lua_push(sol::types<T>, lua_State* L, T& obj); \
 int sol_lua_push(sol::types<T*>, lua_State* L, T* obj); \
 int sol_lua_push(sol::types<NI::Pointer<T>>, lua_State* L, NI::Pointer<T>& obj); \
+int sol_lua_push(sol::types<NI::Pointer<T>>, lua_State* L, NI::Pointer<T>&& obj); \
 int sol_lua_push(sol::types<NI::Pointer<T>*>, lua_State* L, NI::Pointer<T>* obj);
 
-// Must be added to source files that declare Ni types that can be derived.
 #define MWSE_SOL_CUSTOMIZED_PUSHER_DEFINE_NI(T) \
-int sol_lua_push(sol::types<T>, lua_State* L, T& obj) { return obj.getOrCreateLuaObject(L).push(L); } \
 int sol_lua_push(sol::types<T*>, lua_State* L, T* obj) { return obj->getOrCreateLuaObject(L).push(L); } \
 int sol_lua_push(sol::types<NI::Pointer<T>>, lua_State* L, NI::Pointer<T>& obj) { return obj->getOrCreateLuaObject(L).push(L); } \
-int sol_lua_push(sol::types<NI::Pointer<T>*>, lua_State* L, NI::Pointer<T>* obj) { return obj->get()->getOrCreateLuaObject(L).push(L); } 
+int sol_lua_push(sol::types<NI::Pointer<T>>, lua_State* L, NI::Pointer<T>&& obj) { return obj->getOrCreateLuaObject(L).push(L); } \
+int sol_lua_push(sol::types<NI::Pointer<T>*>, lua_State* L, NI::Pointer<T>* obj) { return obj->get()->getOrCreateLuaObject(L).push(L); }
 #endif
 
 namespace NI {


### PR DESCRIPTION
Fixes properties on `getProperty()` return values reading as nil under /std:c++20 (sol2 was falling through to base usertype). Repro and details in the commit message.