### PR TITLE
Optimize `NiDX8Renderer` hash map lookups.

### DIFF
--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -3094,6 +3094,14 @@ namespace mwse::patch {
 		genCallEnforced(0x56F0AF, 0x565350, reinterpret_cast<DWORD>(&ActorTeardownDedupLeaveSimulation));
 		genCallEnforced(0x55ECC0, 0x6FD680, reinterpret_cast<DWORD>(&ActorTeardownResetRootSearchCache));
 		genCallEnforced(0x55ED1B, 0x6A3080, reinterpret_cast<DWORD>(&ActorTeardownMemoizedRootSearch));
+
+		// Patch: Optimize renderer hash map lookups. Use `NiDX8RendererHashBuckets` buckets instead of 37.
+		constexpr DWORD NiDX8RendererHashBuckets = 4093; // Prime, ~16KB per map.
+		writeDoubleWordEnforced(0x6A9AED, 37, NiDX8RendererHashBuckets); // mov ebp, 25h
+		writeDoubleWordEnforced(0x6A9AF2, 0x94, NiDX8RendererHashBuckets * 4); // push 94h (geometry buffers)
+		writeDoubleWordEnforced(0x6A9B38, 0x94, NiDX8RendererHashBuckets * 4); // push 94h (skin partitions)
+		writeDoubleWordEnforced(0x6A9B7E, 0x94, NiDX8RendererHashBuckets * 4); // push 94h (rendered textures)
+		writeDoubleWordEnforced(0x6A9BC4, 0x94, NiDX8RendererHashBuckets * 4); // push 94h (rendered cubemaps)
 	}
 
 	void installPostLuaPatches() {


### PR DESCRIPTION
`NiDX8Renderer` uses a fixed size for its hashmap buckets count, 37.

This may have made more sense in 2001 when memory constraints were a big problem and nobody could render large scenes anyways. In a modern MW install, in a city or complex interior, we might have 5000+ drawables active in the scene. 

Profiling the same scene (Karthwasten) for 3 seconds:

Note: The **createGeometryBufferData** function is where the lookups happen.

<details>
<summary>Before -> (5000 / 37 + 1) / 2 == ~68 comparisons per lookup</summary>
<img width="1211" height="1316" alt="image" src="https://github.com/user-attachments/assets/b6a88b38-bbce-4bc0-b772-f715585bddbe" />
</details>

<details>
<summary>After -> (5000 / 4093 + 1) /2 == ~1 comparisons per lookup</summary>
<img width="1211" height="1316" alt="image" src="https://github.com/user-attachments/assets/ae3bb459-373e-4e6f-a823-eb8a5a4af329" />
</details>

Minus ~200 million instructions over the 3-second window. The 2nd highest CPU time (77ms) moves to far down the list (7ms).

I did not do much experimenting with fine tuning the bucket count. In scenes with less geometry data instances it may be worth using a smaller value, but hashmap lookups in those are not anywhere near the top of the profiler hotspots.