### PR TITLE
More C++ 20

### DIFF
--- a/MWSE/CrashLogRegistryStack.cpp
+++ b/MWSE/CrashLogRegistryStack.cpp
@@ -168,10 +168,11 @@ namespace CrashLogger::Stack {
 			for (unsigned int i : iotaVec) {
 				const auto espi = GetESPi(esp, i);
 				const auto str = Stack::GetLineForObject((void**)espi, 5);
-				if (i <= 0x8 || (!str.empty() && memoize.find(espi) == memoize.end())) {
+				bool memoized = memoize.contains(espi);
+				if (i <= 0x8 || (!str.empty() && !memoized)) {
 					std::stringstream line;
 					line << fmt::format(" {:2X} | 0x{:08X} | ", i, espi);
-					if (!memoize.contains(espi)) {
+					if (!memoized) {
 						if (!str.empty()) line << str;
 						memoize.emplace(espi, static_cast<UINT8>(i));
 					}

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -2668,7 +2668,7 @@ namespace mwse::lua {
 			const auto& lowerPath = maybeLowerPath.value();
 
 			// We only care about *-metadata.toml files.
-			if (!se::string::ends_with(lowerPath, "-metadata.toml")) {
+			if (!lowerPath.ends_with("-metadata.toml")) {
 				continue;
 			}
 

--- a/SharedSE/StringUtil.cpp
+++ b/SharedSE/StringUtil.cpp
@@ -99,20 +99,6 @@ namespace se::string {
 		return true;
 	}
 
-	bool starts_with(const std::string_view& string, const std::string_view& substring) {
-		if (substring.size() >= string.size()) {
-			return false;
-		}
-		return string.compare(0, substring.size(), substring) == 0;
-	}
-
-	bool ends_with(const std::string_view& string, const std::string_view& substring) {
-		if (substring.size() >= string.size()) {
-			return false;
-		}
-		return string.compare(string.size() - substring.size(), substring.size(), substring) == 0;
-	}
-
 	bool contains(const std::string_view& haystack, const std::string_view& needle) {
 		if (needle.empty()) {
 			return true;
@@ -143,13 +129,13 @@ namespace se::string {
 	//
 
 	void strip_start(std::string& string, const std::string_view& substring) {
-		if (starts_with(string, substring)) {
+		if (string.starts_with(substring)) {
 			string.erase(0, substring.length());
 		}
 	}
 
 	void strip_end(std::string& string, const std::string_view& substring) {
-		if (ends_with(string, substring)) {
+		if (string.ends_with(substring)) {
 			string.erase(string.length() - substring.length());
 		}
 	}
@@ -206,7 +192,7 @@ namespace se::string {
 		}
 
 		bool exists(const long id) {
-			return store.find(id) != store.end();
+			return store.contains(id);
 		}
 
 		bool exists(const char* value) {

--- a/SharedSE/StringUtil.h
+++ b/SharedSE/StringUtil.h
@@ -34,8 +34,6 @@ namespace se::string {
 	bool niequal(std::string_view a, std::string_view b, size_t maxCount);
 
 	bool istarts_with(std::string_view string, std::string_view substring);
-	bool starts_with(const std::string_view& string, const std::string_view& substring);
-	bool ends_with(const std::string_view& string, const std::string_view& substring);
 
 	bool contains(const std::string_view& haystack, const std::string_view& needle);
 	bool cicontains(const std::string_view& haystack, const std::string_view& needle);


### PR DESCRIPTION
Use `std::basic_string::starts_with`/`ends_with` instead of our custom implementation.

Also, use `contains` in more places.