### PR TITLE
Suppress `mobileActivated` events during `reloadAnimation`

### DIFF
--- a/MWSE/LuaScopedEventSuppressor.h
+++ b/MWSE/LuaScopedEventSuppressor.h
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace mwse::lua::event {
+	namespace detail {
+		template <typename TEvent>
+		class ScopedEventState {
+		public:
+			ScopedEventState() :
+				m_EventEnabled(TEvent::getEventEnabled())
+			{
+				TEvent::setEventEnabled(false);
+			}
+
+			~ScopedEventState() {
+				TEvent::setEventEnabled(m_EventEnabled);
+			}
+
+		private:
+			bool m_EventEnabled;
+		};
+	}
+
+	template <typename... TEvents>
+	class ScopedEventSuppressor : private detail::ScopedEventState<TEvents>... {
+	public:
+		static_assert(sizeof...(TEvents) > 0, "ScopedEventSuppressor requires at least one event type.");
+
+		ScopedEventSuppressor() = default;
+		~ScopedEventSuppressor() = default;
+
+		ScopedEventSuppressor(const ScopedEventSuppressor&) = delete;
+		ScopedEventSuppressor& operator=(const ScopedEventSuppressor&) = delete;
+	};
+}

--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -1,6 +1,7 @@
 #include "TES3Reference.h"
 
 #include "LuaManager.h"
+#include "LuaScopedEventSuppressor.h"
 #include "LuaUtil.h"
 
 #include "LuaActivateEvent.h"
@@ -9,6 +10,8 @@
 #include "LuaDisarmTrapEvent.h"
 #include "LuaLeveledCreaturePickedEvent.h"
 #include "LuaLeveledItemPickedEvent.h"
+#include "LuaMobileObjectActivatedEvent.h"
+#include "LuaMobileObjectDeactivatedEvent.h"
 #include "LuaPickLockEvent.h"
 #include "LuaReferenceActivatedEvent.h"
 #include "LuaReferenceDeactivatedEvent.h"
@@ -323,6 +326,13 @@ namespace TES3 {
 
 	void Reference::reloadAnimation(const char* path) {
 		auto parentNode = sceneNode->parentNode;
+
+		// Users may want to call `loadAnimation` inside `mobileActivated` events, after which
+		// the `resetVisualNode` and `enterLeaveSimulation` calls below would trigger another 
+		// `mobileActivated` event, causing an infinite loop. Suppress the event temporarily 
+		// to prevent that.
+		using namespace mwse::lua::event;
+		ScopedEventSuppressor<MobileObjectActivatedEvent, MobileObjectDeactivatedEvent> suppressMobileSimulationEvents;
 
 		resetVisualNode();
 		auto node = getSceneGraphNode();


### PR DESCRIPTION
Fixes an infinite loop. Calling `loadAnimation` during `mobileActivated` is a pretty useful thing to support. Requested by Kynesifnar in discord.

Being able to disable events temporary seemed like it is also generically useful. So I made that into something re-usable rather than hard-coding it just to this particular use case. Using an RAII guard so the event suppression doesn't get persisted on exceptions.