### PR TITLE
Make menu input event dispatch re-entrancy safe

### DIFF
--- a/MWSE/TES3UIElement.cpp
+++ b/MWSE/TES3UIElement.cpp
@@ -246,8 +246,8 @@ namespace TES3::UI {
 		TES3_ui_dispatchInputEvent(this, eventId, data0, data1, source);
 	}
 
-	const auto TES3_ui_checkMouseEventInElement = reinterpret_cast<bool(__thiscall*)(Element*, int, int)>(0x587730);
-	bool Element::checkMouseEventInElement(int mouseX, int mouseY) {
+	const auto TES3_ui_checkMouseEventInElement = reinterpret_cast<bool(__thiscall*)(const Element*, int, int)>(0x587730);
+	bool Element::checkMouseEventInElement(int mouseX, int mouseY) const {
 		return TES3_ui_checkMouseEventInElement(this, mouseX, mouseY);
 	}
 

--- a/MWSE/TES3UIElement.cpp
+++ b/MWSE/TES3UIElement.cpp
@@ -241,6 +241,16 @@ namespace TES3::UI {
 		return TES3_ui_getTopLevelParent(this);
 	}
 
+	const auto TES3_ui_dispatchInputEvent = reinterpret_cast<void(__thiscall*)(Element*, Property, int, int, Element*)>(0x583460);
+	void Element::dispatchInputEvent(Property eventId, int data0, int data1, Element* source) {
+		TES3_ui_dispatchInputEvent(this, eventId, data0, data1, source);
+	}
+
+	const auto TES3_ui_checkMouseEventInElement = reinterpret_cast<bool(__thiscall*)(Element*, int, int)>(0x587730);
+	bool Element::checkMouseEventInElement(int mouseX, int mouseY) {
+		return TES3_ui_checkMouseEventInElement(this, mouseX, mouseY);
+	}
+
 	Element* Element::performLayout(bool bUpdateTimestamp) {
 		return TES3_ui_performLayout(this, bUpdateTimestamp);
 	}

--- a/MWSE/TES3UIElement.h
+++ b/MWSE/TES3UIElement.h
@@ -159,7 +159,7 @@ namespace TES3::UI {
 		//
 
 		void dispatchInputEvent(Property eventId, int data0, int data1, Element* source);
-		bool checkMouseEventInElement(int mouseX, int mouseY);
+		bool checkMouseEventInElement(int mouseX, int mouseY) const;
 
 		//
 		// Property methods

--- a/MWSE/TES3UIElement.h
+++ b/MWSE/TES3UIElement.h
@@ -155,6 +155,13 @@ namespace TES3::UI {
 		long timingUpdate();
 
 		//
+		// Input event methods
+		//
+
+		void dispatchInputEvent(Property eventId, int data0, int data1, Element* source);
+		bool checkMouseEventInElement(int mouseX, int mouseY);
+
+		//
 		// Property methods
 		//
 

--- a/MWSE/TES3UIManager.cpp
+++ b/MWSE/TES3UIManager.cpp
@@ -33,9 +33,6 @@
 namespace TES3::UI {
 	static bool bSuppressHelpMenu = false;
 
-	const DWORD TES3_hook_dispatchMousewheelUp = 0x58F19B;
-	const DWORD TES3_hook_dispatchMousewheelDown = 0x58F1CA;
-
 	using TES3_uiMainRoot = se::memory::ExternalGlobal<Element*, 0x7D1C28>;
 	using TES3_uiHelpRoot = se::memory::ExternalGlobal<Element*, 0x7D1C74>;
 	using TES3_ui_captureMouseDrag = se::memory::ExternalGlobal<bool, 0x7D207D>;
@@ -640,32 +637,6 @@ namespace TES3::UI {
 	// UI framework improvement hooks
 	//
 
-	__declspec(naked) void patchDispatchMousewheelUp() {
-		__asm {
-			mov eax, [esi + 4]
-			mov edx, [esi + 8]
-			push ecx
-			push edx
-			push eax
-			push 0xFFFF8036
-			jmp $ + 0x37C
-		}
-	}
-	const size_t patchDispatchMousewheelUp_size = 0x14;
-
-	__declspec(naked) void patchDispatchMousewheelDown() {
-		__asm {
-			mov eax, [esi + 4]
-			mov edx, [esi + 8]
-			push ecx
-			push edx
-			push eax
-			push 0xFFFF8037
-			jmp $ + 0x34D
-		}
-	}
-	const size_t patchDispatchMousewheelDown_size = 0x14;
-
 	const auto TES3_ConsoleLogResult = reinterpret_cast<void(__cdecl*)(const char*, bool)>(0x5B2C20);
 	void logToConsole(const char* text, bool isCommand) {
 		TES3_ConsoleLogResult(text, isCommand);
@@ -681,6 +652,11 @@ namespace TES3::UI {
 	const auto TES3_HideCursor = reinterpret_cast<void(__cdecl*)()>(0x5966F0);
 	void hideCursor() {
 		TES3_HideCursor();
+	}
+
+	const auto TES3_ui_clearAndHideHelpMenu = reinterpret_cast<void(__cdecl*)()>(0x595E30);
+	void clearAndHideHelpMenu() {
+		TES3_ui_clearAndHideHelpMenu();
 	}
 
 	const auto TES3_CloseBookMenu = reinterpret_cast<void(__cdecl*)()>(0x5AC7F0);
@@ -1480,10 +1456,21 @@ namespace TES3::UI {
 	}
 
 	void hook() {
-		// Patch mousewheel event dispatch to not redirect to the top-level element,
-		// allowing mousewheel to apply to more than the first scrollpane in a menu.
-		se::memory::writePatchCodeUnprotected(TES3_hook_dispatchMousewheelUp, (BYTE*)&patchDispatchMousewheelUp, patchDispatchMousewheelUp_size);
-		se::memory::writePatchCodeUnprotected(TES3_hook_dispatchMousewheelDown, (BYTE*)&patchDispatchMousewheelDown, patchDispatchMousewheelDown_size);
+		// Replace the menu event dispatcher with a re-entrancy-safe reimplementation, fixing a
+		// stack-overflow crash when a nested event pump (e.g. the modal script-error box) runs
+		// during event callbacks. Also absorbs the old mousewheel dispatch patch, still allowing
+		// mousewheel to apply to more than the first scrollpane in a menu.
+		auto dispatchEvents = &MenuInputController::dispatchEvents;
+		se::memory::genCallEnforced(0x58E1F6, 0x58F060, *reinterpret_cast<DWORD*>(&dispatchEvents));
+		se::memory::genCallEnforced(0x58EC49, 0x58F060, *reinterpret_cast<DWORD*>(&dispatchEvents));
+		se::memory::genCallEnforced(0x595958, 0x58F060, *reinterpret_cast<DWORD*>(&dispatchEvents));
+
+		// Route element-reference invalidation through a wrapper that also scrubs events the above
+		// replacement has copied out of the queue and is mid-dispatch on.
+		auto invalidateReferences = &MenuInputController::patchInvalidateElementReferences;
+		se::memory::genCallEnforced(0x578502, 0x58EE90, *reinterpret_cast<DWORD*>(&invalidateReferences));
+		se::memory::genCallEnforced(0x5BECA9, 0x58EE90, *reinterpret_cast<DWORD*>(&invalidateReferences));
+		se::memory::genCallEnforced(0x5BECC5, 0x58EE90, *reinterpret_cast<DWORD*>(&invalidateReferences));
 
 		// Patch UI ID reverse lookups to avoid repeatedly scanning the property map.
 		patchUIIDNameLookups();

--- a/MWSE/TES3UIManager.h
+++ b/MWSE/TES3UIManager.h
@@ -64,6 +64,7 @@ namespace TES3::UI {
 	void logToConsole_lua(const char* text, sol::optional<bool> isCommand = false);
 
 	void hideCursor();
+	void clearAndHideHelpMenu();
 	void closeBookMenu();
 	void closeDialogueMenu();
 	void closeScrollMenu();

--- a/MWSE/TES3UIMenuController.cpp
+++ b/MWSE/TES3UIMenuController.cpp
@@ -147,7 +147,7 @@ namespace TES3::UI {
 			}
 
 			// Copy the event and clear its queue slot before any callback can run a nested pump.
-			DispatchingEvent event = { slot.type, slot.data0, slot.data1, slot.element, lastDispatchingEvent };
+			DispatchingEvent event(slot, lastDispatchingEvent);
 			slot.type = Event::Type::None;
 			slot.data0 = 0;
 			slot.data1 = 0;

--- a/MWSE/TES3UIMenuController.cpp
+++ b/MWSE/TES3UIMenuController.cpp
@@ -68,13 +68,18 @@ namespace TES3::UI {
 			return;
 		}
 
+		// Commit the released state before any callback runs, for the same reason dispatchEvents
+		// commits the queue slot: a nested event pump (e.g. the script error box) re-synthesizes a
+		// mouse release from the still-latched input edge, and it must not count as another click.
+		// The engine version clears this only after its callbacks return.
+		isMouseButtonHeldDown = false;
+
 		if (isSameSourceAsLastButtonPress && visible && !TES3_ui_captureMouseDrag::get()) {
 			// Plain click on the pressed element.
 			element->dispatchInputEvent(Property::event_mouse_click, event.data0, event.data1, element);
 			if (isDispatchTargetVisible(event.element)) {
 				event.element->dispatchInputEvent(Property::event_mouse_over, event.data0, event.data1, event.element);
 			}
-			isMouseButtonHeldDown = false;
 			return;
 		}
 
@@ -118,14 +123,12 @@ namespace TES3::UI {
 				}
 				TES3_ui_captureMouseDrag::set(false);
 			}
-			isMouseButtonHeldDown = false;
 			return;
 		}
 
 		// Released over a different element than the one pressed.
 		const auto pressSource = buttonPressEventSource;
 		if (!isDispatchTargetVisible(pressSource)) {
-			isMouseButtonHeldDown = false;
 			return;
 		}
 		pressSource->dispatchInputEvent(Property::event_mouse_release, event.data0, event.data1, pressSource);
@@ -136,7 +139,6 @@ namespace TES3::UI {
 		if (isDispatchTargetVisible(event.element)) {
 			event.element->dispatchInputEvent(Property::event_mouse_over, event.data0, event.data1, event.element);
 		}
-		isMouseButtonHeldDown = false;
 	}
 
 	void MenuInputController::dispatchEvents() {

--- a/MWSE/TES3UIMenuController.cpp
+++ b/MWSE/TES3UIMenuController.cpp
@@ -1,5 +1,7 @@
 #include "TES3UIMenuController.h"
 
+#include "MemoryUtil.h"
+
 #include "TES3DataHandler.h"
 #include "TES3Game.h"
 #include "TES3MobManager.h"
@@ -25,6 +27,229 @@ namespace TES3::UI {
 	const auto TES3_MenuInputController_flushBufferedTextEvents = reinterpret_cast<void(__thiscall*)(MenuInputController*)>(0x58E9C0);
 	void MenuInputController::flushBufferedTextEvents() {
 		TES3_MenuInputController_flushBufferedTextEvents(this);
+	}
+
+	//
+	// Re-entrancy-safe replacement for MenuInputController::dispatchEvents (0x58F060). The engine
+	// version leaves the event it is dispatching in the queue until the end of the iteration, so a
+	// nested event pump run from inside a callback (e.g. the modal script-error box) dispatches it
+	// again -- for a dialogue result script that fails to compile, that recurses until the stack
+	// overflows -- and a nested mouseInput can overwrite the slot mid-iteration. This version
+	// copies the event and clears its slot before any callback runs. In-flight copies form a stack
+	// that patchInvalidateElementReferences scrubs, preserving the engine's protection against
+	// dispatching to elements destroyed during a callback.
+	//
+
+	using TES3_ui_captureMouseDrag = se::memory::ExternalGlobal<bool, 0x7D207D>;
+	using TES3_uiMainRoot = se::memory::ExternalGlobal<Element*, 0x7D1C28>;
+	using TES3_ui_id_MenuConsole = se::memory::ExternalGlobal<UI_ID, 0x7D2ECC>;
+
+	MenuInputController::DispatchingEvent* MenuInputController::lastDispatchingEvent = nullptr;
+
+	const auto TES3_MenuInputController_checkMouseEventInChildren = reinterpret_cast<Element* (__thiscall*)(MenuInputController*, Element*, int, int)>(0x58EDE0);
+	Element* MenuInputController::checkMouseEventInChildren(Element* element, int mouseX, int mouseY) {
+		return TES3_MenuInputController_checkMouseEventInChildren(this, element, mouseX, mouseY);
+	}
+
+	bool MenuInputController::isDispatchTargetVisible(const Element* element) {
+		return element && element->visibleAtLastUpdate;
+	}
+
+	// The engine converts the drag-release cursor position with two truncations: ftol(v), then
+	// ftol(ftol(v) + 0.5). For negative coordinates (UI space is center-origin) this is one higher
+	// than a single truncation; replicate it exactly.
+	int MenuInputController::truncateCursorCoordinate(float value) {
+		const auto truncated = static_cast<int>(value);
+		return static_cast<int>(truncated + 0.5f);
+	}
+
+	void MenuInputController::dispatchMouseReleaseEvent(DispatchingEvent& event, Element* element, bool visible, bool isSameSourceAsLastButtonPress) {
+		if (!isMouseButtonHeldDown) {
+			return;
+		}
+
+		if (isSameSourceAsLastButtonPress && visible && !TES3_ui_captureMouseDrag::get()) {
+			// Plain click on the pressed element.
+			element->dispatchInputEvent(Property::event_mouse_click, event.data0, event.data1, element);
+			if (isDispatchTargetVisible(event.element)) {
+				event.element->dispatchInputEvent(Property::event_mouse_over, event.data0, event.data1, event.element);
+			}
+			isMouseButtonHeldDown = false;
+			return;
+		}
+
+		if (isSameSourceAsLastButtonPress) {
+			if (visible && TES3_ui_captureMouseDrag::get()) {
+				// Drag release: hit-test what the cursor is over to decide between click and release.
+				const auto mouseController = TES3::WorldController::get()->mouseController;
+				const int mouseX = truncateCursorCoordinate(mouseController->position.x);
+				const int mouseY = truncateCursorCoordinate(mouseController->position.z);
+
+				Element* elementUnderCursor = nullptr;
+				const auto uiRoot = TES3_uiMainRoot::get();
+				for (auto it = uiRoot->vectorChildren.end(); it != uiRoot->vectorChildren.begin(); --it) {
+					const auto child = *(it - 1);
+					if (!child->visible) {
+						continue;
+					}
+					elementUnderCursor = checkMouseEventInChildren(child, mouseX, mouseY);
+					if (elementUnderCursor) {
+						break;
+					}
+					if (child->visible && child->flagConsumeMouseEvents && child->checkMouseEventInElement(mouseX, mouseY)) {
+						elementUnderCursor = child;
+						break;
+					}
+				}
+
+				if (pointerMoveEventSource == elementUnderCursor) {
+					event.element->dispatchInputEvent(Property::event_mouse_click, event.data0, event.data1, event.element);
+					if (isDispatchTargetVisible(event.element)) {
+						event.element->dispatchInputEvent(Property::event_mouse_over, event.data0, event.data1, event.element);
+					}
+				}
+				else {
+					pointerMovePreviousEventSource = pointerMoveEventSource;
+					pointerMoveEventSource = elementUnderCursor;
+					event.element->dispatchInputEvent(Property::event_mouse_release, event.data0, event.data1, event.element);
+					if (isDispatchTargetVisible(event.element)) {
+						event.element->dispatchInputEvent(Property::event_mouse_leave, event.data0, event.data1, event.element);
+					}
+				}
+				TES3_ui_captureMouseDrag::set(false);
+			}
+			isMouseButtonHeldDown = false;
+			return;
+		}
+
+		// Released over a different element than the one pressed.
+		const auto pressSource = buttonPressEventSource;
+		if (!isDispatchTargetVisible(pressSource)) {
+			isMouseButtonHeldDown = false;
+			return;
+		}
+		pressSource->dispatchInputEvent(Property::event_mouse_release, event.data0, event.data1, pressSource);
+		const auto pressSourceAfterRelease = buttonPressEventSource;
+		if (isDispatchTargetVisible(pressSourceAfterRelease)) {
+			pressSourceAfterRelease->dispatchInputEvent(Property::event_mouse_leave, event.data0, event.data1, pressSourceAfterRelease);
+		}
+		if (isDispatchTargetVisible(event.element)) {
+			event.element->dispatchInputEvent(Property::event_mouse_over, event.data0, event.data1, event.element);
+		}
+		isMouseButtonHeldDown = false;
+	}
+
+	void MenuInputController::dispatchEvents() {
+		for (int i = 0; i < 2; ++i) {
+			auto& slot = events[i];
+			if (slot.type == Event::Type::None) {
+				break;
+			}
+
+			// Copy the event and clear its queue slot before any callback can run a nested pump.
+			DispatchingEvent event = { slot.type, slot.data0, slot.data1, slot.element, lastDispatchingEvent };
+			slot.type = Event::Type::None;
+			slot.data0 = 0;
+			slot.data1 = 0;
+			slot.element = nullptr;
+			lastDispatchingEvent = &event;
+
+			const bool isSameSourceAsLastButtonPress = event.element == buttonPressEventSource;
+			const auto menuOnTop = getMenuOnTop();
+
+			// Let the menu on top know it is losing focus when another menu is clicked. The unfocus
+			// callback can veto the event by returning false.
+			if (isDispatchTargetVisible(event.element) && menuOnTop && event.element != menuOnTop && menuOnTop == buttonPressPreviousEventSource) {
+				const auto topLevelMenu = event.element->getTopLevelParent();
+				if (menuOnTop != topLevelMenu && topLevelMenu->id != TES3_ui_id_MenuConsole::get()) {
+					PropertyValue propValue;
+					const auto callback = menuOnTop->getProperty(&propValue, Property::event_unfocus, PropertyType::EventCallback, nullptr, false)->eventCallback;
+					if (callback && !callback(menuOnTop, Property::event_unfocus, event.data0, event.data1, topLevelMenu)) {
+						event.element = nullptr;
+					}
+				}
+			}
+
+			// The element and visibility the engine latches before dispatching. Post-callback logic
+			// re-reads event.element instead, which invalidation may have cleared.
+			const auto element = event.element;
+			const bool visible = isDispatchTargetVisible(element);
+
+			switch (event.type) {
+			case Event::Type::KeyEnter:
+			case Event::Type::KeyPress:
+				if (visible) {
+					const auto eventProperty = event.type == Event::Type::KeyEnter ? Property::event_key_enter : Property::event_key_press;
+					element->dispatchInputEvent(eventProperty, event.data0, event.data1, element);
+				}
+				buttonPressEventSource = isDispatchTargetVisible(event.element) ? event.element : nullptr;
+				break;
+			case Event::Type::ScrollUp:
+			case Event::Type::ScrollDown:
+				if (visible) {
+					const auto eventProperty = event.type == Event::Type::ScrollUp ? Property::event_mouse_scroll_up : Property::event_mouse_scroll_down;
+					element->dispatchInputEvent(eventProperty, event.data0, event.data1, element);
+				}
+				break;
+			case Event::Type::MousePress:
+				if (!isMouseButtonHeldDown && visible) {
+					element->dispatchInputEvent(Property::event_mouse_down, event.data0, event.data1, element);
+				}
+				isMouseButtonHeldDown = true;
+				buttonPressEventSource = visible ? event.element : nullptr;
+				break;
+			case Event::Type::MouseRelease:
+				dispatchMouseReleaseEvent(event, element, visible, isSameSourceAsLastButtonPress);
+				break;
+			case Event::Type::MouseEnter:
+				if (!isMouseButtonHeldDown) {
+					if (element) {
+						element->dispatchInputEvent(Property::event_mouse_over, event.data0, event.data1, element);
+					}
+				}
+				else if (isSameSourceAsLastButtonPress && element) {
+					element->dispatchInputEvent(Property::event_mouse_down, event.data0, event.data1, element);
+				}
+				break;
+			case Event::Type::MouseLeave:
+				if (!isMouseButtonHeldDown) {
+					if (element) {
+						element->dispatchInputEvent(Property::event_mouse_leave, event.data0, event.data1, element);
+					}
+				}
+				else if (isSameSourceAsLastButtonPress && element) {
+					// While the button is held, leaving the pressed element reports "still over".
+					element->dispatchInputEvent(Property::event_mouse_over, event.data0, event.data1, element);
+				}
+				break;
+			case Event::Type::MouseDragMove:
+				if (isMouseButtonHeldDown && isSameSourceAsLastButtonPress && element) {
+					element->dispatchInputEvent(Property::event_mouse_still_pressed, event.data0, event.data1, element);
+				}
+				break;
+			}
+
+			buttonPressPreviousEventSource = menuOnTop;
+			lastDispatchingEvent = event.previous;
+		}
+
+		if (TES3::WorldController::get()->menuController->flagClearHelpMenu) {
+			clearAndHideHelpMenu();
+		}
+	}
+
+	const auto TES3_MenuInputController_invalidateElementReferences = reinterpret_cast<void(__thiscall*)(MenuInputController*, Element*)>(0x58EE90);
+	void MenuInputController::patchInvalidateElementReferences(Element* element) {
+		// Call overwritten code: scrubs the element from the event queue and event source fields.
+		TES3_MenuInputController_invalidateElementReferences(this, element);
+
+		// Also scrub events dispatchEvents has copied out of the queue and is mid-dispatch on, so
+		// their post-callback dispatches see the invalidation just like the engine's re-reads did.
+		for (auto dispatching = lastDispatchingEvent; dispatching; dispatching = dispatching->previous) {
+			if (dispatching->element == element) {
+				dispatching->element = nullptr;
+			}
+		}
 	}
 
 	Element* MenuInputController::getTextInputElement() const {

--- a/MWSE/TES3UIMenuController.h
+++ b/MWSE/TES3UIMenuController.h
@@ -27,17 +27,14 @@ namespace TES3::UI {
 			Element* element;
 
 			Event() = delete;
-			~Event() = delete;
 		};
 
 		// An event that dispatchEvents has copied out of the queue and is dispatching. Unlike
 		// Event, this is an MWSE-side type; the engine never sees it.
-		struct DispatchingEvent {
-			int type;
-			int data0;
-			int data1;
-			Element* element;
+		struct DispatchingEvent : Event {
 			DispatchingEvent* previous;
+
+			DispatchingEvent(const Event& event, DispatchingEvent* previous) : Event(event), previous(previous) {}
 		};
 
 		NI::Pick pick; // 0x0

--- a/MWSE/TES3UIMenuController.h
+++ b/MWSE/TES3UIMenuController.h
@@ -8,6 +8,19 @@
 namespace TES3::UI {
 	struct MenuInputController {
 		struct Event {
+			enum Type : int {
+				None = 0,
+				MouseRelease = 1,
+				MousePress = 2,
+				MouseDragMove = 5,
+				MouseEnter = 6,
+				MouseLeave = 7,
+				ScrollUp = 0xE,
+				ScrollDown = 0xF,
+				KeyPress = 0x10,
+				KeyEnter = 0x11,
+			};
+
 			int type;
 			int data0;
 			int data1;
@@ -15,6 +28,16 @@ namespace TES3::UI {
 
 			Event() = delete;
 			~Event() = delete;
+		};
+
+		// An event that dispatchEvents has copied out of the queue and is dispatching. Unlike
+		// Event, this is an MWSE-side type; the engine never sees it.
+		struct DispatchingEvent {
+			int type;
+			int data0;
+			int data1;
+			Element* element;
+			DispatchingEvent* previous;
 		};
 
 		NI::Pick pick; // 0x0
@@ -60,6 +83,18 @@ namespace TES3::UI {
 		//
 
 		void flushBufferedTextEvents();
+		Element* checkMouseEventInChildren(Element* element, int mouseX, int mouseY);
+
+		//
+		// Patch methods
+		//
+
+		// Re-entrancy-safe replacement for the engine's event dispatch (0x58F060).
+		void dispatchEvents();
+
+		// Wrapper for the engine's element-reference invalidation (0x58EE90) that also scrubs
+		// events dispatchEvents has copied out of the queue and is mid-dispatch on.
+		void patchInvalidateElementReferences(Element* element);
 
 		//
 		// Custom functions.
@@ -67,7 +102,15 @@ namespace TES3::UI {
 
 		static Element* previousTextInputFocus;
 
+		// Events currently being dispatched, innermost last. Dispatch can re-enter when an event
+		// callback runs a modal event pump, so this is a stack, linked through the callers' frames.
+		static DispatchingEvent* lastDispatchingEvent;
+
 		void updateObjectTooltip();
+
+		void dispatchMouseReleaseEvent(DispatchingEvent& event, Element* element, bool visible, bool isSameSourceAsLastButtonPress);
+		static bool isDispatchTargetVisible(const Element* element);
+		static int truncateCursorCoordinate(float value);
 	};
 	static_assert(sizeof(MenuInputController) == 0xAC, "TES3::UI::MenuInputController failed size validation");
 	static_assert(sizeof(MenuInputController::Event) == 0x10, "TES3::UI::MenuInputController::Event failed size validation");


### PR DESCRIPTION
Copy each event out of the queue and clear its slot before callbacks run, and commit the mouse button state before dispatching release callbacks. Absorbs the old mousewheel dispatch patch. A wrapper around invalidateElementReferences scrubs in-flight event copies, so invalidation on element death still reaches them.

This fixes the Death and Taxes dialogue crash. The measured cycle: a dialogue result script fails to compile, the error box pumps processEvents once before its modal loop, and readKeyState only runs inside the loop - so the release edge that triggered the click is still latched. mouseInput synthesizes a fresh MouseRelease for the still-hovered topic, and with isMouseButtonHeldDown cleared only after callbacks, it counted as another click: same compile failure, another box inside the first, until stack overflow (213 nested boxes measured). Committing the held flag before callbacks discards the synthesized release and breaks the cycle.