### PR TITLE
Skip the local-map borrow/restore on cell-crosses where no tile renders

### DIFF
--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -2233,9 +2233,63 @@ namespace mwse::patch {
 		sHoistDoneLand = true;
 	}
 
+	// Defer the local-map geometry borrow to the first cell-cross tile that actually renders, and skip the
+	// matching restore when nothing was borrowed. This drops the world-water-plane restore traversal on backtrack crosses, where every tile is already cached and none render.
+	static const auto TES3_MapController_borrowMapGeometry = reinterpret_cast<void(__thiscall*)(TES3::MapController*)>(0x420DB0);
+	static const auto TES3_MapController_restoreMapGeometry = reinterpret_cast<void(__thiscall*)(TES3::MapController*)>(0x421100);
+	static const auto TES3_MapController_renderCellMapTile = reinterpret_cast<TES3::Cell::MappingVisuals* (__thiscall*)(TES3::MapController*, int, int, TES3::Cell*, NI::Point3, float, TES3::Cell::MappingVisuals*)>(0x41FEA0);
+	static const auto TES3_MapController_renderInteriorMap = reinterpret_cast<void(__thiscall*)(TES3::MapController*, TES3::Cell*)>(0x41F680);
+	static const unsigned char* const data_localMapTileCoverageMask = reinterpret_cast<const unsigned char*>(0x777748);
+
+	static TES3::MapController* sMapBorrowController = nullptr;
+	static bool sMapGeometryBorrowed = false;
+
+	static bool PatchDeferMapBorrow_WillRenderTile(TES3::Cell* cell, int tileY, int tileX) {
+		if (cell == nullptr) {
+			return false;
+		}
+		if (cell->getIsInterior() || tileY < 0 || tileY > 2 || tileX < 0 || tileX > 2) {
+			return true;
+		}
+		const auto* mappingVisuals = cell->mappingVisuals;
+		if (mappingVisuals == nullptr) {
+			return true;
+		}
+		const unsigned short mask = data_localMapTileCoverageMask[3 * tileY + tileX];
+		return static_cast<unsigned short>(mappingVisuals->coverageMask & mask) != mask;
+	}
+
+	static void __fastcall PatchDeferMapBorrow_OnBorrow(TES3::MapController* mapController, DWORD _EDX_) {
+		sMapBorrowController = mapController;
+		sMapGeometryBorrowed = false;
+	}
+
+	static TES3::Cell::MappingVisuals* __fastcall PatchDeferMapBorrow_OnRenderTile(TES3::MapController* mapController, DWORD _EDX_, int tileY, int tileX, TES3::Cell* cell, NI::Point3 worldPos, float northMarkerOrientation, TES3::Cell::MappingVisuals* accumulator) {
+		if (!sMapGeometryBorrowed && PatchDeferMapBorrow_WillRenderTile(cell, tileY, tileX)) {
+			TES3_MapController_borrowMapGeometry(sMapBorrowController ? sMapBorrowController : mapController);
+			sMapGeometryBorrowed = true;
+		}
+		return TES3_MapController_renderCellMapTile(mapController, tileY, tileX, cell, worldPos, northMarkerOrientation, accumulator);
+	}
+
+	static void __fastcall PatchDeferMapBorrow_OnRenderInteriorMap(TES3::MapController* mapController, DWORD _EDX_, TES3::Cell* cell) {
+		if (!sMapGeometryBorrowed) {
+			TES3_MapController_borrowMapGeometry(sMapBorrowController ? sMapBorrowController : mapController);
+			sMapGeometryBorrowed = true;
+		}
+		TES3_MapController_renderInteriorMap(mapController, cell);
+	}
+
+	static void __fastcall PatchDeferMapBorrow_OnRestore(TES3::MapController* mapController, DWORD _EDX_) {
+		if (sMapGeometryBorrowed) {
+			TES3_MapController_restoreMapGeometry(mapController);
+			sMapGeometryBorrowed = false;
+		}
+	}
+
 	//
 	// Patch: Optimize relighting of actors during cell transition.
-	// 
+	//
 	// Actor teardown: skip markActorCorpse's redundant AIPlanner::enterLeaveSimulation when the actor has
 	// already left simulation, and memoize resetCollisionGroup's loop-invariant root-collision-node search.
 	//
@@ -3071,6 +3125,16 @@ namespace mwse::patch {
 		genCallEnforced(0x420089, 0x6EB0E0, reinterpret_cast<DWORD>(&PatchOptimizeMapUpdates_WrapUpdateProperties));
 		genCallEnforced(0x420090, 0x6EB380, reinterpret_cast<DWORD>(&PatchOptimizeMapUpdates_WrapUpdateEffects));
 		genCallEnforced(0x42009E, 0x6EB000, reinterpret_cast<DWORD>(&PatchOptimizeMapUpdates_WrapUpdate));
+
+		// Patch: Skip the local-map borrow/restore on cell-crosses where no tile renders.
+		genCallEnforced(0x486B09, 0x420DB0, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnBorrow));
+		genCallEnforced(0x486F5B, 0x420DB0, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnBorrow));
+		genCallEnforced(0x486F0F, 0x421100, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRestore));
+		genCallEnforced(0x486F99, 0x421100, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRestore));
+		genCallEnforced(0x486F72, 0x41F680, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRenderInteriorMap));
+		for (DWORD site : { 0x486B7Bu, 0x486BF6u, 0x486C8Au, 0x486D06u, 0x486D8Au, 0x486DE9u, 0x486E5Fu, 0x486EBEu }) {
+			genCallEnforced(site, 0x41FEA0, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRenderTile));
+		}
 
 		// Patch: Optimize relighting of actors during cell transition.
 		auto DataHandler_relightExteriorCellsAfterCross = &TES3::DataHandler::relightExteriorCellsAfterCross;

--- a/MWSE/TES3Cell.h
+++ b/MWSE/TES3Cell.h
@@ -101,7 +101,8 @@ namespace TES3 {
 			int unknown_0x0;
 			int unknown_0x4;
 			int unknown_0x8;
-			int unknown_0xC;
+			unsigned short coverageMask; // 0xC
+			unsigned short unknown_0xE; // 0xE
 			int unknown_0x10;
 			NI::Pointer<NI::SourceTexture> texture; // 0x14
 

--- a/MWSE/TES3WorldController.h
+++ b/MWSE/TES3WorldController.h
@@ -119,6 +119,28 @@ namespace TES3 {
 	};
 	static_assert(sizeof(WorldControllerRenderTarget) == 0x84, "TES3::WorldControllerRenderTarget failed size validation");
 
+	struct MapController {
+		char localMapTileVector[0x10]; // 0x0
+		unsigned short tileCountY; // 0x10
+		unsigned short tileCountX; // 0x12
+		int unknown_0x14;
+		void* unknown_0x18;
+		float northMarkerRotationDegrees; // 0x1C
+		NI::Node* nodePick; // 0x20
+		NI::Node* nodeObjects; // 0x24
+		NI::Node* nodeLand; // 0x28
+		NI::Node* nodeWater; // 0x2C
+		NI::Node* waterNodeParent; // 0x30
+		char cachedPickNodeCulled; // 0x34
+		char cachedObjectsNodeCulled; // 0x35
+		char cachedLandNodeCulled; // 0x36
+		char cachedWaterNodeCulled; // 0x37
+
+		MapController() = delete;
+		~MapController() = delete;
+	};
+	static_assert(sizeof(MapController) == 0x38, "TES3::MapController failed size validation");
+
 	struct MouseController {
 		NI::Object* cursors[5];
 		int unknown_0x14;
@@ -385,7 +407,7 @@ namespace TES3 {
 		WorldControllerRenderTarget mapRenderTarget; // 0x22C
 		WorldControllerRenderCamera shadowCamera; // 0x2B0
 		void * shadowManager; // 0x2DC
-		void * mapController; // 0x2E0
+		MapController * mapController; // 0x2E0
 		UI::MenuController * menuController; // 0x2E4
 		InventoryData * inventoryData; // 0x2E8
 		Sound * soundWeaponSwish; // 0x2EC


### PR DESCRIPTION
Skip the local-map borrow/restore on cell-crosses where no tile renders

On every exterior cell-cross the engine borrows all loaded cells' statics/land/water into the map scene, renders the newly-seen tiles, then restores them. The restore's world-water-plane property traversal runs on every cross — including backtracks through already-explored cells where all tiles are cached and nothing actually renders, making that work pure waste.

This defers the borrow until the first tile that will actually render, and skips the restore entirely when nothing was borrowed. The render-need check is a side-effect-free replica of the engine's own seen-test, biased so it can only ever over-borrow (wasted work), never blank a tile. It composes with the existing map-update hoist from #708 (that works at the UpdateProperties/Effects sites inside renderCellMapTile; this works at the borrow/restore/render-tile sites in updateCellThreadLoader).

Measured (Morrowind Refreshed, DXVK): on backtrack crosses (click=readback=0) the restore cost 2.5–5.9 ms of pure waste — eliminated here. The borrow itself is 0.07–0.79 ms (untouched), and first-visit crosses are unchanged.

Commits

Model TES3::MapController — adds the MapController struct (layout verified against the binary) and retypes WorldController::mapController from void*.
Skip local-map borrow/restore on cell-crosses with no rendered tile — the patch itself.