### PR TITLE
[mwse] Map fog-of-war pixel cache: fix local-map cell-cross stutter

### DIFF
--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -33,6 +33,7 @@
 #include "TES3Sound.h"
 #include "TES3UIElement.h"
 #include "TES3UIInventoryTile.h"
+#include "TES3UIManager.h"
 #include "TES3UIMenuController.h"
 #include "TES3VFXManager.h"
 #include "TES3VoiceStreamer.h"
@@ -2167,6 +2168,44 @@ namespace mwse::patch {
 	}
 
 	//
+	// Map fog-of-war pixel cache install.
+	//
+	// The cache itself lives on TES3::WorldControllerRenderTarget. Here we only install the hooks:
+	//  - bracket the local-map compositor (ui_MenuMap_updateMapRender, 0x5E99C0) at its four entry
+	//    sites so the cache is active for the duration of each pass, and
+	//  - replace getFogOfWarPixel (0x42FE20) at its two call sites (inside
+	//    isPositionUncoveredByFogOfWar) with the cached variant.
+	//
+
+	// Hook target for getFogOfWarPixel. __fastcall(self, edx, ...) matches the engine __thiscall.
+	unsigned char __fastcall MapFogPixelCacheHook(TES3::WorldControllerRenderTarget* renderTarget, void*, NI::RenderedTexture* texture, float worldX, float worldY) {
+		return renderTarget->getFogOfWarPixelCached(texture, worldX, worldY);
+	}
+
+	// Hook target that brackets the compositor so the fog cache is active while it runs.
+	const auto TES3_ui_MenuMap_updateMapRender = reinterpret_cast<void(__cdecl*)()>(0x5E99C0);
+	void __cdecl MapCompositorWithFogCache() {
+		TES3::WorldControllerRenderTarget::beginFogCache();
+		TES3_ui_MenuMap_updateMapRender();
+		TES3::WorldControllerRenderTarget::endFogCache();
+	}
+
+	void installMapFogPixelCache() {
+		using se::memory::genCallEnforced;
+		using se::memory::genJumpEnforced;
+
+		const DWORD compositor = reinterpret_cast<DWORD>(&MapCompositorWithFogCache);
+		genJumpEnforced(0x420415, 0x5E99C0, compositor);  // MapController::updateMapRender tail-jmp (cell-cross)
+		genCallEnforced(0x5E9757, 0x5E99C0, compositor);  // ui_showMapMenu (map open)
+		genCallEnforced(0x5F0BF2, 0x5E99C0, compositor);  // ui_MenuMapNoteEdit_onOK
+		genCallEnforced(0x5F0D32, 0x5E99C0, compositor);  // ui_MenuMapNoteEdit_onDeleteNote
+
+		const DWORD fogPixel = reinterpret_cast<DWORD>(&MapFogPixelCacheHook);
+		genCallEnforced(0x5EE104, 0x42FE20, fogPixel);    // isPositionUncoveredByFogOfWar (path 1)
+		genCallEnforced(0x5EE286, 0x42FE20, fogPixel);    // isPositionUncoveredByFogOfWar (path 2)
+	}
+
+	//
 	// Install all the patches.
 	//
 
@@ -2182,6 +2221,9 @@ namespace mwse::patch {
 		using se::memory::writePatchCodeUnprotected;
 		using se::memory::writeBytesUnprotected;
 		using se::memory::writeDoubleWordEnforced;
+
+		// Map fog-of-war pixel cache: removes the per-door GPU render-target lock stutter on cell-cross.
+		installMapFogPixelCache();
 
 		// Patch: Enable/Disable.
 		genCallUnprotected(0x508FEB, reinterpret_cast<DWORD>(PatchScriptOpEnable), 0x9);

--- a/MWSE/TES3WorldController.cpp
+++ b/MWSE/TES3WorldController.cpp
@@ -120,9 +120,9 @@ namespace TES3 {
 		if (!sFogCacheActive) {
 			return getFogOfWarPixel(texture, worldX, worldY);  // outside the burst: exact vanilla
 		}
-		const int px = static_cast<int>(static_cast<double>(worldX) * 64.0);
-		const int py = static_cast<int>(static_cast<double>(worldY) * 64.0);
-		if (static_cast<unsigned int>(px) > 64 || static_cast<unsigned int>(py) > 64) {
+		const unsigned int px = static_cast<unsigned int>(static_cast<double>(worldX) * 64.0);
+		const unsigned int py = static_cast<unsigned int>(static_cast<double>(worldY) * 64.0);
+		if (px > 64 || py > 64) {
 			if (texture) {
 				texture->release();  // vanilla OOB path consumes one reference
 			}
@@ -132,8 +132,8 @@ namespace TES3 {
 		if (texture) {
 			const FogTileCacheEntry* entry = fogCacheFindOrLoad(this, texture);
 			if (entry) {
-				const int cx = px < 64 ? px : 63;  // engine reads index 64 (OOB); clamp safely
-				const int cy = py < 64 ? py : 63;
+				const unsigned int cx = px < 64 ? px : 63;  // engine reads index 64 (OOB); clamp safely
+				const unsigned int cy = py < 64 ? py : 63;
 				result = entry->pixels[cy * 64 + cx];
 			}
 			// vanilla success path is net-zero on refCount -> nothing to do

--- a/MWSE/TES3WorldController.cpp
+++ b/MWSE/TES3WorldController.cpp
@@ -47,6 +47,101 @@ namespace TES3 {
 	}
 
 	//
+	// WorldControllerRenderTarget
+	//
+
+	const auto TES3_WorldControllerRenderTarget_lockRenderTarget = reinterpret_cast<D3DLOCKED_RECT*(__thiscall*)(WorldControllerRenderTarget*, NI::Texture*)>(0x42F3F0);
+	D3DLOCKED_RECT* WorldControllerRenderTarget::lockRenderTarget(NI::Texture* texture) {
+		return TES3_WorldControllerRenderTarget_lockRenderTarget(this, texture);
+	}
+
+	const auto TES3_WorldControllerRenderTarget_unlockRenderTarget = reinterpret_cast<void(__thiscall*)(WorldControllerRenderTarget*, D3DLOCKED_RECT*, int)>(0x42F620);
+	void WorldControllerRenderTarget::unlockRenderTarget(D3DLOCKED_RECT* lockedRect, int flag) {
+		TES3_WorldControllerRenderTarget_unlockRenderTarget(this, lockedRect, flag);
+	}
+
+	const auto TES3_WorldControllerRenderTarget_getFogOfWarPixel = reinterpret_cast<unsigned char(__thiscall*)(WorldControllerRenderTarget*, NI::RenderedTexture*, float, float)>(0x42FE20);
+	unsigned char WorldControllerRenderTarget::getFogOfWarPixel(NI::RenderedTexture* texture, float worldX, float worldY) {
+		return TES3_WorldControllerRenderTarget_getFogOfWarPixel(this, texture, worldX, worldY);
+	}
+
+	// Fog-of-war pixel cache (see header). Per-compositor-pass cache, keyed by fog tile texture.
+	namespace {
+		struct FogTileCacheEntry {
+			NI::RenderedTexture* texture;
+			unsigned char pixels[64 * 64];  // the sampled channel (offset +1) for the 64x64 fog tile
+		};
+		bool sFogCacheActive = false;
+		int sFogCacheCount = 0;
+		FogTileCacheEntry sFogCache[16];  // loaded ring never exceeds this; overflow degrades to "covered"
+
+		FogTileCacheEntry* fogCacheFindOrLoad(WorldControllerRenderTarget* renderTarget, NI::RenderedTexture* texture) {
+			for (int i = 0; i < sFogCacheCount; ++i) {
+				if (sFogCache[i].texture == texture) {
+					return &sFogCache[i];
+				}
+			}
+			if (sFogCacheCount >= 16) {
+				return nullptr;
+			}
+			// Keep the texture alive across the lock (mirrors the engine's defensive ++/-- guard).
+			texture->refCount += 1;
+			D3DLOCKED_RECT* rect = renderTarget->lockRenderTarget(texture);
+			if (!rect || !rect->pBits) {
+				texture->release();
+				return nullptr;
+			}
+			FogTileCacheEntry* entry = &sFogCache[sFogCacheCount];
+			entry->texture = texture;
+			const unsigned char* bits = static_cast<const unsigned char*>(rect->pBits);
+			const int pitch = rect->Pitch;
+			for (int y = 0; y < 64; ++y) {
+				for (int x = 0; x < 64; ++x) {
+					entry->pixels[y * 64 + x] = bits[4 * x + pitch * y + 1];  // same channel as getFogOfWarPixel
+				}
+			}
+			renderTarget->unlockRenderTarget(rect, 0);
+			++sFogCacheCount;
+			return entry;
+		}
+	}
+
+	void WorldControllerRenderTarget::beginFogCache() {
+		sFogCacheActive = true;
+		sFogCacheCount = 0;
+	}
+
+	void WorldControllerRenderTarget::endFogCache() {
+		sFogCacheActive = false;
+		sFogCacheCount = 0;
+	}
+
+	unsigned char WorldControllerRenderTarget::getFogOfWarPixelCached(NI::RenderedTexture* texture, float worldX, float worldY) {
+		if (!sFogCacheActive) {
+			return getFogOfWarPixel(texture, worldX, worldY);  // outside the burst: exact vanilla
+		}
+		const int px = static_cast<int>(static_cast<double>(worldX) * 64.0);
+		const int py = static_cast<int>(static_cast<double>(worldY) * 64.0);
+		if (static_cast<unsigned int>(px) > 64 || static_cast<unsigned int>(py) > 64) {
+			if (texture) {
+				texture->release();  // vanilla OOB path consumes one reference
+			}
+			return 0;
+		}
+		unsigned char result = 0;
+		if (texture) {
+			const FogTileCacheEntry* entry = fogCacheFindOrLoad(this, texture);
+			if (entry) {
+				const int cx = px < 64 ? px : 63;  // engine reads index 64 (OOB); clamp safely
+				const int cy = py < 64 ? py : 63;
+				result = entry->pixels[cy * 64 + cx];
+			}
+			// vanilla success path is net-zero on refCount -> nothing to do
+		}
+		return result;
+	}
+
+	//
 	// KillCounter
 	//
 

--- a/MWSE/TES3WorldController.h
+++ b/MWSE/TES3WorldController.h
@@ -106,6 +106,20 @@ namespace TES3 {
 
 		WorldControllerRenderTarget() = delete;
 		~WorldControllerRenderTarget() = delete;
+
+		D3DLOCKED_RECT* lockRenderTarget(NI::Texture* texture);
+		void unlockRenderTarget(D3DLOCKED_RECT* lockedRect, int flag);
+		unsigned char getFogOfWarPixel(NI::RenderedTexture* texture, float worldX, float worldY);
+
+		// Fog-of-war pixel cache. getFogOfWarPixel locks a 64x64 GPU render target to read a single
+		// byte, and the local-map compositor calls it once per door (~500-700 per cell-cross) - a
+		// ~40 ms stall on the cross frame. The fog is immutable within one compositor pass, so cache
+		// each tile once and serve all door queries from the copy. beginFogCache/endFogCache bracket
+		// the compositor; getFogOfWarPixelCached replaces getFogOfWarPixel at its call sites and uses
+		// the cache while active (falling back to getFogOfWarPixel otherwise).
+		unsigned char getFogOfWarPixelCached(NI::RenderedTexture* texture, float worldX, float worldY);
+		static void beginFogCache();
+		static void endFogCache();
 	};
 	static_assert(sizeof(WorldControllerRenderTarget) == 0x84, "TES3::WorldControllerRenderTarget failed size validation");
 


### PR DESCRIPTION
ui_MenuMap_updateMapRender re-tests every door's fog-of-war state on each cell-cross via WorldControllerRenderTarget::getFogOfWarPixel, which LOCKS a 64x64 GPU render target to read a single byte. The compositor calls it once per door (~500-700 per cross), so the cross frame stalls ~40 ms in Narsis.

The fog texture is immutable within one compositor pass, so cache each fog tile once and serve all door queries from the 64x64 copy:

- WorldControllerRenderTarget gains lockRenderTarget / unlockRenderTarget / getFogOfWarPixel member wrappers, plus getFogOfWarPixelCached and beginFogCache / endFogCache (a per-pass cache keyed by the fog tile texture).
- PatchUtil brackets the compositor at its four entry sites (cell-cross, map-open, two note-edit paths) and replaces getFogOfWarPixel at its two call sites with the cached variant. The vanilla refcount contract is preserved (OOB releases one reference; the success path is net-zero).

~600 GPU render-target locks per cross -> ~9 (one per loaded fog tile); the local-map compositor drops from ~45 ms to ~5 ms in Narsis cell transitions, for both the minimap and the full map, with the saved/world map unchanged.