### PR TITLE
Refactor searching to use `contains`

### DIFF
--- a/CSSE/DialogDialogueWindow.cpp
+++ b/CSSE/DialogDialogueWindow.cpp
@@ -214,7 +214,7 @@ namespace se::cs::dialog::dialogue_window {
 		std::string lowercased = object->getObjectID();
 		string::to_lower(lowercased);
 
-		if (insertedCells.find(lowercased) == insertedCells.end()) {
+		if (!insertedCells.contains(lowercased)) {
 			auto r = SendMessageA(hWnd, CB_ADDSTRING, NULL, (LPARAM)object->getObjectID());
 			SendMessageA(hWnd, CB_SETITEMDATA, r, (LPARAM)object);
 			insertedCells.insert(std::move(lowercased));

--- a/CSSE/DialogLayersWindow.cpp
+++ b/CSSE/DialogLayersWindow.cpp
@@ -156,86 +156,86 @@ namespace se::cs::dialog::layer_window {
 		if (!node) return;
 
 		for (auto& child : node->children) {
-			if (child && child->isInstanceOfType(NI::RTTIStaticPtr::NiTriShape)) {
+			if (!child || !child->isInstanceOfType(NI::RTTIStaticPtr::NiTriShape)) {
+				continue;
+			}
 
-				auto triShape = static_cast<NI::TriShape*>(child.get());
+			auto triShape = static_cast<NI::TriShape*>(child.get());
+			auto currMaterialProp = triShape->getMaterialProperty();
+			if (!currMaterialProp) {
+				continue;
+			}
 
-				auto currMaterialProp = triShape->getMaterialProperty();
+			auto nodeColorData = getNodeColorData(triShape);
 
-				if (currMaterialProp) {
+			auto layerColor = getLayerColor();
+			auto layerMaterial = getLayerOverlayMaterial(currMaterialProp);
+			auto layerVertexProp = getLayerVertexColorProperty();
+			auto layerAlphaProp = getLayerAlphaProperty();
 
-					auto nodeColorData = getNodeColorData(triShape);
+			auto currVertexProp = triShape->getVertexColorProperty();
+			auto currAlphaProperty = triShape->getAlphaProperty();
 
-					auto layerColor = getLayerColor();
-					auto layerMaterial = getLayerOverlayMaterial(currMaterialProp);
-					auto layerVertexProp = getLayerVertexColorProperty();
-					auto layerAlphaProp = getLayerAlphaProperty();
-
-					auto currVertexProp = triShape->getVertexColorProperty();
-					auto currAlphaProperty = triShape->getAlphaProperty();
-
-					if (isOverlayActive && !forceRestore) {
-						// Apply overlay material
-						if (!nodeColorData->originalMaterial) {
-							nodeColorData->originalMaterial = currMaterialProp;
-						}
-						triShape->setMaterialProperty(layerMaterial);
-
-						// Apply vertex color prop
-						if (!nodeColorData->originalVColorProperty) {
-							nodeColorData->originalVColorProperty = currVertexProp;
-						}
-						triShape->setVertexColorProperty(layerVertexProp);
-					}
-					else {
-						// Restore original material
-						auto& originalMaterial = nodeColorData->originalMaterial;
-						if (originalMaterial) {
-							triShape->setMaterialProperty(originalMaterial);
-						}
-						else if (layerMaterial == currMaterialProp) {
-							triShape->detachPropertyByType(NI::PropertyType::Material);
-						}
-
-						// Restore original vertex color prop
-						auto& originalVertexProp = nodeColorData->originalVColorProperty;
-						if (originalVertexProp) {
-							triShape->setVertexColorProperty(originalVertexProp);
-						}
-						else if (layerVertexProp == currVertexProp) {
-							triShape->detachPropertyByType(NI::PropertyType::VertexColor);
-						}
-					}
-
-					if (isOverlayActive && isLayerHidden && !forceRestore) {
-						// Apply transparency 
-						if (!nodeColorData->originalAlphaProperty) {
-							nodeColorData->originalAlphaProperty = currAlphaProperty;
-						}
-
-						triShape->setAlphaProperty(layerAlphaProp);
-
-						layerMaterial->setAlpha(0.5f);
-					}
-					else {
-						// Restore original alpha prop
-						auto& originalAlphaProp = nodeColorData->originalAlphaProperty;
-
-						layerMaterial->setAlpha(1.0f);
-						if (originalAlphaProp) {
-							triShape->setAlphaProperty(originalAlphaProp);
-						}
-						else if (layerAlphaProp == currAlphaProperty) {
-							triShape->detachPropertyByType(NI::PropertyType::Alpha);
-						}
-					}
-
-					triShape->updateProperties();
-
-					if (forceRestore) {
-						removeNodeColorData(triShape);
-					}
+			if (isOverlayActive && !forceRestore) {
+				// Apply overlay material
+				if (!nodeColorData->originalMaterial) {
+					nodeColorData->originalMaterial = currMaterialProp;
 				}
+				triShape->setMaterialProperty(layerMaterial);
+
+				// Apply vertex color prop
+				if (!nodeColorData->originalVColorProperty) {
+					nodeColorData->originalVColorProperty = currVertexProp;
+				}
+				triShape->setVertexColorProperty(layerVertexProp);
+			}
+			else {
+				// Restore original material
+				auto& originalMaterial = nodeColorData->originalMaterial;
+				if (originalMaterial) {
+					triShape->setMaterialProperty(originalMaterial);
+				}
+				else if (layerMaterial == currMaterialProp) {
+					triShape->detachPropertyByType(NI::PropertyType::Material);
+				}
+
+				// Restore original vertex color prop
+				auto& originalVertexProp = nodeColorData->originalVColorProperty;
+				if (originalVertexProp) {
+					triShape->setVertexColorProperty(originalVertexProp);
+				}
+				else if (layerVertexProp == currVertexProp) {
+					triShape->detachPropertyByType(NI::PropertyType::VertexColor);
+				}
+			}
+
+			if (isOverlayActive && isLayerHidden && !forceRestore) {
+				// Apply transparency 
+				if (!nodeColorData->originalAlphaProperty) {
+					nodeColorData->originalAlphaProperty = currAlphaProperty;
+				}
+
+				triShape->setAlphaProperty(layerAlphaProp);
+
+				layerMaterial->setAlpha(0.5f);
+			}
+			else {
+				// Restore original alpha prop
+				auto& originalAlphaProp = nodeColorData->originalAlphaProperty;
+
+				layerMaterial->setAlpha(1.0f);
+				if (originalAlphaProp) {
+					triShape->setAlphaProperty(originalAlphaProp);
+				}
+				else if (layerAlphaProp == currAlphaProperty) {
+					triShape->detachPropertyByType(NI::PropertyType::Alpha);
+				}
+			}
+
+			triShape->updateProperties();
+
+			if (forceRestore) {
+				removeNodeColorData(triShape);
 			}
 		}
 

--- a/CSSE/DialogLayersWindow.cpp
+++ b/CSSE/DialogLayersWindow.cpp
@@ -121,7 +121,7 @@ namespace se::cs::dialog::layer_window {
 		auto objIt = perCellReferences.find(objCell);
 		if (objIt != perCellReferences.end()) {
 			auto cellRefs = &objIt->second;
-			if (cellRefs->find(objRef) != cellRefs->end()) {
+			if (cellRefs->contains(objRef)) {
 				updateObject(objRef, true);
 				isRemoved = true;
 				cellRefs->erase(objRef);
@@ -147,10 +147,10 @@ namespace se::cs::dialog::layer_window {
 		auto objCell = objRef ? objRef->getCell() : nullptr;
 		if (!objCell) return;
 
-		if (perCellReferences.find(objCell) == perCellReferences.end()) return;
+		if (!perCellReferences.contains(objCell)) return;
 
 		auto& cellRefs = perCellReferences[objCell];
-		if (cellRefs.find(objRef) == cellRefs.end()) return;
+		if (!cellRefs.contains(objRef)) return;
 
 		auto node = objRef ? objRef->sceneNode : nullptr;
 		if (!node) return;
@@ -374,7 +374,7 @@ namespace se::cs::dialog::layer_window {
 
 	size_t getNextLayerId() {
 		size_t nextId = 0;
-		while (g_LayersIdMap.find(nextId) != g_LayersIdMap.end()) {
+		while (g_LayersIdMap.contains(nextId)) {
 			++nextId;
 		}
 
@@ -496,8 +496,7 @@ namespace se::cs::dialog::layer_window {
 		auto cellList = recordHandler->cells;
 
 		// Populate layer data with actual object references
-		for (auto cellIt = cellList->begin(); cellIt != cellList->end(); ++cellIt) {
-			Cell* cell = *cellIt;
+		for (auto cell : *cellList) {
 			if (!cell) continue;
 
 			std::string currentCellId = cell->getEditorId(); // will fail to be restored if cell was renamed
@@ -551,7 +550,7 @@ namespace se::cs::dialog::layer_window {
 		}
 
 		// if layer id 0 is missing, recreate default layer
-		if (g_LayersIdMap.find(0) == g_LayersIdMap.end()) {
+		if (!g_LayersIdMap.contains(0)) {
 			auto hiddenLayer = new LayerData();
 			hiddenLayer->id = HIDDEN_LAYER_ID;
 			hiddenLayer->layerName = new std::string("Hidden");

--- a/CSSE/MetadataUtil.cpp
+++ b/CSSE/MetadataUtil.cpp
@@ -25,7 +25,7 @@ namespace se::cs::metadata {
 		const auto recordHandler = DataHandler::get()->recordHandler;
 		for (const auto& gameFile : *recordHandler->availableDataFiles) {
 			// Skip any that are already loaded.
-			if (gameFileMap.find(gameFile) != gameFileMap.end()) {
+			if (gameFileMap.contains(gameFile)) {
 				continue;
 			}
 
@@ -109,6 +109,6 @@ namespace se::cs::metadata {
 			return false;
 		}
 		string::to_lower(id);
-		return deprecatedIds.find(id) != deprecatedIds.end();
+		return deprecatedIds.contains(id);
 	}
 }

--- a/CSSE/WindowMain.cpp
+++ b/CSSE/WindowMain.cpp
@@ -563,7 +563,7 @@ namespace se::cs::window::main {
 		// Flag any game files as marked to load.
 		for (auto itt = recordHandler->availableDataFiles->head; itt; itt = itt->next) {
 			auto gameFile = itt->data;
-			if (toLoadSet.find(gameFile->fileName) != toLoadSet.end()) {
+			if (toLoadSet.contains(gameFile->fileName)) {
 				gameFile->setToLoadFlag(true);
 			}
 		}

--- a/MWSE/CrashLogCallTrace.cpp
+++ b/MWSE/CrashLogCallTrace.cpp
@@ -441,7 +441,7 @@ namespace CrashLogger::Warnings {
 			std::string line;
 			while (std::getline(warnings, line)) {
 				if (line.empty()) continue;
-				if (seenLines.find(line) == seenLines.end()) {
+				if (!seenLines.contains(line)) {
 					output << line << std::endl;
 					seenLines.insert(line);
 				}

--- a/MWSE/CrashLogRegistryStack.cpp
+++ b/MWSE/CrashLogRegistryStack.cpp
@@ -171,7 +171,7 @@ namespace CrashLogger::Stack {
 				if (i <= 0x8 || (!str.empty() && memoize.find(espi) == memoize.end())) {
 					std::stringstream line;
 					line << fmt::format(" {:2X} | 0x{:08X} | ", i, espi);
-					if (memoize.find(espi) == memoize.end()) {
+					if (!memoize.contains(espi)) {
 						if (!str.empty()) line << str;
 						memoize.emplace(espi, static_cast<UINT8>(i));
 					}

--- a/MWSE/ReferenceTracker.cpp
+++ b/MWSE/ReferenceTracker.cpp
@@ -411,7 +411,7 @@ namespace mwse {
 							continue;
 						}
 
-						if (trackedReferences.find(reference) == trackedReferences.end()) {
+						if (!trackedReferences.contains(reference)) {
 							log << "[MWSE] ReferenceTracker validation failed: untracked reference found in cell"
 								<< " cell=" << cell
 								<< " list=" << listName

--- a/MWSE/TES3Cell.cpp
+++ b/MWSE/TES3Cell.cpp
@@ -240,7 +240,7 @@ namespace TES3 {
 
 	void Cell::setCellActive() {
 		// Skip if the cell is already active.
-		if (activeCells.find(this) != activeCells.end()) {
+		if (getCellActive()) {
 			return;
 		}
 
@@ -259,7 +259,7 @@ namespace TES3 {
 	}
 
 	void Cell::setCellInactive() {
-		if (activeCells.find(this) == activeCells.end()) {
+		if (!getCellActive()) {
 			return;
 		}
 
@@ -278,7 +278,7 @@ namespace TES3 {
 	}
 
 	bool Cell::getCellActive() const {
-		return activeCells.find(this) != activeCells.end();
+		return activeCells.contains(this);
 	}
 
 	bool Cell::getHasCellMarker() const {

--- a/MWSE/TES3DataHandler.cpp
+++ b/MWSE/TES3DataHandler.cpp
@@ -496,7 +496,7 @@ namespace TES3 {
 			}
 
 			if (destinationCell->getIsInterior()) {
-				if (visitedCells.find(destinationCell) == visitedCells.end()) {
+				if (!visitedCells.contains(destinationCell)) {
 					linkedInteriorCells.push_back(destinationCell);
 				}
 				continue;

--- a/MWSE/TES3MagicEffectController.cpp
+++ b/MWSE/TES3MagicEffectController.cpp
@@ -67,7 +67,7 @@ namespace TES3 {
 		const auto effect = effectObjects[id];
 		if (effect == nullptr) {
 			// Warn only once per effect ID.
-			if (warnedMagicEffectIds.find(id) == warnedMagicEffectIds.end()) {
+			if (!warnedMagicEffectIds.contains(id)) {
 				mwse::log::getLog() << "Invalid effect ID " << id << " encountered. Spoofing substitute. Uninstalling mods that add custom effects can lead to unexpected behavior and crashes." << std::endl;
 				warnedMagicEffectIds.insert(id);
 			}

--- a/MWSE/TES3Object.cpp
+++ b/MWSE/TES3Object.cpp
@@ -371,7 +371,7 @@ namespace TES3 {
 
 	const auto TES3_isSourcelessObject = reinterpret_cast<bool(__stdcall*)(const BaseObject*)>(0x4C1980);
 	bool __stdcall BaseObject::isSourcelessObject(const BaseObject* object) {
-		return TES3_isSourcelessObject(object) || sourcelessObjects.find(object) != sourcelessObjects.end();
+		return TES3_isSourcelessObject(object) || sourcelessObjects.contains(object);
 	}
 
 	void BaseObject::setSourcelessObject(const BaseObject* object) {
@@ -383,7 +383,7 @@ namespace TES3 {
 	static std::unordered_map<const BaseObject*, sol::object> baseObjectCache;
 
 	bool BaseObject::hasCachedLuaObject() const {
-		return baseObjectCache.find(this) != baseObjectCache.end();
+		return baseObjectCache.contains(this);
 	}
 
 	sol::object BaseObject::getCachedLuaObject() const {

--- a/MWSE/TES3Util.cpp
+++ b/MWSE/TES3Util.cpp
@@ -182,8 +182,7 @@ namespace mwse::tes3 {
 		}
 
 		if (objectOrReference->objectType == TES3::ObjectType::Misc) {
-			auto searchResult = customSoulGems.find(reinterpret_cast<const TES3::Misc*>(objectOrReference));
-			if (searchResult != customSoulGems.end()) {
+			if (customSoulGems.contains(reinterpret_cast<const TES3::Misc*>(objectOrReference))) {
 				return true;
 			}
 		}

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -2733,7 +2733,7 @@ namespace mwse::lua {
 			std::unordered_set<unsigned int> instancesToRetire;
 
 			for (const auto& effect : mobile->activeMagicEffects) {
-				if (instancesToRetire.find(effect.magicInstanceSerial) != instancesToRetire.end()) {
+				if (instancesToRetire.contains(effect.magicInstanceSerial)) {
 					continue;
 				}
 


### PR DESCRIPTION
- Simplifies searching over various containers by using `contains` where possible. 
- Reduced deep nesting in DialogLayersWindow.