### PR TITLE
Crash Fix: Prevent actor objects being put in the `temporaryRefs` list.

### DIFF
--- a/CSSE/CSBaseObject.cpp
+++ b/CSSE/CSBaseObject.cpp
@@ -43,6 +43,18 @@ namespace se::cs {
 		return (flags & 0x2000);
 	}
 
+	bool BaseObject::isMobileCapableActor() const {
+		switch (objectType) {
+		case ObjectType::Creature:
+		case ObjectType::CreatureClone:
+		case ObjectType::NPC:
+		case ObjectType::NPCClone:
+			return true;
+		default:
+			return false;
+		}
+	}
+
 	void BaseObject::setFlag80(bool set) {
 		const auto BaseObject_setFlag80 = reinterpret_cast<void(__thiscall*)(BaseObject*, bool)>(0x4019E7);
 		BaseObject_setFlag80(this, set);

--- a/CSSE/CSBaseObject.h
+++ b/CSSE/CSBaseObject.h
@@ -43,6 +43,8 @@ namespace se::cs {
 		bool getPersists() const;
 		bool getBlocked() const;
 
+		bool isMobileCapableActor() const;
+
 		void setFlag80(bool set);
 
 		struct SearchSettings {

--- a/CSSE/CSCell.cpp
+++ b/CSSE/CSCell.cpp
@@ -3,6 +3,7 @@
 #include "CSDataHandler.h"
 #include "CSGameSetting.h"
 #include "CSRecordHandler.h"
+#include "CSReference.h"
 #include "CSRegion.h"
 
 namespace se::cs {
@@ -50,6 +51,24 @@ namespace se::cs {
 		}
 		else {
 			return nullptr;
+		}
+	}
+
+	const auto TES3CS_Cell_addReference = reinterpret_cast<void(__thiscall*)(Cell*, Reference*)>(0x5352F0);
+	void Cell::addReference(Reference* reference) {
+		TES3CS_Cell_addReference(this, reference);
+	}
+
+	void Cell::reclassifyReference(Reference* reference) {
+		if (!reference || !reference->baseObject) {
+			return;
+		}
+
+		auto& incorrectList = reference->baseObject->isMobileCapableActor() ? cellObjRefs : cellNpcRefs;
+		const auto it = std::find(incorrectList.begin(), incorrectList.end(), reference);
+		if (it != incorrectList.end()) {
+			incorrectList.erase(it);
+			addReference(reference);
 		}
 	}
 

--- a/CSSE/CSCell.h
+++ b/CSSE/CSCell.h
@@ -64,6 +64,9 @@ namespace se::cs {
 		Land* getOrCreateLand();
 		Region* getRegion() const;
 
+		void addReference(Reference* reference);
+		void reclassifyReference(Reference* reference);
+
 		const char* getDisplayName() const;
 		std::string getEditorId() const;
 	};

--- a/CSSE/CSRecordHandler.cpp
+++ b/CSSE/CSRecordHandler.cpp
@@ -108,4 +108,10 @@ namespace se::cs {
 		const auto RecordHandler_getAvailableGameFileByIndex = reinterpret_cast<GameFile * (__thiscall*)(const RecordHandler*, size_t)>(0x501140);
 		return RecordHandler_getAvailableGameFileByIndex(this, index);
 	}
+
+	Reference* RecordHandler::createReference(PhysicalObject* baseObject, NI::Point3* position, NI::Point3* orientation, bool* cellWasCreated, Reference* existingReference, Cell* cell) {
+		const auto RecordHandler_createReference = reinterpret_cast<Reference * (__thiscall*)(RecordHandler*, CreateReferenceParams, Reference*, Cell*)>(0x506C80);
+		const auto params = CreateReferenceParams { baseObject, position, orientation, cellWasCreated };
+		return RecordHandler_createReference(this, params, existingReference, cell);
+	}
 }

--- a/CSSE/CSRecordHandler.cpp
+++ b/CSSE/CSRecordHandler.cpp
@@ -110,8 +110,7 @@ namespace se::cs {
 	}
 
 	Reference* RecordHandler::createReference(PhysicalObject* baseObject, NI::Point3* position, NI::Point3* orientation, bool* cellWasCreated, Reference* existingReference, Cell* cell) {
-		const auto RecordHandler_createReference = reinterpret_cast<Reference * (__thiscall*)(RecordHandler*, CreateReferenceParams, Reference*, Cell*)>(0x506C80);
-		const auto params = CreateReferenceParams { baseObject, position, orientation, cellWasCreated };
-		return RecordHandler_createReference(this, params, existingReference, cell);
+		const auto RecordHandler_createReference = reinterpret_cast<Reference * (__thiscall*)(RecordHandler*, PhysicalObject*, NI::Point3*, NI::Point3*, bool*, Reference*, Cell*)>(0x506C80);
+		return RecordHandler_createReference(this, baseObject, position, orientation, cellWasCreated, existingReference, cell);
 	}
 }

--- a/CSSE/CSRecordHandler.h
+++ b/CSSE/CSRecordHandler.h
@@ -112,7 +112,17 @@ namespace se::cs {
 		MagicEffect* getMagicEffect(int id);
 
 		GameFile* getAvailableGameFileByIndex(unsigned int index) const;
+
+		Reference* createReference(PhysicalObject* baseObject, NI::Point3* position, NI::Point3* orientation, bool* cellWasCreated, Reference* existingReference, Cell* cell);
 	};
 	static_assert(sizeof(RecordHandler) == 0xB0F8, "RecordHandler failed size validation");
 	static_assert(sizeof(RecordHandler::GameSettingsContainer) == 0x17D4, "RecordHandler::GameSettingsContainer failed size validation");
+
+	struct CreateReferenceParams {
+		PhysicalObject* baseObject;
+		NI::Point3* position;
+		NI::Point3* orientation;
+		bool* cellWasCreated;
+	};
+	static_assert(sizeof(CreateReferenceParams) == 0x10, "CreateReferenceParams failed size validation");
 }

--- a/CSSE/CSRecordHandler.h
+++ b/CSSE/CSRecordHandler.h
@@ -117,12 +117,4 @@ namespace se::cs {
 	};
 	static_assert(sizeof(RecordHandler) == 0xB0F8, "RecordHandler failed size validation");
 	static_assert(sizeof(RecordHandler::GameSettingsContainer) == 0x17D4, "RecordHandler::GameSettingsContainer failed size validation");
-
-	struct CreateReferenceParams {
-		PhysicalObject* baseObject;
-		NI::Point3* position;
-		NI::Point3* orientation;
-		bool* cellWasCreated;
-	};
-	static_assert(sizeof(CreateReferenceParams) == 0x10, "CreateReferenceParams failed size validation");
 }

--- a/CSSE/DialogSearchAndReplaceWindow.cpp
+++ b/CSSE/DialogSearchAndReplaceWindow.cpp
@@ -70,8 +70,8 @@ namespace se::cs::dialog::search_and_replace_window {
 		return context.getResult();
 	}
 
-	Reference* __fastcall PatchCreateReference(RecordHandler* recordHandler, DWORD _EDX_, CreateReferenceParams params, Reference* existingReference, Cell* cell) {
-		auto reference = recordHandler->createReference(params.baseObject, params.position, params.orientation, params.cellWasCreated, existingReference, cell);
+	Reference* __fastcall PatchCreateReference(RecordHandler* recordHandler, DWORD _EDX_, PhysicalObject* baseObject, NI::Point3* position, NI::Point3* orientation, bool* cellWasCreated, Reference* existingReference, Cell* cell) {
+		auto reference = recordHandler->createReference(baseObject, position, orientation, cellWasCreated, existingReference, cell);
 
 		if (reference && existingReference && cell) {
 			cell->reclassifyReference(reference);

--- a/CSSE/DialogSearchAndReplaceWindow.cpp
+++ b/CSSE/DialogSearchAndReplaceWindow.cpp
@@ -3,6 +3,10 @@
 #include "MemoryUtil.h"
 #include "LogUtil.h"
 
+#include "CSCell.h"
+#include "CSReference.h"
+#include "CSRecordHandler.h"
+
 #include "DialogProcContext.h"
 
 namespace se::cs::dialog::search_and_replace_window {
@@ -66,10 +70,25 @@ namespace se::cs::dialog::search_and_replace_window {
 		return context.getResult();
 	}
 
+	Reference* __fastcall PatchCreateReference(RecordHandler* recordHandler, DWORD _EDX_, CreateReferenceParams params, Reference* existingReference, Cell* cell) {
+		auto reference = recordHandler->createReference(params.baseObject, params.position, params.orientation, params.cellWasCreated, existingReference, cell);
+
+		if (reference && existingReference && cell) {
+			cell->reclassifyReference(reference);
+		}
+
+		return reference;
+	}
+
 	void installPatches() {
 		using memory::genJumpEnforced;
+		using memory::genCallEnforced;
 
 		// Patch: Extend Object Window message handling.
 		genJumpEnforced(0x4024D7, 0x438CE0, reinterpret_cast<DWORD>(PatchDialogProc));
+
+		// Patch: Fix Search & Replace not moving references between actor/non-actor lists.
+		genCallEnforced(0x438EF5, 0x403CF1, reinterpret_cast<DWORD>(PatchCreateReference));
+		genCallEnforced(0x439003, 0x403CF1, reinterpret_cast<DWORD>(PatchCreateReference));
 	}
 }

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -2106,6 +2106,13 @@ namespace mwse::patch {
 		) {
 			cell->temporaryRefs.remove(reference);
 			cell->actors.insertAtEnd(reference);
+			const auto objectId = reference->baseObject->getObjectID();
+			mwse::log::getLog() << fmt::format(
+				"[MWSE] Warning: Loaded actor '{}' from the temporary references list of cell '{}' in '{}'.",
+				objectId ? objectId : "<invalid>",
+				cell->getEditorName(),
+				gameFile ? gameFile->getFilename() : "<unknown>"
+			) << std::endl;
 		}
 		ReferenceTracker::rekeyReference(reference, previousLookupKey);
 		return result;

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -2098,6 +2098,15 @@ namespace mwse::patch {
 	static bool __cdecl PatchCellLoadReference(TES3::Reference* reference, TES3::GameFile* gameFile, bool mustBePersistent, bool insertNew, TES3::Cell* cell) {
 		const auto previousLookupKey = ReferenceTracker::getLookupKey(reference);
 		const auto result = TES3_Cell_static_loadReference(reference, gameFile, mustBePersistent, insertNew, cell);
+		if (
+			cell
+			&& reference->baseObject
+			&& reference->baseObject->isMobileCapableActor()
+			&& reference->owningCollection.asReferenceList == &cell->temporaryRefs
+		) {
+			cell->temporaryRefs.remove(reference);
+			cell->actors.insertAtEnd(reference);
+		}
 		ReferenceTracker::rekeyReference(reference, previousLookupKey);
 		return result;
 	}


### PR DESCRIPTION
Reported by abot in discord. It seems some mods have NPCs/Creatures somehow in the cell's temporary section in their ESP/ESM.

Test case is Stuporstar's practice dummies mod:

https://stuporstar.sarahdimento.com/other-mods/practice-dummies-targets/

Repr: Visit `Vivec, Guild of Fighters` and try to activate the practice dummy -> crash.

The bad ESP probably happened via using TESCS `Find & Replace` feature on the vanilla (static) practice dummy with the mod's (creature) animated alternatives.

The `Cell::loadReference` function is massive and patching the asm inside it or rewriting it in C++ would be really complicated. Fixing up the problem after-the-fact inside a hook we already had seems an easier/safer fix.