### PR TITLE
Take the local-map work off the cell-cross frame (builds on #712)

### DIFF
--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -2310,6 +2310,12 @@ namespace mwse::patch {
 
 		static void(__thiscall* sChainTickClock)(TES3::WorldController*) = nullptr;
 
+		// Deferred compositor: the cross marks it pending; it runs once in the tick drain, after the
+		// tile completions, when the GPU queue has drained. Rapid crosses coalesce into one run.
+		static const auto TES3_MapController_updateMapRenderEngine = reinterpret_cast<void(__thiscall*)(TES3::MapController*)>(0x420400);
+		static bool sCompositorPending = false;
+		static int sCompositorAge = 0;
+
 		static bool isTestingCells() {
 			// DataHandler.flagTestingCells (-createmaps mode); not yet typed in MWSE.
 			return *(reinterpret_cast<const char*>(TES3::DataHandler::get()) + 0xB4DD) != 0;
@@ -2537,10 +2543,22 @@ namespace mwse::patch {
 			TES3_RecordsHandler_mapDrawCell(recordsHandler, cell);
 		}
 
+		static void __fastcall OnDeferCompositor(TES3::MapController* mapController, DWORD _EDX_) {
+			sCompositorPending = true;
+			sCompositorAge = 0;
+		}
+
 		static void __fastcall OnTickClock(TES3::WorldController* worldController, DWORD _EDX_) {
 			for (auto& pending : sPending) {
 				if (pending.cell && ++pending.age >= 3) {
 					completeOne(pending);
+				}
+			}
+			if (sCompositorPending && ++sCompositorAge >= 3) {
+				sCompositorPending = false;
+				auto mapController = worldController->mapController;
+				if (mapController) {
+					TES3_MapController_updateMapRenderEngine(mapController);
 				}
 			}
 			sChainTickClock(worldController);
@@ -3450,6 +3468,8 @@ namespace mwse::patch {
 		// GPU->CPU readback and the world-map paint off the cross frame.
 		genCallEnforced(0x4E32FE, 0x4C81C0, reinterpret_cast<DWORD>(&PatchMapTileDirectDisplay::OnMapDrawCell));
 		genCallEnforced(0x4854CD, 0x41DFB0, reinterpret_cast<DWORD>(&PatchMapTileDirectDisplay::OnReleaseAllMapTextures));
+		genCallEnforced(0x486F1F, 0x420400, reinterpret_cast<DWORD>(&PatchMapTileDirectDisplay::OnDeferCompositor));
+		genCallEnforced(0x486FA9, 0x420400, reinterpret_cast<DWORD>(&PatchMapTileDirectDisplay::OnDeferCompositor));
 		for (DWORD site : { 0x486B7Bu, 0x486BF6u, 0x486C8Au, 0x486D06u, 0x486D8Au, 0x486DE9u, 0x486E5Fu, 0x486EBEu }) {
 			genCallEnforced(site, 0x41FEA0, reinterpret_cast<DWORD>(&PatchMapTileDirectDisplay::OnRenderCellMapTile));
 		}

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -2568,6 +2568,7 @@ namespace mwse::patch {
 			}
 			sCapsChecked = false;
 			sUnsupported = false;
+			TES3::WorldControllerRenderTarget::clearFogCache();
 			TES3_MapController_releaseAllTextures(mapController);
 		}
 	}
@@ -2577,6 +2578,21 @@ namespace mwse::patch {
 			TES3_MapController_restoreMapGeometry(mapController);
 			sMapGeometryBorrowed = false;
 		}
+	}
+
+	//
+	// Patch: Persist the fog-of-war pixel cache across compositor passes.
+	//
+	// Every fog draw funnels through updateFogOfWarVertexBuffer, so invalidating the drawn tile's cache
+	// entry there keeps the cache exact while persisting it across passes - the GPU lock then runs only
+	// when a queried tile's fog actually changed.
+	//
+
+	static const auto TES3_WorldControllerRenderTarget_updateFogOfWarVertexBuffer = reinterpret_cast<int(__thiscall*)(TES3::WorldControllerRenderTarget*, NI::RenderedTexture*, int, short, float)>(0x42FA50);
+
+	static int __fastcall PatchPersistentFogCache_OnFogDraw(TES3::WorldControllerRenderTarget* renderTarget, DWORD _EDX_, NI::RenderedTexture* texture, int fowX, short fowY, float radius) {
+		TES3::WorldControllerRenderTarget::invalidateFogCacheTexture(texture);
+		return TES3_WorldControllerRenderTarget_updateFogOfWarVertexBuffer(renderTarget, texture, fowX, fowY, radius);
 	}
 
 	//
@@ -3424,6 +3440,11 @@ namespace mwse::patch {
 		genCallEnforced(0x486F0F, 0x421100, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRestore));
 		genCallEnforced(0x486F99, 0x421100, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRestore));
 		genCallEnforced(0x486F72, 0x41F680, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRenderInteriorMap));
+
+		// Patch: Persist the fog-of-war pixel cache across compositor passes (invalidate on fog draw).
+		for (DWORD site : { 0x42082Cu, 0x4208C2u, 0x420A7Fu, 0x420BB9u, 0x420CC8u, 0x421CE4u, 0x42FD7Cu }) {
+			genCallEnforced(site, 0x42FA50, reinterpret_cast<DWORD>(&PatchPersistentFogCache_OnFogDraw));
+		}
 
 		// Patch: Render local-map tiles into per-tile render targets, displayed directly; defer the
 		// GPU->CPU readback and the world-map paint off the cross frame.

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -2233,9 +2233,63 @@ namespace mwse::patch {
 		sHoistDoneLand = true;
 	}
 
+	// Defer the local-map geometry borrow to the first cell-cross tile that actually renders, and skip the
+	// matching restore when nothing was borrowed. This drops the world-water-plane restore traversal on backtrack crosses, where every tile is already cached and none render.
+	static const auto TES3_MapController_borrowMapGeometry = reinterpret_cast<void(__thiscall*)(TES3::MapController*)>(0x420DB0);
+	static const auto TES3_MapController_restoreMapGeometry = reinterpret_cast<void(__thiscall*)(TES3::MapController*)>(0x421100);
+	static const auto TES3_MapController_renderCellMapTile = reinterpret_cast<TES3::Cell::MappingVisuals* (__thiscall*)(TES3::MapController*, int, int, TES3::Cell*, NI::Point3, float, TES3::Cell::MappingVisuals*)>(0x41FEA0);
+	static const auto TES3_MapController_renderInteriorMap = reinterpret_cast<void(__thiscall*)(TES3::MapController*, TES3::Cell*)>(0x41F680);
+	static const unsigned char* const data_localMapTileCoverageMask = reinterpret_cast<const unsigned char*>(0x777748);
+
+	static TES3::MapController* sMapBorrowController = nullptr;
+	static bool sMapGeometryBorrowed = false;
+
+	static bool PatchDeferMapBorrow_WillRenderTile(TES3::Cell* cell, int tileY, int tileX) {
+		if (cell == nullptr) {
+			return false;
+		}
+		if (cell->getIsInterior() || tileY < 0 || tileY > 2 || tileX < 0 || tileX > 2) {
+			return true;
+		}
+		const auto* mappingVisuals = cell->mappingVisuals;
+		if (mappingVisuals == nullptr) {
+			return true;
+		}
+		const unsigned short mask = data_localMapTileCoverageMask[3 * tileY + tileX];
+		return static_cast<unsigned short>(mappingVisuals->coverageMask & mask) != mask;
+	}
+
+	static void __fastcall PatchDeferMapBorrow_OnBorrow(TES3::MapController* mapController, DWORD _EDX_) {
+		sMapBorrowController = mapController;
+		sMapGeometryBorrowed = false;
+	}
+
+	static TES3::Cell::MappingVisuals* __fastcall PatchDeferMapBorrow_OnRenderTile(TES3::MapController* mapController, DWORD _EDX_, int tileY, int tileX, TES3::Cell* cell, NI::Point3 worldPos, float northMarkerOrientation, TES3::Cell::MappingVisuals* accumulator) {
+		if (!sMapGeometryBorrowed && PatchDeferMapBorrow_WillRenderTile(cell, tileY, tileX)) {
+			TES3_MapController_borrowMapGeometry(sMapBorrowController ? sMapBorrowController : mapController);
+			sMapGeometryBorrowed = true;
+		}
+		return TES3_MapController_renderCellMapTile(mapController, tileY, tileX, cell, worldPos, northMarkerOrientation, accumulator);
+	}
+
+	static void __fastcall PatchDeferMapBorrow_OnRenderInteriorMap(TES3::MapController* mapController, DWORD _EDX_, TES3::Cell* cell) {
+		if (!sMapGeometryBorrowed) {
+			TES3_MapController_borrowMapGeometry(sMapBorrowController ? sMapBorrowController : mapController);
+			sMapGeometryBorrowed = true;
+		}
+		TES3_MapController_renderInteriorMap(mapController, cell);
+	}
+
+	static void __fastcall PatchDeferMapBorrow_OnRestore(TES3::MapController* mapController, DWORD _EDX_) {
+		if (sMapGeometryBorrowed) {
+			TES3_MapController_restoreMapGeometry(mapController);
+			sMapGeometryBorrowed = false;
+		}
+	}
+
 	//
 	// Patch: Optimize relighting of actors during cell transition.
-	// 
+	//
 	// Actor teardown: skip markActorCorpse's redundant AIPlanner::enterLeaveSimulation when the actor has
 	// already left simulation, and memoize resetCollisionGroup's loop-invariant root-collision-node search.
 	//
@@ -3071,6 +3125,16 @@ namespace mwse::patch {
 		genCallEnforced(0x420089, 0x6EB0E0, reinterpret_cast<DWORD>(&PatchOptimizeMapUpdates_WrapUpdateProperties));
 		genCallEnforced(0x420090, 0x6EB380, reinterpret_cast<DWORD>(&PatchOptimizeMapUpdates_WrapUpdateEffects));
 		genCallEnforced(0x42009E, 0x6EB000, reinterpret_cast<DWORD>(&PatchOptimizeMapUpdates_WrapUpdate));
+
+		// Patch: Skip the local-map borrow/restore on cell-crosses where no tile renders.
+		genCallEnforced(0x486B09, 0x420DB0, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnBorrow));
+		genCallEnforced(0x486F5B, 0x420DB0, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnBorrow));
+		genCallEnforced(0x486F0F, 0x421100, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRestore));
+		genCallEnforced(0x486F99, 0x421100, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRestore));
+		genCallEnforced(0x486F72, 0x41F680, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRenderInteriorMap));
+		for (DWORD site : { 0x486B7Bu, 0x486BF6u, 0x486C8Au, 0x486D06u, 0x486D8Au, 0x486DE9u, 0x486E5Fu, 0x486EBEu }) {
+			genCallEnforced(site, 0x41FEA0, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRenderTile));
+		}
 
 		// Patch: Optimize relighting of actors during cell transition.
 		auto DataHandler_relightExteriorCellsAfterCross = &TES3::DataHandler::relightExteriorCellsAfterCross;

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -39,14 +39,19 @@
 #include "TES3UIMenuController.h"
 #include "TES3VFXManager.h"
 #include "TES3VoiceStreamer.h"
+#include "TES3WaterController.h"
 #include "TES3WorldController.h"
 #include "ReferenceTracker.h"
 
 #include "NIAVObject.h"
 #include "NIBound.h"
+#include "NICamera.h"
 #include "NICollisionGroup.h"
 #include "NICollisionSwitch.h"
+#include "NIDX8Renderer.h"
+#include "NINode.h"
 #include "NIPoint3.h"
+#include "NIRenderedTexture.h"
 #include "NIFlipController.h"
 #include "NILinesData.h"
 #include "NIPick.h"
@@ -2264,20 +2269,307 @@ namespace mwse::patch {
 		sMapGeometryBorrowed = false;
 	}
 
-	static TES3::Cell::MappingVisuals* __fastcall PatchDeferMapBorrow_OnRenderTile(TES3::MapController* mapController, DWORD _EDX_, int tileY, int tileX, TES3::Cell* cell, NI::Point3 worldPos, float northMarkerOrientation, TES3::Cell::MappingVisuals* accumulator) {
-		if (!sMapGeometryBorrowed && PatchDeferMapBorrow_WillRenderTile(cell, tileY, tileX)) {
-			TES3_MapController_borrowMapGeometry(sMapBorrowController ? sMapBorrowController : mapController);
-			sMapGeometryBorrowed = true;
-		}
-		return TES3_MapController_renderCellMapTile(mapController, tileY, tileX, cell, worldPos, northMarkerOrientation, accumulator);
-	}
-
 	static void __fastcall PatchDeferMapBorrow_OnRenderInteriorMap(TES3::MapController* mapController, DWORD _EDX_, TES3::Cell* cell) {
 		if (!sMapGeometryBorrowed) {
 			TES3_MapController_borrowMapGeometry(sMapBorrowController ? sMapBorrowController : mapController);
 			sMapGeometryBorrowed = true;
 		}
 		TES3_MapController_renderInteriorMap(mapController, cell);
+	}
+
+	//
+	// Patch: Render local-map tiles into per-tile render targets, displayed directly; defer the GPU->CPU
+	// readback off the cross frame.
+	//
+	// Each new tile renders into an owned render target that the map displays immediately, and is
+	// converted to the engine's CPU-backed record a few ticks later when the GPU has finished - the
+	// readback lock is then instant instead of stalling the cross frame. Interiors, map-making mode,
+	// and unsupported hardware fall back to the engine path.
+	//
+
+	namespace PatchMapTileDirectDisplay {
+		static const auto TES3_RecordsHandler_mapDrawCell = reinterpret_cast<void(__thiscall*)(TES3::NonDynamicData*, TES3::Cell*)>(0x4C81C0);
+		static const auto TES3_WaterController_renderWater = reinterpret_cast<void(__thiscall*)(TES3::WaterController*, NI::Camera*, int)>(0x51C550);
+		static const auto TES3_LoadScreenManager_renderMutexLock = reinterpret_cast<void(__thiscall*)(void*)>(0x458D70);
+		static const auto TES3_LoadScreenManager_renderMutexUnlock = reinterpret_cast<void(__thiscall*)(void*)>(0x458DA0);
+		static const auto TES3_MapController_releaseAllTextures = reinterpret_cast<void(__thiscall*)(TES3::MapController*)>(0x41DFB0);
+		static const auto NI_RenderedTexture_create = reinterpret_cast<NI::RenderedTexture* (__cdecl*)(unsigned int, unsigned int, NI::Renderer*, const NI::Texture::FormatPrefs*)>(0x6DC090);
+
+		struct PendingTile {
+			NI::Pointer<NI::RenderedTexture> texture;
+			TES3::Cell* cell = nullptr;
+			int age = 0;
+			bool worldMapPaintPending = false;
+		};
+		constexpr int kPendingCap = 12;
+		static PendingTile sPending[kPendingCap];
+		static NI::Pointer<NI::RenderedTexture> sRecycledTextures[kPendingCap];
+		static bool sUnsupported = false;
+		static bool sCapsChecked = false;
+		static bool sScenePrepared = false;
+
+		static void(__thiscall* sChainTickClock)(TES3::WorldController*) = nullptr;
+
+		static bool isTestingCells() {
+			// DataHandler.flagTestingCells (-createmaps mode); not yet typed in MWSE.
+			return *(reinterpret_cast<const char*>(TES3::DataHandler::get()) + 0xB4DD) != 0;
+		}
+
+		static IDirect3DDevice8* getD3DDevice(NI::Renderer* renderer) {
+			return static_cast<NI::DX8Renderer*>(renderer)->d3dDevice;
+		}
+
+		static bool ensureColorWriteCapable(NI::Renderer* renderer) {
+			if (!sCapsChecked) {
+				sCapsChecked = true;
+				D3DCAPS8 caps = {};
+				auto device = getD3DDevice(renderer);
+				if (device == nullptr || FAILED(device->GetDeviceCaps(&caps)) || (caps.PrimitiveMiscCaps & D3DPMISCCAPS_COLORWRITEENABLE) == 0) {
+					sUnsupported = true;
+				}
+			}
+			return !sUnsupported;
+		}
+
+		static NI::Pointer<NI::RenderedTexture> acquireTexture(TES3::WorldControllerRenderTarget& mapRT) {
+			for (auto& recycled : sRecycledTextures) {
+				if (recycled) {
+					NI::Pointer<NI::RenderedTexture> result = recycled;
+					recycled = nullptr;
+					return result;
+				}
+			}
+			NI::Texture::FormatPrefs prefs(NI::Texture::FormatPrefs::PixelLayout::PIX_DEFAULT, NI::Texture::FormatPrefs::MipFlag::NO, NI::Texture::FormatPrefs::AlphaFormat::SMOOTH);
+			return NI_RenderedTexture_create(mapRT.targetWidth, mapRT.targetHeight, mapRT.renderer, &prefs);
+		}
+
+		// The visible 3x3 ring position of a loaded exterior cell, using the exteriorCellData ordering
+		// the engine's own purge re-render loop uses: index k -> tileX = k / 3, tileY = 2 - k % 3.
+		static bool currentRingCoords(const TES3::Cell* cell, int& tileY, int& tileX) {
+			auto dataHandler = TES3::DataHandler::get();
+			if (dataHandler == nullptr || dataHandler->currentInteriorCell) {
+				return false;
+			}
+			for (int k = 0; k < 9; ++k) {
+				auto cellData = dataHandler->exteriorCellData[k];
+				if (cellData && cellData->cell == cell) {
+					tileX = k / 3;
+					tileY = 2 - k % 3;
+					return true;
+				}
+			}
+			return false;
+		}
+
+		// Convert a pending tile's RT into the engine's CPU-backed NiSourceTexture record. Runs ticks
+		// after the render, so the GPU has finished and the lock does not stall.
+		static void completeOne(PendingTile& pending) {
+			auto cell = pending.cell;
+			pending.cell = nullptr;
+			auto& mapRT = TES3::WorldController::get()->mapRenderTarget;
+			auto mappingVisuals = cell ? cell->mappingVisuals : nullptr;
+			if (mappingVisuals && static_cast<void*>(mappingVisuals->texture) == static_cast<void*>(pending.texture)) {
+				auto lockedRect = mapRT.lockRenderTarget(pending.texture.get());
+				if (lockedRect) {
+					mapRT.readbackRenderedTexture(lockedRect);
+					mapRT.unlockRenderTarget(lockedRect, 0);
+					mappingVisuals->texture = mapRT.readbackTexture;
+					mapRT.readbackTexture = nullptr;
+					int tileY, tileX;
+					if (currentRingCoords(cell, tileY, tileX)) {
+						cell->refreshMapTileFromCache(tileY, tileX);
+					}
+					if (pending.worldMapPaintPending) {
+						TES3_RecordsHandler_mapDrawCell(TES3::DataHandler::get()->nonDynamicData, cell);
+					}
+				}
+				else {
+					cell->maybeDeleteMappingVisuals(0);
+					cell->mappingVisuals = nullptr;
+				}
+			}
+			for (auto& recycled : sRecycledTextures) {
+				if (recycled == nullptr) {
+					recycled = pending.texture;
+					break;
+				}
+			}
+			pending.texture = nullptr;
+			pending.age = 0;
+			pending.worldMapPaintPending = false;
+		}
+
+		static PendingTile* acquirePendingSlot() {
+			PendingTile* oldest = nullptr;
+			for (auto& pending : sPending) {
+				if (pending.cell == nullptr) {
+					return &pending;
+				}
+				if (oldest == nullptr || pending.age > oldest->age) {
+					oldest = &pending;
+				}
+			}
+			completeOne(*oldest);
+			return oldest;
+		}
+
+		// Render the bound map scene into the given RT: the render-only body of the engine's drawMap
+		// (0x42E320), minus the recreate logic and the synchronous readback, plus the opaque bracket.
+		static bool renderTileToTexture(TES3::WorldControllerRenderTarget& mapRT, NI::RenderedTexture* texture) {
+			auto loadScreenManager = TES3::Game::get()->loadScreenManager;
+			if (loadScreenManager) {
+				TES3_LoadScreenManager_renderMutexLock(loadScreenManager);
+			}
+			NI::Renderer* renderer = mapRT.renderer;
+			bool rendered = renderer->setRenderTarget(texture);
+			if (rendered) {
+				auto camera = mapRT.getCamera();
+				camera->clear(static_cast<NI::Renderer::ClearFlags>(NI::Renderer::ClearFlags::BACKBUFFER | NI::Renderer::ClearFlags::ZBUFFER));
+				auto device = getD3DDevice(renderer);
+				device->Clear(0, nullptr, D3DCLEAR_TARGET, D3DCOLOR_ARGB(255, 0, 0, 0), 1.0f, 0);
+				NI::Pointer<NI::Accumulator> savedAccumulator = renderer->accumulator;
+				renderer->accumulator = reinterpret_cast<NI::Accumulator*>(mapRT.accumulator.get());
+				device->SetRenderState(D3DRS_COLORWRITEENABLE, D3DCOLORWRITEENABLE_RED | D3DCOLORWRITEENABLE_GREEN | D3DCOLORWRITEENABLE_BLUE);
+				camera->click(false);
+				auto waterController = TES3::DataHandler::get()->waterController;
+				if (waterController && waterController->pixelShaderEnabled) {
+					TES3_WaterController_renderWater(waterController, camera, 1);
+				}
+				device->SetRenderState(D3DRS_COLORWRITEENABLE, D3DCOLORWRITEENABLE_RED | D3DCOLORWRITEENABLE_GREEN | D3DCOLORWRITEENABLE_BLUE | D3DCOLORWRITEENABLE_ALPHA);
+				renderer->accumulator = savedAccumulator;
+				renderer->setRenderTarget(nullptr);
+			}
+			if (loadScreenManager) {
+				TES3_LoadScreenManager_renderMutexUnlock(loadScreenManager);
+			}
+			return rendered;
+		}
+
+		// Owned exterior renderCellMapTile (faithful to 0x41FEA0), rendering into an owned RT that is
+		// displayed directly. Subsumes the deferred-borrow render gate.
+		static TES3::Cell::MappingVisuals* __fastcall OnRenderCellMapTile(TES3::MapController* mapController, DWORD _EDX_, int tileY, int tileX, TES3::Cell* cell, NI::Point3 worldPos, float northMarkerOrientation, TES3::Cell::MappingVisuals* accumulator) {
+			if (!sMapGeometryBorrowed && PatchDeferMapBorrow_WillRenderTile(cell, tileY, tileX)) {
+				TES3_MapController_borrowMapGeometry(sMapBorrowController ? sMapBorrowController : mapController);
+				sMapGeometryBorrowed = true;
+				sScenePrepared = false;
+			}
+			if (sUnsupported || accumulator != nullptr || cell == nullptr || cell->getIsInterior() || isTestingCells()) {
+				return TES3_MapController_renderCellMapTile(mapController, tileY, tileX, cell, worldPos, northMarkerOrientation, accumulator);
+			}
+			if (cell->refreshMapTileFromCache(tileY, tileX) || tileY >= mapController->tileCountY || tileX >= mapController->tileCountX) {
+				return nullptr;
+			}
+
+			auto worldController = TES3::WorldController::get();
+			auto& mapRT = worldController->mapRenderTarget;
+			if (mapRT.renderer == nullptr || !ensureColorWriteCapable(mapRT.renderer)) {
+				return TES3_MapController_renderCellMapTile(mapController, tileY, tileX, cell, worldPos, northMarkerOrientation, accumulator);
+			}
+			auto texture = acquireTexture(mapRT);
+			if (texture == nullptr) {
+				return TES3_MapController_renderCellMapTile(mapController, tileY, tileX, cell, worldPos, northMarkerOrientation, accumulator);
+			}
+
+			constexpr float halfPi = 1.570795f;
+			NI::Point3 northAxis = { std::sin(northMarkerOrientation), std::cos(northMarkerOrientation), 0.0f };
+			const float perpSin = std::sin(northMarkerOrientation + halfPi);
+			const float perpCos = std::cos(northMarkerOrientation + halfPi);
+			NI::Point3 target = { float(cell->getGridX() << 13) + 4096.0f, float(cell->getGridY() << 13) + 4096.0f, 0.0f };
+
+			mapRT.setSceneNode(mapRT.root);
+			auto camera = mapRT.getCamera();
+			camera->localTranslate.x = target.x;
+			camera->localTranslate.y = target.y;
+			camera->localTranslate.z = target.z + 1000000.0f;
+			camera->update();
+			camera->LookAtWorldPoint(&target, &northAxis);
+			camera->update();
+			if (!sScenePrepared) {
+				mapRT.root->updateProperties();
+				mapRT.root->updateEffects();
+				mapController->nodeLand->update();
+				sScenePrepared = true;
+			}
+
+			const bool hasWater = cell->getHasWater();
+			if (hasWater) {
+				mapController->nodeWater->setAppCulled(false);
+			}
+			const bool rendered = renderTileToTexture(mapRT, texture);
+			if (hasWater) {
+				mapController->nodeWater->setAppCulled(true);
+			}
+			if (!rendered) {
+				return TES3_MapController_renderCellMapTile(mapController, tileY, tileX, cell, worldPos, northMarkerOrientation, accumulator);
+			}
+
+			const float positionX = target.x - perpSin * 4096.0f - northAxis.x * 4096.0f;
+			const float positionY = target.y - perpCos * 4096.0f - northAxis.y * 4096.0f;
+			auto visuals = TES3::Cell::MappingVisuals::create(positionX, positionY, data_localMapTileCoverageMask[3 * tileY + tileX]);
+			visuals->texture = reinterpret_cast<NI::SourceTexture*>(texture.get());
+			if (cell->mappingVisuals) {
+				cell->maybeDeleteMappingVisuals(0);
+			}
+			cell->mappingVisuals = visuals;
+
+			auto pending = acquirePendingSlot();
+			pending->texture = texture;
+			pending->cell = cell;
+			pending->age = 0;
+			pending->worldMapPaintPending = false;
+
+			cell->refreshMapTileFromCache(tileY, tileX);
+			return visuals;
+		}
+
+		// mapDrawCell needs the tile's CPU pixels; for a tile still living in an RT, defer the world-map
+		// paint to its completion.
+		static void __fastcall OnMapDrawCell(TES3::NonDynamicData* recordsHandler, DWORD _EDX_, TES3::Cell* cell) {
+			for (auto& pending : sPending) {
+				if (pending.cell == cell) {
+					auto mappingVisuals = cell->mappingVisuals;
+					if (mappingVisuals && static_cast<void*>(mappingVisuals->texture) == static_cast<void*>(pending.texture)) {
+						pending.worldMapPaintPending = true;
+						return;
+					}
+				}
+			}
+			TES3_RecordsHandler_mapDrawCell(recordsHandler, cell);
+		}
+
+		static void __fastcall OnTickClock(TES3::WorldController* worldController, DWORD _EDX_) {
+			for (auto& pending : sPending) {
+				if (pending.cell && ++pending.age >= 3) {
+					completeOne(pending);
+				}
+			}
+			sChainTickClock(worldController);
+		}
+
+		// Device reset: the RTs' contents are unrecoverable, so force the affected cells to re-render
+		// through the purge flow that follows this call.
+		static void __fastcall OnReleaseAllMapTextures(TES3::MapController* mapController, DWORD _EDX_) {
+			for (auto& pending : sPending) {
+				auto cell = pending.cell;
+				if (cell) {
+					auto mappingVisuals = cell->mappingVisuals;
+					if (mappingVisuals && static_cast<void*>(mappingVisuals->texture) == static_cast<void*>(pending.texture)) {
+						cell->maybeDeleteMappingVisuals(0);
+						cell->mappingVisuals = nullptr;
+					}
+				}
+				pending.texture = nullptr;
+				pending.cell = nullptr;
+				pending.age = 0;
+				pending.worldMapPaintPending = false;
+			}
+			for (auto& recycled : sRecycledTextures) {
+				recycled = nullptr;
+			}
+			sCapsChecked = false;
+			sUnsupported = false;
+			TES3_MapController_releaseAllTextures(mapController);
+		}
 	}
 
 	static void __fastcall PatchDeferMapBorrow_OnRestore(TES3::MapController* mapController, DWORD _EDX_) {
@@ -3132,8 +3424,18 @@ namespace mwse::patch {
 		genCallEnforced(0x486F0F, 0x421100, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRestore));
 		genCallEnforced(0x486F99, 0x421100, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRestore));
 		genCallEnforced(0x486F72, 0x41F680, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRenderInteriorMap));
+
+		// Patch: Render local-map tiles into per-tile render targets, displayed directly; defer the
+		// GPU->CPU readback and the world-map paint off the cross frame.
+		genCallEnforced(0x4E32FE, 0x4C81C0, reinterpret_cast<DWORD>(&PatchMapTileDirectDisplay::OnMapDrawCell));
+		genCallEnforced(0x4854CD, 0x41DFB0, reinterpret_cast<DWORD>(&PatchMapTileDirectDisplay::OnReleaseAllMapTextures));
 		for (DWORD site : { 0x486B7Bu, 0x486BF6u, 0x486C8Au, 0x486D06u, 0x486D8Au, 0x486DE9u, 0x486E5Fu, 0x486EBEu }) {
-			genCallEnforced(site, 0x41FEA0, reinterpret_cast<DWORD>(&PatchDeferMapBorrow_OnRenderTile));
+			genCallEnforced(site, 0x41FEA0, reinterpret_cast<DWORD>(&PatchMapTileDirectDisplay::OnRenderCellMapTile));
+		}
+		{
+			const DWORD chain = se::memory::getCallAddress(0x41B857);
+			PatchMapTileDirectDisplay::sChainTickClock = reinterpret_cast<void(__thiscall*)(TES3::WorldController*)>(chain);
+			genCallEnforced(0x41B857, chain, reinterpret_cast<DWORD>(&PatchMapTileDirectDisplay::OnTickClock));
 		}
 
 		// Patch: Optimize relighting of actors during cell transition.

--- a/MWSE/TES3Cell.cpp
+++ b/MWSE/TES3Cell.cpp
@@ -46,6 +46,25 @@ namespace TES3 {
 		return TES3_Cell_getExteriorGridX(this);
 	}
 
+	Cell::MappingVisuals* Cell::MappingVisuals::create(float positionX, float positionY, unsigned short coverageMask) {
+		auto* result = reinterpret_cast<MappingVisuals*>(se::memory::_new(sizeof(MappingVisuals)));
+		memset(result, 0, sizeof(MappingVisuals));
+		result->positionX = positionX;
+		result->positionY = positionY;
+		result->coverageMask = coverageMask;
+		return result;
+	}
+
+	const auto TES3_Cell_refreshMapTileFromCache = reinterpret_cast<bool(__thiscall *)(Cell*, int, int)>(0x4E3210);
+	bool Cell::refreshMapTileFromCache(int tileY, int tileX) {
+		return TES3_Cell_refreshMapTileFromCache(this, tileY, tileX);
+	}
+
+	const auto TES3_Cell_maybeDeleteMappingVisuals = reinterpret_cast<void(__thiscall *)(Cell*, int)>(0x4E3550);
+	void Cell::maybeDeleteMappingVisuals(int keepData) {
+		TES3_Cell_maybeDeleteMappingVisuals(this, keepData);
+	}
+
 	const auto TES3_Cell_setGridX = reinterpret_cast<void(__thiscall *)(Cell*, int)>(0x4DB9E0);
 	void Cell::setGridX(int x) {
 		const auto dataHandler = TES3::DataHandler::get();

--- a/MWSE/TES3Cell.h
+++ b/MWSE/TES3Cell.h
@@ -98,9 +98,9 @@ namespace TES3 {
 			~SourceMod() = delete;
 		};
 		struct MappingVisuals {
-			int unknown_0x0;
-			int unknown_0x4;
-			int unknown_0x8;
+			void* pixels; // 0x0
+			float positionX; // 0x4
+			float positionY; // 0x8
 			unsigned short coverageMask; // 0xC
 			unsigned short unknown_0xE; // 0xE
 			int unknown_0x10;
@@ -108,6 +108,8 @@ namespace TES3 {
 
 			MappingVisuals() = delete;
 			~MappingVisuals() = delete;
+
+			static MappingVisuals* create(float positionX, float positionY, unsigned short coverageMask);
 		};
 
 		char * name; // 0x10
@@ -199,6 +201,9 @@ namespace TES3 {
 
 		bool getIsInterior() const;
 		void setIsInterior(bool value);
+
+		bool refreshMapTileFromCache(int tileY, int tileX);
+		void maybeDeleteMappingVisuals(int keepData);
 
 		bool getSleepingIsIllegal() const;
 		void setSleepingIsIllegal(bool value);

--- a/MWSE/TES3Cell.h
+++ b/MWSE/TES3Cell.h
@@ -101,7 +101,8 @@ namespace TES3 {
 			int unknown_0x0;
 			int unknown_0x4;
 			int unknown_0x8;
-			int unknown_0xC;
+			unsigned short coverageMask; // 0xC
+			unsigned short unknown_0xE; // 0xE
 			int unknown_0x10;
 			NI::Pointer<NI::SourceTexture> texture; // 0x14
 

--- a/MWSE/TES3WorldController.cpp
+++ b/MWSE/TES3WorldController.cpp
@@ -75,7 +75,9 @@ namespace TES3 {
 		return TES3_WorldControllerRenderTarget_getFogOfWarPixel(this, texture, worldX, worldY);
 	}
 
-	// Fog-of-war pixel cache: a per-compositor-pass copy of each fog tile, keyed by texture.
+	// Fog-of-war pixel cache: a CPU copy of each fog tile, keyed by texture. Entries persist across
+	// compositor passes; a tile's entry is invalidated when fog is drawn to it, so the GPU lock runs
+	// only when a queried tile's fog actually changed.
 	static constexpr auto FogTileResolution = 64u;
 	static constexpr auto FogCacheCapacity = 16u;
 
@@ -84,17 +86,23 @@ namespace TES3 {
 		unsigned char pixels[FogTileResolution * FogTileResolution] = {};
 	};
 	static auto sFogCacheActive = false;
-	static auto sFogCacheCount = 0u;
+	static auto sFogCacheNextEvict = 0u;
 	static FogTileCacheEntry sFogCache[FogCacheCapacity] = {};
 
 	static FogTileCacheEntry* fogCacheFindOrLoad(WorldControllerRenderTarget* renderTarget, NI::Pointer<NI::RenderedTexture> texture) {
-		for (auto i = 0u; i < sFogCacheCount; ++i) {
+		FogTileCacheEntry* freeEntry = nullptr;
+		for (auto i = 0u; i < FogCacheCapacity; ++i) {
 			if (sFogCache[i].texture == texture) {
 				return &sFogCache[i];
 			}
+			if (freeEntry == nullptr && sFogCache[i].texture == nullptr) {
+				freeEntry = &sFogCache[i];
+			}
 		}
-		if (sFogCacheCount >= FogCacheCapacity) {
-			return nullptr;
+		if (freeEntry == nullptr) {
+			freeEntry = &sFogCache[sFogCacheNextEvict];
+			sFogCacheNextEvict = (sFogCacheNextEvict + 1u) % FogCacheCapacity;
+			*freeEntry = {};
 		}
 		D3DLOCKED_RECT* rect = renderTarget->lockRenderTarget(texture);
 		if (!rect) {
@@ -103,7 +111,7 @@ namespace TES3 {
 			renderTarget->unlockRenderTarget(rect, 0);
 			return nullptr;
 		}
-		FogTileCacheEntry* entry = &sFogCache[sFogCacheCount];
+		FogTileCacheEntry* entry = freeEntry;
 		entry->texture = texture;
 		const unsigned char* bits = static_cast<const unsigned char*>(rect->pBits);
 		const int pitch = rect->Pitch;
@@ -113,24 +121,31 @@ namespace TES3 {
 			}
 		}
 		renderTarget->unlockRenderTarget(rect, 0);
-		++sFogCacheCount;
 		return entry;
 	}
 
 	void WorldControllerRenderTarget::beginFogCache() {
-		for (auto i = 0u; i < sFogCacheCount; ++i) {
-			sFogCache[i] = {};
-		}
 		sFogCacheActive = true;
-		sFogCacheCount = 0;
 	}
 
 	void WorldControllerRenderTarget::endFogCache() {
-		for (auto i = 0u; i < sFogCacheCount; ++i) {
+		sFogCacheActive = false;
+	}
+
+	void WorldControllerRenderTarget::invalidateFogCacheTexture(NI::RenderedTexture* texture) {
+		for (auto i = 0u; i < FogCacheCapacity; ++i) {
+			if (sFogCache[i].texture == texture) {
+				sFogCache[i] = {};
+				return;
+			}
+		}
+	}
+
+	void WorldControllerRenderTarget::clearFogCache() {
+		for (auto i = 0u; i < FogCacheCapacity; ++i) {
 			sFogCache[i] = {};
 		}
-		sFogCacheActive = false;
-		sFogCacheCount = 0;
+		sFogCacheNextEvict = 0;
 	}
 
 	unsigned char WorldControllerRenderTarget::getFogOfWarPixelCached(NI::Pointer<NI::RenderedTexture> texture, float worldX, float worldY) {

--- a/MWSE/TES3WorldController.cpp
+++ b/MWSE/TES3WorldController.cpp
@@ -60,6 +60,16 @@ namespace TES3 {
 		TES3_WorldControllerRenderTarget_unlockRenderTarget(this, lockedRect, flag);
 	}
 
+	const auto TES3_WorldControllerRenderTarget_setSceneNode = reinterpret_cast<void(__thiscall*)(WorldControllerRenderTarget*, NI::Node*)>(0x42ED30);
+	void WorldControllerRenderTarget::setSceneNode(NI::Node* sceneRoot) {
+		TES3_WorldControllerRenderTarget_setSceneNode(this, sceneRoot);
+	}
+
+	const auto TES3_WorldControllerRenderTarget_readbackRenderedTexture = reinterpret_cast<void(__thiscall*)(WorldControllerRenderTarget*, D3DLOCKED_RECT*)>(0x42F830);
+	void WorldControllerRenderTarget::readbackRenderedTexture(D3DLOCKED_RECT* lockedRect) {
+		TES3_WorldControllerRenderTarget_readbackRenderedTexture(this, lockedRect);
+	}
+
 	const auto TES3_WorldControllerRenderTarget_getFogOfWarPixel = reinterpret_cast<unsigned char(__thiscall*)(WorldControllerRenderTarget*, NI::Pointer<NI::RenderedTexture>, float, float)>(0x42FE20);
 	unsigned char WorldControllerRenderTarget::getFogOfWarPixel(NI::Pointer<NI::RenderedTexture> texture, float worldX, float worldY) {
 		return TES3_WorldControllerRenderTarget_getFogOfWarPixel(this, texture, worldX, worldY);

--- a/MWSE/TES3WorldController.h
+++ b/MWSE/TES3WorldController.h
@@ -113,11 +113,14 @@ namespace TES3 {
 		void readbackRenderedTexture(D3DLOCKED_RECT* lockedRect);
 		unsigned char getFogOfWarPixel(NI::Pointer<NI::RenderedTexture> texture, float worldX, float worldY);
 
-		// Fog-of-war pixel cache: getFogOfWarPixelCached serves door queries from a per-compositor-pass
-		// copy (bracketed by beginFogCache/endFogCache) instead of locking the GPU once per door.
+		// Fog-of-war pixel cache: getFogOfWarPixelCached serves door queries from a CPU copy of each
+		// fog tile (bracketed by beginFogCache/endFogCache) instead of locking the GPU once per door.
+		// Entries persist across passes and are invalidated when fog is drawn to their tile.
 		unsigned char getFogOfWarPixelCached(NI::Pointer<NI::RenderedTexture> texture, float worldX, float worldY);
 		static void beginFogCache();
 		static void endFogCache();
+		static void invalidateFogCacheTexture(NI::RenderedTexture* texture);
+		static void clearFogCache();
 	};
 	static_assert(sizeof(WorldControllerRenderTarget) == 0x84, "TES3::WorldControllerRenderTarget failed size validation");
 

--- a/MWSE/TES3WorldController.h
+++ b/MWSE/TES3WorldController.h
@@ -119,6 +119,28 @@ namespace TES3 {
 	};
 	static_assert(sizeof(WorldControllerRenderTarget) == 0x84, "TES3::WorldControllerRenderTarget failed size validation");
 
+	struct MapController {
+		char localMapTileVector[0x10]; // 0x0
+		unsigned short tileCountY; // 0x10
+		unsigned short tileCountX; // 0x12
+		int unknown_0x14;
+		void* unknown_0x18;
+		float northMarkerRotationDegrees; // 0x1C
+		NI::Node* nodePick; // 0x20
+		NI::Node* nodeObjects; // 0x24
+		NI::Node* nodeLand; // 0x28
+		NI::Node* nodeWater; // 0x2C
+		NI::Node* waterNodeParent; // 0x30
+		char cachedPickNodeCulled; // 0x34
+		char cachedObjectsNodeCulled; // 0x35
+		char cachedLandNodeCulled; // 0x36
+		char cachedWaterNodeCulled; // 0x37
+
+		MapController() = delete;
+		~MapController() = delete;
+	};
+	static_assert(sizeof(MapController) == 0x38, "TES3::MapController failed size validation");
+
 	struct MouseController {
 		NI::Object* cursors[5];
 		int unknown_0x14;
@@ -385,7 +407,7 @@ namespace TES3 {
 		WorldControllerRenderTarget mapRenderTarget; // 0x22C
 		WorldControllerRenderCamera shadowCamera; // 0x2B0
 		void * shadowManager; // 0x2DC
-		void * mapController; // 0x2E0
+		MapController * mapController; // 0x2E0
 		UI::MenuController * menuController; // 0x2E4
 		InventoryData * inventoryData; // 0x2E8
 		Sound * soundWeaponSwish; // 0x2EC

--- a/MWSE/TES3WorldController.h
+++ b/MWSE/TES3WorldController.h
@@ -109,6 +109,8 @@ namespace TES3 {
 
 		D3DLOCKED_RECT* lockRenderTarget(NI::Pointer<NI::Texture> texture);
 		void unlockRenderTarget(D3DLOCKED_RECT* lockedRect, int flag);
+		void setSceneNode(NI::Node* sceneRoot);
+		void readbackRenderedTexture(D3DLOCKED_RECT* lockedRect);
 		unsigned char getFogOfWarPixel(NI::Pointer<NI::RenderedTexture> texture, float worldX, float worldY);
 
 		// Fog-of-war pixel cache: getFogOfWarPixelCached serves door queries from a per-compositor-pass


### PR DESCRIPTION
Three changes that move the local map's remaining cross-frame costs to a few ticks later, where the GPU queue has drained:

Render tiles to per-tile render targets, displayed directly; defer the readback. The engine renders every tile through one shared RT and synchronously reads it back (CopyRects + LockRect) to build the NiSourceTexture the map displays — measured 0.5–29 ms on the cross frame under DXVK, as the lock drains the queued pipeline. The map UI binds NiRenderedTextures directly (the fog overlay already does), so each new tile now renders into an owned RT that displays immediately and converts to the engine's CPU-backed record ~3 ticks later — the deferred lock measures 0.1–0.5 ms. Tiles are opaque by construction (alpha-255 clear + RGB-only color writes), replacing the readback's alpha fixup. The world-map paint defers to the same completion. Interiors, -createmaps, and hardware without COLORWRITEENABLE fall back to the engine path.
Persist the fog-of-war pixel cache across compositor passes, invalidating per-tile on fog draw.
Defer the compositor (~4–8 ms, 40+ with the map open) to the same tick drain — its fog-cache locks were the first GPU sync after the unsynced tile renders and inherited the pipeline flush (measured 10–128 ms when caches were cold).
Measured (Morrowind Refreshed + DXVK): typical render-cross updateCellThreadLoader drops to ~13–23 ms with the map share being only the tile renders themselves; the deferred work lands on an otherwise-idle frame at ~2–10 ms total; backtrack crosses carry no map cost at all (with #712).