### PR TITLE
MathUtil updates

### DIFF
--- a/CSSE/DialogRenderWindow.cpp
+++ b/CSSE/DialogRenderWindow.cpp
@@ -817,8 +817,6 @@ namespace se::cs::dialog::render_window {
 	SnappingAxis snappingAxis = SnappingAxis::POSITIVE_Z;
 
 	int Patch_AlignToSurfaceDragMovementLogic(RenderController* renderController, SelectionData::Target* firstTarget, int dx, int dy, bool lockX, bool lockY, bool lockZ) {
-		using se::math::M_PIf;
-
 		// Currently requires a single selection.
 		auto selectionData = SelectionData::get();
 		if (selectionData->numberOfTargets != 1) {
@@ -914,13 +912,13 @@ namespace se::cs::dialog::render_window {
 						NI::Matrix33 flipMatrix;
 						switch (refSnappingAxis) {
 						case SnappingAxis::NEGATIVE_X:
-							flipMatrix.toRotationY(M_PIf);
+							flipMatrix.toRotationY(std::numbers::pi_v<float>);
 							break;
 						case SnappingAxis::NEGATIVE_Y:
-							flipMatrix.toRotationZ(M_PIf);
+							flipMatrix.toRotationZ(std::numbers::pi_v<float>);
 							break;
 						case SnappingAxis::NEGATIVE_Z:
-							flipMatrix.toRotationX(M_PIf);
+							flipMatrix.toRotationX(std::numbers::pi_v<float>);
 							break;
 						default:
 							flipMatrix.toIdentity();

--- a/MWSE/TES3MobManager.cpp
+++ b/MWSE/TES3MobManager.cpp
@@ -329,6 +329,6 @@ namespace TES3 {
 
 	void MobManager::setMaxClimbableSlope(float value) {
 		maxClimbableSlopeDegrees = value;
-		dotProductOfMaxClimbableSlope = cos(static_cast<float>(maxClimbableSlopeDegrees * se::math::M_PI / 180.0));
+		dotProductOfMaxClimbableSlope = cos(se::math::degreesToRadians(maxClimbableSlopeDegrees));
 	}
 }

--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -1067,11 +1067,8 @@ namespace TES3 {
 			return;
 		}
 
-		// Recalculate rotation to always be between [0,2pi].
-		constexpr auto math2Pi = (se::math::M_PI * 2);
-		auto rotationInRadians = static_cast<float>(fmod(rotationInDegrees * (se::math::M_PI / 180.f), math2Pi));
-		if (rotationInRadians < 0)
-			rotationInRadians += static_cast<float>(math2Pi);
+		auto rotationInRadians = se::math::degreesToRadians(rotationInDegrees);
+		se::math::standardizeAngleRadians(rotationInRadians);
 
 		// Get reused variables.
 		auto dataHandler = TES3::DataHandler::get();
@@ -1174,12 +1171,12 @@ namespace TES3 {
 	}
 
 	const auto TES3_game_relocateReference = reinterpret_cast<void(__cdecl*)(Reference*, Cell*, const NI::Point3*, float)>(0x50EDD0);
-	void Reference::relocate(Cell * cell, const NI::Point3 * position, float rotation) {
+	void Reference::relocate(Cell * cell, const NI::Point3 * position, float rotationInDegrees) {
 		// Store old cell.
 		const auto oldCell = getCell();
 
 		// Fire off original function.
-		TES3_game_relocateReference_replacement(this, cell, position, rotation);
+		TES3_game_relocateReference_replacement(this, cell, position, rotationInDegrees);
 		
 		// Determine if cell active state changed.
 		const auto oldCellActive = oldCell ? oldCell->getCellActive() : false;
@@ -1201,7 +1198,7 @@ namespace TES3 {
 			sceneNode->localRotation->toEulerXYZ(&cachedOrientation);
 		}
 
-		relocate(cell, position, static_cast<float>(cachedOrientation.z * (180.0f / se::math::M_PI)));
+		relocate(cell, position, se::math::radiansToDegrees(cachedOrientation.z));
 
 		setOrientation(&cachedOrientation);
 	}

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -2475,7 +2475,7 @@ namespace mwse::lua {
 			std::swap(TES3::DataHandler::suppressThreadLoad, suppressThreadLoad);
 
 			if (userProvidedOrientation) {
-				reference->relocate(cell, &position.value(), static_cast<float>(orientation.value().z * (180.0f / se::math::M_PI)));
+				reference->relocate(cell, &position.value(), se::math::radiansToDegrees(orientation.value().z));
 			}
 			else {
 				reference->relocateNoRotation(cell, &position.value());

--- a/MWSE/stdafx.h
+++ b/MWSE/stdafx.h
@@ -15,6 +15,7 @@
 #include <list>
 #include <map>
 #include <mutex>
+#include <numbers>
 #include <numeric>
 #include <ostream>
 #include <queue>

--- a/SharedSE/MathUtil.cpp
+++ b/SharedSE/MathUtil.cpp
@@ -5,12 +5,9 @@
 
 namespace se::math {
 	void standardizeAngleRadians(float& value) {
-		while (value > M_2PIf) {
-			value -= M_2PIf;
-		}
-		while (value < 0.0f) {
+		value = fmod(value, M_2PIf);
+		if (value < 0.0f)
 			value += M_2PIf;
-		}
 	}
 
 	std::tuple<float, NI::Point3> rayPlaneIntersection(

--- a/SharedSE/MathUtil.h
+++ b/SharedSE/MathUtil.h
@@ -15,11 +15,11 @@ namespace se::math {
 	constexpr auto M_NORMALIZE_EPSILON = 1e-6f; // Epsilon for NiVector normalization.
 
 	inline float radiansToDegrees(float radians) {
-		return float(radians * 180.0f / std::numbers::pi_v<float>);
+		return radians * 180.0f / std::numbers::pi_v<float>;
 	}
 
 	inline float degreesToRadians(float degrees) {
-		return float(degrees * std::numbers::pi_v<float> / 180.0f);
+		return degrees * std::numbers::pi_v<float> / 180.0f;
 	}
 
 	// Recalculates rotation to always be between [0, 2pi].

--- a/SharedSE/MathUtil.h
+++ b/SharedSE/MathUtil.h
@@ -1,35 +1,28 @@
 #pragma once
 
+#include <numbers>
 #include "NIPoint3.h"
 
 namespace se::math {
-	constexpr auto M_E = 2.71828182845904523536; // e
-	constexpr auto M_LOG2E = 1.44269504088896340736; // log2(e)
-	constexpr auto M_LOG10E = 0.434294481903251827651; // log10(e)
-	constexpr auto M_LN2 = 0.693147180559945309417; // ln(2)
-	constexpr auto M_LN10 = 2.30258509299404568402; // ln(10)
-	constexpr auto M_PI = 3.14159265358979323846; // pi
-	constexpr auto M_PIf = float(M_PI);
 	constexpr auto M_PI_2 = 1.57079632679489661923; // pi/2
 	constexpr auto M_PI_2f = float(M_PI_2);
 	constexpr auto M_PI_4 = 0.785398163397448309616; // pi/4
-	constexpr auto M_2PI = 2.0 * M_PI; // 2pi
+	constexpr auto M_2PI = 2.0 * std::numbers::pi; // 2pi
 	constexpr auto M_2PIf = float(M_2PI);
-	constexpr auto M_1_PI = 0.318309886183790671538; // 1/pi
 	constexpr auto M_2_PI = 0.636619772367581343076; // 2/pi
 	constexpr auto M_2_SQRTPI = 1.12837916709551257390; // 2/sqrt(pi)
-	constexpr auto M_SQRT2 = 1.41421356237309504880; // sqrt(2)
 	constexpr auto M_SQRT1_2 = 0.707106781186547524401; // 1/sqrt(2)
 	constexpr auto M_NORMALIZE_EPSILON = 1e-6f; // Epsilon for NiVector normalization.
 
 	inline float radiansToDegrees(float radians) {
-		return float(radians * 180.0 / M_PI);
+		return float(radians * 180.0f / std::numbers::pi_v<float>);
 	}
 
 	inline float degreesToRadians(float degrees) {
-		return float(degrees * M_PI / 180.0);
+		return float(degrees * std::numbers::pi_v<float> / 180.0f);
 	}
 
+	// Recalculates rotation to always be between [0, 2pi].
 	void standardizeAngleRadians(float& value);
 	
 	std::tuple<float, NI::Point3> rayPlaneIntersection(

--- a/SharedSE/NIMatrix33.cpp
+++ b/SharedSE/NIMatrix33.cpp
@@ -217,8 +217,6 @@ namespace NI {
 	}
 
 	bool Matrix33::toRotationDifference(const Point3& a, const Point3& b) {
-		using se::math::M_PIf;
-
 		auto axis = a.crossProduct(&b);
 		auto norm = axis.length();
 		if (norm <= 1e-5) {
@@ -229,7 +227,7 @@ namespace NI {
 			axis = axis / norm;
 			auto angle = asin(norm);
 			if (a.dotProduct(&b) < 0) {
-				angle = M_PIf - angle;
+				angle = std::numbers::pi_v<float> - angle;
 			}
 			toRotation(-angle, axis);
 			return true;

--- a/SharedSE/NIQuaternion.cpp
+++ b/SharedSE/NIQuaternion.cpp
@@ -131,7 +131,7 @@ namespace NI {
 			half_theta = 0;
 		}
 		else if (dot_product <= -1.0) {
-			half_theta = se::math::M_PI;
+			half_theta = std::numbers::pi;
 		}
 		else {
 			half_theta = std::acos(dot_product);


### PR DESCRIPTION
- Use mathematical [constants from the standard library](https://en.cppreference.com/cpp/numeric/constants) where possible. I removed constants that also exist in the `std::numbers` header.
- Use already available degrees<->radians conversion functions where possible 
- Simplify standardizeAngleRadians and use it in TES3Reference.cpp