### PR TITLE
Guard agains empty child slots in AVObject:traverse

### DIFF
--- a/MWSE/NIObjectLua.cpp
+++ b/MWSE/NIObjectLua.cpp
@@ -16,6 +16,9 @@
 
 namespace {
 	bool passesTraverseFilters(const NI::AVObject* object, const std::unordered_set<unsigned int>& typeFilters, std::string_view prefix) {
+		if (object == nullptr) {
+			return false;
+		}
 		bool passesFilter = typeFilters.empty() ? true : false;
 		if (!passesFilter) {
 			for (const auto type : typeFilters) {


### PR DESCRIPTION
Attempt at fixing a bug reported by Storm. Apparently, calling traverse on a mesh with an empty child slot will cause a crash. 