### PR TITLE
Allow turning on/off "Radius-Aware Texture Painting" in CSSE settings.

### DIFF
--- a/CSSE/DialogCSSESettings.cpp
+++ b/CSSE/DialogCSSESettings.cpp
@@ -69,6 +69,10 @@ BOOL DialogCSSESettings::OnInitDialog() {
 	groupRenderWindow->AddSubItem(new CDataBoundPropertyGridProperty("Use Group Scaling", &se::cs::settings.render_window.use_group_scaling, "If true, all selected objects will be scaled together, and move appropriately to keep consistent spacing. The CS by default scales items independently and keep them in-place."));
 	m_PropertyGrid.AddProperty(groupRenderWindow);
 
+	auto groupLandscapeWindow = new CMFCPropertyGridProperty("Landscape Window");
+	groupLandscapeWindow->AddSubItem(new CDataBoundPropertyGridProperty("Radius-Aware Texture Painting", &se::cs::settings.landscape_window.radius_aware_texture_painting_enabled, "If true, texture painting applies across the landscape edit radius. If false, texture painting uses the Construction Set's vanilla single-tile behavior."));
+	m_PropertyGrid.AddProperty(groupLandscapeWindow);
+
 	/*
 	auto groupScriptEditor = new CMFCPropertyGridProperty("Script Editor");
 	groupScriptEditor->AddSubItem(new CMFCPropertyGridFontProperty("Font", &se::cs::settings.script_editor.font_face, CF_SCREENFONTS, "The font to use."));

--- a/CSSE/DialogRenderWindow.cpp
+++ b/CSSE/DialogRenderWindow.cpp
@@ -1465,7 +1465,7 @@ namespace se::cs::dialog::render_window {
 		const auto Land__worldPosToGridAndLandData = reinterpret_cast<bool(__thiscall*)(DataHandler*, NI::Point3*, LandTexture**)>(0x4A46C0);
 
 		const auto result = Land__worldPosToGridAndLandData(dataHandler, worldPos, currentTexture);
-		if (gLandscapeEditRadius::get() > 1) {
+		if (settings.landscape_window.radius_aware_texture_painting_enabled && gLandscapeEditRadius::get() > 1) {
 			*currentTexture = nullptr;
 		}
 
@@ -1479,7 +1479,8 @@ namespace se::cs::dialog::render_window {
 		const auto Land__applyTextureToTile = reinterpret_cast<LandApplyTextureToTileFn>(0x519300);
 		const auto radius = gLandscapeEditRadius::get();
 
-		if (radius <= 1) {
+		if (!settings.landscape_window.radius_aware_texture_painting_enabled || radius <= 1) {
+			resetTexturePaintDragState();
 			Land__applyTextureByWorldPos(land, worldPos);
 			return;
 		}

--- a/CSSE/Settings.cpp
+++ b/CSSE/Settings.cpp
@@ -340,6 +340,7 @@ namespace se::cs {
 		edit_circle_color_vertex = toml::find_or(v, "edit_circle_color_vertex", edit_circle_color_vertex);
 
 		show_preview_enabled = toml::find_or(v, "show_preview_enabled", show_preview_enabled);
+		radius_aware_texture_painting_enabled = toml::find_or(v, "radius_aware_texture_painting_enabled", radius_aware_texture_painting_enabled);
 
 		vertex_color_strength = std::clamp(toml::find_or(v, "vertex_color_strength", vertex_color_strength), 0, 100);
 		vertex_color_blend_mode = toml::find_or(v, "vertex_color_blend_mode", vertex_color_blend_mode);
@@ -359,6 +360,7 @@ namespace se::cs {
 				{ "column_filename", column_filename },
 
 				{ "show_preview_enabled", show_preview_enabled},
+				{ "radius_aware_texture_painting_enabled", radius_aware_texture_painting_enabled },
 
 				{ "vertex_color_strength", vertex_color_strength },
 				{ "vertex_color_blend_mode", vertex_color_blend_mode },

--- a/CSSE/Settings.h
+++ b/CSSE/Settings.h
@@ -167,6 +167,7 @@ namespace se::cs {
 			std::array<float, 3> edit_circle_color_vertex = { 1.0f, 1.0f, 0.0f };
 
 			bool show_preview_enabled = false;
+			bool radius_aware_texture_painting_enabled = true;
 
 			int vertex_color_strength = 100;
 			std::string vertex_color_blend_mode = "Mix";


### PR DESCRIPTION
Requested in TR server.

Makes `Radius-Aware Texture Painting` optional via a `CSSE Settings` dialog.
