### PR TITLE
Use more `std::string_view` in the codebase

### DIFF
--- a/CSSE/CSAlchemy.cpp
+++ b/CSSE/CSAlchemy.cpp
@@ -1,7 +1,7 @@
 #include "CSAlchemy.h"
 
 namespace se::cs {
-	bool Alchemy::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Alchemy::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (Object::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSAlchemy.h
+++ b/CSSE/CSAlchemy.h
@@ -15,7 +15,7 @@ namespace se::cs {
 		Effect effects[8]; // 0x60
 		unsigned short flags; // 0x120
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Alchemy) == 0x124, "TES3::Alchemy failed size validation");
 }

--- a/CSSE/CSBaseObject.cpp
+++ b/CSSE/CSBaseObject.cpp
@@ -60,7 +60,7 @@ namespace se::cs {
 		BaseObject_setFlag80(this, set);
 	}
 
-	bool BaseObject::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool BaseObject::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (settings.id && string::complex_contains(getObjectID(), needle, settings, regex)) {
 			return true;
 		}
@@ -68,7 +68,7 @@ namespace se::cs {
 		return false;
 	}
 
-	bool BaseObject::searchWithInheritance(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool BaseObject::searchWithInheritance(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		switch (objectType) {
 		case ObjectType::Birthsign:
 			return static_cast<const Birthsign*>(this)->search(needle, settings, regex);

--- a/CSSE/CSBaseObject.h
+++ b/CSSE/CSBaseObject.h
@@ -62,8 +62,8 @@ namespace se::cs {
 			bool training = true;
 		};
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
-		bool searchWithInheritance(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool searchWithInheritance(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(BaseObject) == 0x10, "TES3::BaseObject failed size validation");
 	static_assert(sizeof(BaseObject_VirtualTable) == 0x24, "TES3::BaseObject_VirtualTable failed size validation");

--- a/CSSE/CSBirthsign.cpp
+++ b/CSSE/CSBirthsign.cpp
@@ -3,7 +3,7 @@
 #include "StringUtil.h"
 
 namespace se::cs {
-	bool Birthsign::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Birthsign::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (BaseObject::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSBirthsign.h
+++ b/CSSE/CSBirthsign.h
@@ -11,7 +11,7 @@ namespace se::cs {
 		char* description; // 0x38
 		SpellList spellList; // 0x3C
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Birthsign) == 0x54, "Birthsign failed size validation");
 }

--- a/CSSE/CSBook.cpp
+++ b/CSSE/CSBook.cpp
@@ -16,7 +16,7 @@ namespace se::cs {
 		return gmst->value.asString;
 	}
 
-	bool Book::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Book::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (Object::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSBook.h
+++ b/CSSE/CSBook.h
@@ -18,7 +18,7 @@ namespace se::cs {
 
 		const char* getTaughtSkillName() const;
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Book) == 0x74, "Book failed size validation");
 }

--- a/CSSE/CSClass.cpp
+++ b/CSSE/CSClass.cpp
@@ -3,7 +3,7 @@
 #include "StringUtil.h"
 
 namespace se::cs {
-	bool Class::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Class::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (BaseObject::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSClass.h
+++ b/CSSE/CSClass.h
@@ -14,7 +14,7 @@ namespace se::cs {
 		char* description; // 0x8C
 		unsigned int descriptionOffset; // 0x90
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Class) == 0x94, "Class failed size validation");
 }

--- a/CSSE/CSDialogue.cpp
+++ b/CSSE/CSDialogue.cpp
@@ -3,7 +3,7 @@
 #include "StringUtil.h"
 
 namespace se::cs {
-	bool Dialogue::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Dialogue::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		return id && string::complex_contains(id, needle, settings, regex);
 	}
 }

--- a/CSSE/CSDialogue.h
+++ b/CSSE/CSDialogue.h
@@ -19,7 +19,7 @@ namespace se::cs {
 		DialogueType type; // 0x14
 		NI::IteratedList<DialogueInfo*> infos; // 0x18
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const;
 	};
 	static_assert(sizeof(Dialogue) == 0x2C, "Dialogue failed size validation");
 }

--- a/CSSE/CSDialogueInfo.cpp
+++ b/CSSE/CSDialogueInfo.cpp
@@ -26,7 +26,7 @@ namespace se::cs {
 		return TES3_DialogueInfo_filter(this, actor, reference, source, dialogue);
 	}
 
-	bool DialogueInfo::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool DialogueInfo::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (loadLinkNodes && loadLinkNodes->name && string::complex_contains(loadLinkNodes->name, needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSDialogueInfo.h
+++ b/CSSE/CSDialogueInfo.h
@@ -67,7 +67,7 @@ namespace se::cs {
 
 		bool filter(Object* actor, Reference* reference = nullptr, int source = 1, Dialogue* dialogue = nullptr) const;
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(DialogueInfo) == 0xA4, "TES3::DialogueInfo failed size validation");
 	static_assert(sizeof(DialogueInfo::LoadLinkNode) == 0xC, "TES3::DialogueInfo::LoadLinkNode failed size validation");

--- a/CSSE/CSEffect.cpp
+++ b/CSSE/CSEffect.cpp
@@ -108,7 +108,7 @@ namespace se::cs {
 		return ss.str();
 	}
 
-	bool Effect::search(const std::string_view& needle, const BaseObject::SearchSettings& settings, std::regex* regex) const {
+	bool Effect::search(std::string_view needle, const BaseObject::SearchSettings& settings, std::regex* regex) const {
 		const auto effectData = getEffectData();
 		if (effectData == nullptr) {
 			return false;

--- a/CSSE/CSEffect.h
+++ b/CSSE/CSEffect.h
@@ -25,7 +25,7 @@ namespace se::cs {
 		MagicEffect* getEffectData() const;
 		std::optional<std::string> toString() const;
 
-		bool search(const std::string_view& needle, const BaseObject::SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const BaseObject::SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Effect) == 0x18, "Effect failed size validation");
 }

--- a/CSSE/CSEnchantment.cpp
+++ b/CSSE/CSEnchantment.cpp
@@ -2,7 +2,7 @@
 
 namespace se::cs {
 
-	bool Enchantment::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Enchantment::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (Object::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSEnchantment.h
+++ b/CSSE/CSEnchantment.h
@@ -13,7 +13,7 @@ namespace se::cs {
 		unsigned int enchantFlags; // 0xF4
 		int useCount; // 0xF8
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Enchantment) == 0xFC, "Enchantment failed size validation");
 }

--- a/CSSE/CSFaction.cpp
+++ b/CSSE/CSFaction.cpp
@@ -3,7 +3,7 @@
 #include "StringUtil.h"
 
 namespace se::cs {
-	bool Faction::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Faction::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (BaseObject::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSFaction.h
+++ b/CSSE/CSFaction.h
@@ -22,7 +22,7 @@ namespace se::cs {
 		int unknown_0x28C;
 		int unknown_0x290;
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Faction) == 0x294, "Faction failed size validation");
 }

--- a/CSSE/CSGameSetting.cpp
+++ b/CSSE/CSGameSetting.cpp
@@ -44,7 +44,7 @@ namespace se::cs {
 		return &initializers[index];
 	}
 
-	bool GameSetting::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool GameSetting::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (BaseObject::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSGameSetting.h
+++ b/CSSE/CSGameSetting.h
@@ -1564,7 +1564,7 @@ namespace se::cs {
 
 		GameSettingInitializer* getInitializer() const;
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(GameSetting) == 0x18, "GameSetting failed size validation");
 }

--- a/CSSE/CSIngredient.cpp
+++ b/CSSE/CSIngredient.cpp
@@ -16,7 +16,7 @@ namespace se::cs {
 		strncpy_s(buffer, bufferSize, response.c_str(), response.size());
 	}
 
-	bool Ingredient::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Ingredient::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (Object::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSIngredient.h
+++ b/CSSE/CSIngredient.h
@@ -16,7 +16,7 @@ namespace se::cs {
 
 		void getEffectName(char* buffer, size_t bufferSize, int index) const;
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Ingredient) == 0xE4, "Ingredient failed size validation");
 }

--- a/CSSE/CSMagicEffect.cpp
+++ b/CSSE/CSMagicEffect.cpp
@@ -236,7 +236,7 @@ namespace se::cs {
 		BIT_SET(flags, EffectFlag::AllowEnchantingBit, value);
 	}
 
-	bool MagicEffect::search(const std::string_view& needle, const BaseObject::SearchSettings& settings, std::regex* regex, int attribute, int skill) const {
+	bool MagicEffect::search(std::string_view needle, const BaseObject::SearchSettings& settings, std::regex* regex, int attribute, int skill) const {
 		if (!settings.effect) {
 			return false;
 		}

--- a/CSSE/CSMagicEffect.h
+++ b/CSSE/CSMagicEffect.h
@@ -295,7 +295,7 @@ namespace se::cs {
 		bool getAllowEnchanting() const;
 		void setAllowEnchanting(bool value);
 
-		bool search(const std::string_view& needle, const BaseObject::SearchSettings& settings, std::regex* regex = nullptr, int attribute = -1, int skill = -1) const;
+		bool search(std::string_view needle, const BaseObject::SearchSettings& settings, std::regex* regex = nullptr, int attribute = -1, int skill = -1) const;
 	};
 	static_assert(sizeof(MagicEffect) == 0x10C, "TES3::MagicEffect failed size validation");
 }

--- a/CSSE/CSNPC.cpp
+++ b/CSSE/CSNPC.cpp
@@ -52,7 +52,7 @@ namespace se::cs {
 		return;
 	}
 
-	bool NPC::search(const std::string_view& needle, const BaseObject::SearchSettings& settings, std::regex* regex) const {
+	bool NPC::search(std::string_view needle, const BaseObject::SearchSettings& settings, std::regex* regex) const {
 		if (Object::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSNPC.h
+++ b/CSSE/CSNPC.h
@@ -41,7 +41,7 @@ namespace se::cs {
 		const char* getFactionRankName() const;
 		void getTraining(char* buffer, size_t bufferSize) const;
 		int getFight() const;
-		bool search(const std::string_view& needle, const BaseObject::SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const BaseObject::SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(NPC) == 0x108, "NPC failed size validation");
 }

--- a/CSSE/CSObject.cpp
+++ b/CSSE/CSObject.cpp
@@ -107,7 +107,7 @@ namespace se::cs {
 		vtbl.object->populateObjectWindow(this, hWnd);
 	}
 
-	bool Object::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Object::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (BaseObject::search(needle, settings, regex)) {
 			return true;
 		}
@@ -140,7 +140,7 @@ namespace se::cs {
 		return false;
 	}
 
-	bool Object::searchWithInheritance(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Object::searchWithInheritance(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		switch (objectType) {
 		case ObjectType::Alchemy:
 			return static_cast<const Alchemy*>(this)->search(needle, settings, regex);

--- a/CSSE/CSObject.h
+++ b/CSSE/CSObject.h
@@ -117,8 +117,8 @@ namespace se::cs {
 		// Custom functions
 		//
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
-		bool searchWithInheritance(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool searchWithInheritance(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Object) == 0x28, "CS::Object failed size validation");
 	static_assert(sizeof(Object_VirtualTable) == 0x138, "CS::Object's virtual table failed size validation");

--- a/CSSE/CSRace.cpp
+++ b/CSSE/CSRace.cpp
@@ -3,7 +3,7 @@
 #include "StringUtil.h"
 
 namespace se::cs {
-	bool Race::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Race::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (BaseObject::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSRace.h
+++ b/CSSE/CSRace.h
@@ -93,7 +93,7 @@ namespace se::cs {
 			BodyPart* bodyParts[int(PartIndex::COUNT) * 2 * 2]; // 0xE4 // Body parts for both sexes and each vampirism state.
 		};
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Race) == 0x1D4, "Race failed size validation");
 }

--- a/CSSE/CSScript.cpp
+++ b/CSSE/CSScript.cpp
@@ -20,7 +20,7 @@ namespace se::cs {
 	}
 
 
-	bool Script::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Script::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (BaseObject::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSScript.h
+++ b/CSSE/CSScript.h
@@ -32,7 +32,7 @@ namespace se::cs {
 		const char* getLongVarName(int index) const;
 		const char* getFloatVarName(int index) const;
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Script) == 0x70, "Script failed size validation");
 }

--- a/CSSE/CSSpell.cpp
+++ b/CSSE/CSSpell.cpp
@@ -11,7 +11,7 @@ namespace se::cs {
 		return getSpellFlag(SpellFlag::PCStartSpell);
 	}
 
-	bool Spell::search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex) const {
+	bool Spell::search(std::string_view needle, const SearchSettings& settings, std::regex* regex) const {
 		if (Object::search(needle, settings, regex)) {
 			return true;
 		}

--- a/CSSE/CSSpell.h
+++ b/CSSE/CSSpell.h
@@ -60,7 +60,7 @@ namespace se::cs {
 		bool getSpellFlag(SpellFlag::Flag flag) const;
 		bool getPlayerStart() const;
 
-		bool search(const std::string_view& needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
+		bool search(std::string_view needle, const SearchSettings& settings, std::regex* regex = nullptr) const;
 	};
 	static_assert(sizeof(Spell) == 0xFC, "Spell failed size validation");
 }

--- a/CSSE/DialogCellWindow.cpp
+++ b/CSSE/DialogCellWindow.cpp
@@ -56,7 +56,7 @@ namespace se::cs::dialog::cell_window {
 		}
 	}
 
-	bool matchDispatcher(const std::string_view& haystack) {
+	bool matchDispatcher(std::string_view haystack) {
 		if (currentSearchRegex) {
 			return std::regex_search(haystack.data(), currentSearchRegex.value());
 		}

--- a/CSSE/DialogRenderWindow.cpp
+++ b/CSSE/DialogRenderWindow.cpp
@@ -3255,7 +3255,7 @@ namespace se::cs::dialog::render_window {
 			}
 		}
 
-		size_t parseHeaderOffset(const std::string& html, const std::string& key) {
+		size_t parseHeaderOffset(std::string_view html, std::string_view key) {
 			size_t keyPos = html.find(key);
 			if (keyPos == std::string::npos) return 0;
 			size_t valStart = keyPos + key.size();
@@ -3268,7 +3268,7 @@ namespace se::cs::dialog::render_window {
 			}
 			if (valStart == valEnd) return 0;
 			try {
-				return static_cast<size_t>(std::stoull(html.substr(valStart, valEnd - valStart)));
+				return static_cast<size_t>(std::stoull(std::string(html.substr(valStart, valEnd - valStart))));
 			} catch (...) {
 				return 0;
 			}
@@ -3377,7 +3377,7 @@ namespace se::cs::dialog::render_window {
 			}
 		}
 
-		void parseHtmlFormat(const std::string& html, std::vector<std::string>& outIds) {
+		void parseHtmlFormat(std::string_view html, std::vector<std::string>& outIds) {
 			size_t startFrag = parseHeaderOffset(html, "StartFragment");
 			size_t endFrag = parseHeaderOffset(html, "EndFragment");
 			if (startFrag == 0 || endFrag == 0 || startFrag >= html.size() || endFrag > html.size() || startFrag >= endFrag) {

--- a/CSSE/DialogScriptListWindow.cpp
+++ b/CSSE/DialogScriptListWindow.cpp
@@ -19,7 +19,7 @@ namespace se::cs::dialog::script_list_window {
 	static std::optional<std::regex> currentSearchRegex;
 	static bool modeShowModifiedOnly = false;
 
-	bool matchDispatcher(const std::string_view& haystack) {
+	bool matchDispatcher(std::string_view haystack) {
 		if (currentSearchRegex) {
 			return std::regex_search(haystack.data(), currentSearchRegex.value());
 		}

--- a/CSSE/DialogTextSearchWindow.cpp
+++ b/CSSE/DialogTextSearchWindow.cpp
@@ -54,7 +54,7 @@ namespace se::cs::dialog::text_search_window {
 
 	static std::regex TextSearchRegex;
 
-	bool TextSearchGatherObjectResults(const std::string_view& needle, NI::IteratedList<BaseObject*>* results, const BaseObject::SearchSettings& settings, std::regex* regex) {
+	bool TextSearchGatherObjectResults(std::string_view needle, NI::IteratedList<BaseObject*>* results, const BaseObject::SearchSettings& settings, std::regex* regex) {
 		const auto recordHandler = DataHandler::get()->recordHandler;
 
 		// Search game settings.

--- a/CSSE/ModMetadata.cpp
+++ b/CSSE/ModMetadata.cpp
@@ -3,7 +3,7 @@
 #include "PathUtil.h"
 
 namespace se::cs::metadata {
-	ModMetadata::ModMetadata(const std::string_view& file, GameFile* gameFile) {
+	ModMetadata::ModMetadata(std::string_view file, GameFile* gameFile) {
 		m_FilePath = path::getDataFilesPath() / file;
 		m_Toml = {};
 		m_GameFile = gameFile;

--- a/CSSE/ModMetadata.h
+++ b/CSSE/ModMetadata.h
@@ -5,7 +5,7 @@
 namespace se::cs::metadata {
 	class ModMetadata {
 	public:
-		ModMetadata(const std::string_view& file, GameFile* gameFile);
+		ModMetadata(std::string_view file, GameFile* gameFile);
 
 		void reload();
 

--- a/CSSE/WinUIUtil.cpp
+++ b/CSSE/WinUIUtil.cpp
@@ -33,7 +33,7 @@ namespace se::cs::winui {
 		return TRUE;
 	}
 
-	HWND GetControlByText(HWND hParent, const std::string_view& text, bool ignoreResultsWithIDs) {
+	HWND GetControlByText(HWND hParent, std::string_view text, bool ignoreResultsWithIDs) {
 		// Make sure our buffer in GetControlByTextEnumChildProc is big enough.
 		if (text.length() > 127) {
 			throw std::invalid_argument("Buffer length insufficient to perform operation.");
@@ -47,7 +47,7 @@ namespace se::cs::winui {
 		return param.result;
 	}
 
-	bool SetWindowIdByValue(HWND hParent, const std::string_view text, int newID) {
+	bool SetWindowIdByValue(HWND hParent, std::string_view text, int newID) {
 		auto hWnd = GetControlByText(hParent, text, true);
 		if (hWnd == NULL) {
 			return false;

--- a/CSSE/WinUIUtil.h
+++ b/CSSE/WinUIUtil.h
@@ -8,8 +8,8 @@ namespace se::cs::winui {
 
 	bool GetIsValidID(int iDlgId);
 
-	HWND GetControlByText(HWND hParent, const std::string_view& text, bool ignoreResultsWithIDs);
-	bool SetWindowIdByValue(HWND hParent, const std::string_view text, int newID);
+	HWND GetControlByText(HWND hParent, std::string_view text, bool ignoreResultsWithIDs);
+	bool SetWindowIdByValue(HWND hParent, std::string_view text, int newID);
 
 	inline LONG GetRectWidth(const RECT* rect) {
 		return rect->right - rect->left;

--- a/MWSE/FileUtil.cpp
+++ b/MWSE/FileUtil.cpp
@@ -7,7 +7,7 @@ namespace mwse {
 
 	FileSystem::FileSystem() {}
 
-	HANDLE FileSystem::getFile(const char* fileName) {
+	HANDLE FileSystem::getFile(std::string_view fileName) {
 		HANDLE result = NULL;
 
 		std::string str(fileName);
@@ -21,14 +21,14 @@ namespace mwse {
 		}
 		else {
 			mwseFileState_t state = { openFileAt(fileName, 0), 0 };
-			fileMap[fileName] = state;
+			fileMap[str] = state;
 			result = state.file;
 		}
 
 		return result;
 	}
 
-	short FileSystem::readShort(const char* fileName) {
+	short FileSystem::readShort(std::string_view fileName) {
 		short result = 0;
 		if (read(fileName, &result, sizeof(short)) != sizeof(short)) {
 			throw std::exception("Invalid size read.");
@@ -36,7 +36,7 @@ namespace mwse {
 		return result;
 	}
 
-	long FileSystem::readLong(const char* fileName) {
+	long FileSystem::readLong(std::string_view fileName) {
 		long result = 0;
 		if (read(fileName, &result, sizeof(long)) != sizeof(long)) {
 			throw std::exception("Invalid size read.");
@@ -44,7 +44,7 @@ namespace mwse {
 		return result;
 	}
 
-	float FileSystem::readFloat(const char* fileName) {
+	float FileSystem::readFloat(std::string_view fileName) {
 		float result = 0.0f;
 		if (read(fileName, &result, sizeof(float)) != sizeof(float)) {
 			throw std::exception("Invalid size read.");
@@ -52,7 +52,7 @@ namespace mwse {
 		return result;
 	}
 
-	std::string FileSystem::readString(const char* fileName, bool stopAtEndOfLine) {
+	std::string FileSystem::readString(std::string_view fileName, bool stopAtEndOfLine) {
 		HANDLE file = getFile(fileName);
 
 		// String buffer.
@@ -104,19 +104,19 @@ namespace mwse {
 		return buffer;
 	}
 
-	void FileSystem::writeShort(const char* fileName, const short value) {
+	void FileSystem::writeShort(std::string_view fileName, const short value) {
 		write(fileName, &value, sizeof(short));
 	}
 
-	void FileSystem::writeLong(const char* fileName, const long value) {
+	void FileSystem::writeLong(std::string_view fileName, const long value) {
 		write(fileName, &value, sizeof(long));
 	}
 
-	void FileSystem::writeFloat(const char* fileName, const float value) {
+	void FileSystem::writeFloat(std::string_view fileName, const float value) {
 		write(fileName, &value, sizeof(float));
 	}
 
-	void FileSystem::writeString(const char* fileName, std::string_view value, bool suppressNull) {
+	void FileSystem::writeString(std::string_view fileName, std::string_view value, bool suppressNull) {
 		size_t length = value.length();
 		if (!suppressNull) {
 			length++;
@@ -124,7 +124,7 @@ namespace mwse {
 		write(fileName, value.data(), length);
 	}
 
-	bool FileSystem::seek(const char* fileName, long position) {
+	bool FileSystem::seek(std::string_view fileName, long position) {
 		bool result = false;
 		HANDLE file = getFile(fileName);
 		if (file != INVALID_HANDLE_VALUE) {
@@ -134,7 +134,7 @@ namespace mwse {
 		return result;
 	}
 
-	HANDLE FileSystem::openFileAt(const char* fileName, size_t position) {
+	HANDLE FileSystem::openFileAt(std::string_view fileName, size_t position) {
 		if (!validFileName(fileName)) {
 			return INVALID_HANDLE_VALUE;
 		}
@@ -145,12 +145,12 @@ namespace mwse {
 		CreateDirectoryA("Data Files\\MWSE", NULL);
 
 		// Allow connection to named pipes one the local machine.
-		if (*fileName == '|') {
+		if (fileName[0] == '|') {
 			strcpy(realName, "\\\\.\\pipe\\MWSE");
-			fileName++;
+			fileName = fileName.substr(1);
 		}
 
-		strncpy(&realName[strlen(realName)], fileName, NELEM(realName) - strlen(realName));
+		strncpy(&realName[strlen(realName)], fileName.data(), NELEM(realName) - strlen(realName));
 		HANDLE result = CreateFileA(
 			realName,
 			GENERIC_READ | GENERIC_WRITE,
@@ -168,43 +168,36 @@ namespace mwse {
 		return result;
 	}
 
-	bool FileSystem::validFileName(const char* fileName) {
-		// Allow for a named pipe (I'm not sure it's wise, but
-		// it's requested enough.)
-		if (*fileName == '|') {
-			fileName++;
+	bool FileSystem::validFileName(std::string_view fileName) {
+		// Allow for a named pipe (I'm not sure it's wise, but it's requested enough.)
+		if (fileName[0] == '|') {
+			fileName = fileName.substr(1);
 		}
-
-		int len = 0;
-		while (*fileName) {
-			if (len++ >= 61) {
-				return false;
-			}
-			// Allow _ and . in filenames but limit their length.
-			else if (!isalnum(*fileName) && *fileName != '_' && *fileName != '.') {
-				return false;
-			}
-			fileName++;
-		}
-
+		
 		// By forcing at least 5 characters, we don't have to
 		// worry about someone opening the .. or . files.
 		// Files 4 characters and under might be special like
 		// the CON, PRN, COM1, etc. DOS device files. 
-		if (len < 5) {
+		if (fileName.length() < 5 || fileName.length() >= 61) {
 			return false;
 		}
 
+		for (auto& c : fileName) {
+			// Allow _ and . in filenames but limit their length.
+			if (!isalnum(c) && c != '_' && c != '.') 
+				return false;
+		}
+		
 		return true;
 	}
 
-	int FileSystem::read(const char* fileName, void* data, size_t size) {
+	int FileSystem::read(std::string_view fileName, void* data, size_t size) {
 		int result = 0;
 		HANDLE file = getFile(fileName);
 		if (file != INVALID_HANDLE_VALUE)
 		{
 			//Tp21 2006-06-21: Stop MWSE getting stuck if there's no data available to be read (original code from timeslip)
-			if (*fileName == '|') { //check if it's a pipe
+			if (fileName[0] == '|') { //check if it's a pipe
 				DWORD toread;
 				PeekNamedPipe(file, NULL, 0, NULL, &toread, NULL); //look if there is something to read
 				if (!toread) return 0; //if not, return
@@ -218,7 +211,7 @@ namespace mwse {
 		return result;
 	}
 
-	int FileSystem::write(const char* fileName, const void* data, size_t size) {
+	int FileSystem::write(std::string_view fileName, const void* data, size_t size) {
 		int result = 0;
 		HANDLE file = getFile(fileName);
 		if (file != INVALID_HANDLE_VALUE) {

--- a/MWSE/FileUtil.cpp
+++ b/MWSE/FileUtil.cpp
@@ -139,20 +139,21 @@ namespace mwse {
 			return INVALID_HANDLE_VALUE;
 		}
 
-		char realName[BUFSIZ] = "Data Files\\MWSE\\";
+		std::string realName = "Data Files\\MWSE\\";
 
 		// Create the file storage area if it doesn't already exist
 		CreateDirectoryA("Data Files\\MWSE", NULL);
 
 		// Allow connection to named pipes one the local machine.
+		// We performed a check that fileName isn't empty in validFileName
 		if (fileName[0] == '|') {
-			strcpy(realName, "\\\\.\\pipe\\MWSE");
-			fileName = fileName.substr(1);
+			realName = "\\\\.\\pipe\\MWSE";
+			fileName.remove_prefix(1);
 		}
+		realName += fileName;
 
-		strncpy(&realName[strlen(realName)], fileName.data(), NELEM(realName) - strlen(realName));
 		HANDLE result = CreateFileA(
-			realName,
+			realName.c_str(),
 			GENERIC_READ | GENERIC_WRITE,
 			FILE_SHARE_READ | FILE_SHARE_WRITE,
 			NULL,
@@ -169,25 +170,25 @@ namespace mwse {
 	}
 
 	bool FileSystem::validFileName(std::string_view fileName) {
-		// Allow for a named pipe (I'm not sure it's wise, but it's requested enough.)
-		if (fileName[0] == '|') {
-			fileName = fileName.substr(1);
-		}
-		
 		// By forcing at least 5 characters, we don't have to
 		// worry about someone opening the .. or . files.
 		// Files 4 characters and under might be special like
 		// the CON, PRN, COM1, etc. DOS device files. 
-		if (fileName.length() < 5 || fileName.length() >= 61) {
+		if (fileName.empty() || fileName.length() < 5 || fileName.length() >= 62) {
 			return false;
 		}
+	
+		auto itt = fileName.begin();
+		if (*itt == '|') {
+			++itt;
+		}
 
-		for (auto& c : fileName) {
+		for (auto c = *itt; itt != fileName.end(); ++itt) {
 			// Allow _ and . in filenames but limit their length.
-			if (!isalnum(c) && c != '_' && c != '.') 
+			if (!isalnum(c) && c != '_' && c != '.')
 				return false;
 		}
-		
+
 		return true;
 	}
 

--- a/MWSE/FileUtil.h
+++ b/MWSE/FileUtil.h
@@ -17,30 +17,30 @@ namespace mwse {
 	public:
 		static FileSystem& getInstance() { return singleton; };
 
-		HANDLE getFile(const char* fileName);
+		HANDLE getFile(std::string_view fileName);
 
-		short readShort(const char* fileName);
-		long readLong(const char* fileName);
-		float readFloat(const char* fileName);
-		std::string readString(const char* fileName, bool stopAtEndOfLine);
+		short readShort(std::string_view fileName);
+		long readLong(std::string_view fileName);
+		float readFloat(std::string_view fileName);
+		std::string readString(std::string_view fileName, bool stopAtEndOfLine);
 
-		void writeShort(const char* fileName, const short value);
-		void writeLong(const char* fileName, const long value);
-		void writeFloat(const char* fileName, const float value);
-		void writeString(const char* fileName, std::string_view value, bool suppressNull = false);
+		void writeShort(std::string_view fileName, const short value);
+		void writeLong(std::string_view fileName, const long value);
+		void writeFloat(std::string_view fileName, const float value);
+		void writeString(std::string_view fileName, std::string_view value, bool suppressNull = false);
 
-		bool seek(const char* fileName, long absolute);
+		bool seek(std::string_view fileName, long absolute);
 
 	private:
 		FileSystem();
 
-		HANDLE openFileAt(const char* fileName, size_t position);
+		HANDLE openFileAt(std::string_view fileName, size_t position);
 
-		bool validFileName(const char* fileName);
+		bool validFileName(std::string_view fileName);
 
-		int read(const char* fileName, void* data, size_t size);
+		int read(std::string_view fileName, void* data, size_t size);
 
-		int write(const char* fileName, const void* data, size_t size);
+		int write(std::string_view fileName, const void* data, size_t size);
 
 		static FileSystem singleton;
 

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -2734,7 +2734,7 @@ namespace mwse::lua {
 
 	const std::array<std::string, 2> disabledMarkers = { ".disabled", ".mohidden" };
 
-	bool isPathDisabled(const std::string_view& path) {
+	bool isPathDisabled(std::string_view path) {
 		const auto disabledPathItt = std::find_if(disabledMarkers.begin(), disabledMarkers.end(),
 			[&](std::string_view s) {
 				return path.find(s) != std::string::npos;

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -2742,7 +2742,7 @@ namespace mwse::lua {
 		return disabledPathItt != disabledMarkers.end();
 	}
 
-	void LuaManager::gatherMainModScripts(const std::string_view& path, bool core, const std::string_view& scriptFilename) {
+	void LuaManager::gatherMainModScripts(std::string_view path, bool core, const std::string_view& scriptFilename) {
 		if (!std::filesystem::exists(path)) {
 			return;
 		}

--- a/MWSE/LuaManager.h
+++ b/MWSE/LuaManager.h
@@ -67,7 +67,7 @@ namespace mwse::lua {
 
 		// Helper functions to execute main.lua scripts recursively in a directory.
 		void gatherModMetadata();
-		void gatherMainModScripts(const std::string_view& path, bool core, const std::string_view& scriptFilename = "main.lua");
+		void gatherMainModScripts(std::string_view path, bool core, const std::string_view& scriptFilename = "main.lua");
 		void executeMainModScripts();
 
 		// Management functions for timers.

--- a/MWSE/TES3DataHandler.cpp
+++ b/MWSE/TES3DataHandler.cpp
@@ -744,7 +744,7 @@ namespace TES3 {
 		return results;
 	}
 
-	bool NonDynamicData::objectExists(const std::string_view& id) {
+	bool NonDynamicData::objectExists(std::string_view id) {
 		return resolveObject(id.data()) != nullptr;
 	}
 

--- a/MWSE/TES3DataHandler.h
+++ b/MWSE/TES3DataHandler.h
@@ -52,7 +52,7 @@ namespace TES3 {
 #if MWSE_CUSTOM_GLOBALS
 	struct GlobalHashContainer {
 		struct icomp {
-			bool operator() (const std::string_view& lhs, const std::string_view& rhs) const {
+			bool operator() (std::string_view lhs, std::string_view rhs) const {
 				return _strnicmp(lhs.data(), rhs.data(), 32) < 0;
 			}
 		};
@@ -194,12 +194,12 @@ namespace TES3 {
 
 		sol::table getMagicEffects_lua(sol::this_state ts);
 
-		bool objectExists(const std::string_view& id);
+		bool objectExists(std::string_view id);
 		void clearCellByNameCache(const Cell* cell);
 
 		// Wrapper around resolveObject that enforces type.
 		template <typename T>
-		T* resolveObjectByType(const std::string_view& id) {
+		T* resolveObjectByType(std::string_view id) {
 			const auto potentialResult = resolveObject(id.data());
 			if (potentialResult == nullptr) {
 				return nullptr;

--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -543,7 +543,7 @@ namespace TES3 {
 		}
 	}
 
-	void Reference::setNoCollision_lua (bool set, sol::optional<bool> updateCollisions) {
+	void Reference::setNoCollision_lua(bool set, sol::optional<bool> updateCollisions) {
 		setNoCollision(set, updateCollisions.value_or(true));
 	}
 

--- a/MWSE/TES3UIElement.cpp
+++ b/MWSE/TES3UIElement.cpp
@@ -1166,7 +1166,7 @@ namespace TES3::UI {
 		return container->getData();
 	}
 
-	sol::object Element::getLuaData(const std::string_view& key) const {
+	sol::object Element::getLuaData(std::string_view key) const {
 		auto container = getLuaDataContainer();
 		if (container == nullptr) {
 			return sol::nil;
@@ -1175,7 +1175,7 @@ namespace TES3::UI {
 		return container->getValue(key);
 	}
 
-	void Element::setLuaData(sol::this_state ts, const std::string_view& key, sol::object value) {
+	void Element::setLuaData(sol::this_state ts, std::string_view key, sol::object value) {
 		auto container = getLuaDataContainer();
 		if (container == nullptr) {
 			container = new LuaData(ts);

--- a/MWSE/TES3UIElement.h
+++ b/MWSE/TES3UIElement.h
@@ -330,8 +330,8 @@ namespace TES3::UI {
 
 		LuaData* getLuaDataContainer() const;
 		sol::object getAllLuaData() const;
-		sol::object getLuaData(const std::string_view& key) const;
-		void setLuaData(sol::this_state ts, const std::string_view& key, sol::object value);
+		sol::object getLuaData(std::string_view key) const;
+		void setLuaData(sol::this_state ts, std::string_view key, sol::object value);
 
 		void registerBefore_lua(const std::string& eventID, sol::protected_function callback, sol::optional<double> priority);
 		void registerAfter_lua(const std::string& eventID, sol::protected_function callback, sol::optional<double> priority);

--- a/MWSE/TES3UILuaData.cpp
+++ b/MWSE/TES3UILuaData.cpp
@@ -14,11 +14,11 @@ namespace TES3::UI {
 		return data;
 	}
 
-	sol::object LuaData::getValue(const std::string_view& key) {
+	sol::object LuaData::getValue(std::string_view key) {
 		return data[key];
 	}
 
-	void LuaData::setValue(const std::string_view& key, sol::object value) {
+	void LuaData::setValue(std::string_view key, sol::object value) {
 		data[key] = value;
 	}
 }

--- a/MWSE/TES3UILuaData.h
+++ b/MWSE/TES3UILuaData.h
@@ -7,8 +7,8 @@ namespace TES3::UI {
 		~LuaData();
 
 		sol::object getData() const;
-		sol::object getValue(const std::string_view& key);
-		void setValue(const std::string_view& key, sol::object value);
+		sol::object getValue(std::string_view key);
+		void setValue(std::string_view key, sol::object value);
 
 	private:
 		sol::table data;

--- a/MWSE/xFileReadFloat.cpp
+++ b/MWSE/xFileReadFloat.cpp
@@ -29,7 +29,7 @@ namespace mwse {
 		std::list<float> values;
 		for (long i = 0; i < count; ++i) {
 			try {
-				float value = mwse::FileSystem::getInstance().readFloat(fileName.c_str());
+				float value = mwse::FileSystem::getInstance().readFloat(fileName);
 				values.push_front(value);
 				valuesRead++;
 			}

--- a/MWSE/xFileReadLong.cpp
+++ b/MWSE/xFileReadLong.cpp
@@ -29,7 +29,7 @@ namespace mwse {
 		std::list<long> values;
 		for (long i = 0; i < count; ++i) {
 			try {
-				long value = mwse::FileSystem::getInstance().readLong(fileName.c_str());
+				long value = mwse::FileSystem::getInstance().readLong(fileName);
 				values.push_front(value);
 				valuesRead++;
 			}

--- a/MWSE/xFileReadShort.cpp
+++ b/MWSE/xFileReadShort.cpp
@@ -29,7 +29,7 @@ namespace mwse {
 		std::list<short> values;
 		for (long i = 0; i < count; ++i) {
 			try {
-				short value = mwse::FileSystem::getInstance().readShort(fileName.c_str());
+				short value = mwse::FileSystem::getInstance().readShort(fileName);
 				values.push_front(value);
 				valuesRead++;
 			}

--- a/MWSE/xFileReadString.cpp
+++ b/MWSE/xFileReadString.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 		mwseString& fileName = virtualMachine.getString(mwse::Stack::getInstance().popLong());
 
 		// Read the string from the file.
-		std::string readString = mwse::FileSystem::getInstance().readString(fileName.c_str(), true);
+		std::string readString = mwse::FileSystem::getInstance().readString(fileName, true);
 
 		// Push the found string to the stack.
 		if (!readString.empty()) {

--- a/MWSE/xFileReadText.cpp
+++ b/MWSE/xFileReadText.cpp
@@ -34,7 +34,7 @@ namespace mwse {
 		long* results = new long[maxResults];
 
 		// Read the string from the file. If we can't read a string back, push 0s.
-		std::string readString = mwse::FileSystem::getInstance().readString(fileName.c_str(), stopAtEndOfLine);
+		std::string readString = mwse::FileSystem::getInstance().readString(fileName, stopAtEndOfLine);
 		if (readString.empty()) {
 			while (maxResults--) {
 				mwse::Stack::getInstance().pushLong(0);

--- a/MWSE/xFileRewind.cpp
+++ b/MWSE/xFileRewind.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		mwseString& fileName = virtualMachine.getString(mwse::Stack::getInstance().popLong());
 
-		mwse::FileSystem::getInstance().seek(fileName.c_str(), 0);
+		mwse::FileSystem::getInstance().seek(fileName, 0);
 
 		return 0.0f;
 	}

--- a/MWSE/xFileSeek.cpp
+++ b/MWSE/xFileSeek.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		mwseString& fileName = virtualMachine.getString(mwse::Stack::getInstance().popLong());
 		long position = mwse::Stack::getInstance().popLong();
 
-		mwse::FileSystem::getInstance().seek(fileName.c_str(), position);
+		mwse::FileSystem::getInstance().seek(fileName, position);
 
 		return 0.0f;
 	}

--- a/MWSE/xFileWriteFloat.cpp
+++ b/MWSE/xFileWriteFloat.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		mwseString& fileName = virtualMachine.getString(mwse::Stack::getInstance().popLong());
 		float value = mwse::Stack::getInstance().popFloat();
 
-		mwse::FileSystem::getInstance().writeFloat(fileName.c_str(), value);
+		mwse::FileSystem::getInstance().writeFloat(fileName, value);
 
 		return 0.0f;
 	}

--- a/MWSE/xFileWriteLong.cpp
+++ b/MWSE/xFileWriteLong.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		mwseString& fileName = virtualMachine.getString(mwse::Stack::getInstance().popLong());
 		long value = mwse::Stack::getInstance().popLong();
 
-		mwse::FileSystem::getInstance().writeLong(fileName.c_str(), value);
+		mwse::FileSystem::getInstance().writeLong(fileName, value);
 
 		return 0.0f;
 	}

--- a/MWSE/xFileWriteShort.cpp
+++ b/MWSE/xFileWriteShort.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		mwseString& fileName = virtualMachine.getString(mwse::Stack::getInstance().popLong());
 		short value = mwse::Stack::getInstance().popShort();
 
-		mwse::FileSystem::getInstance().writeShort(fileName.c_str(), value);
+		mwse::FileSystem::getInstance().writeShort(fileName, value);
 
 		return 0.0f;
 	}

--- a/MWSE/xFileWriteString.cpp
+++ b/MWSE/xFileWriteString.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		mwseString& fileName = virtualMachine.getString(mwse::Stack::getInstance().popLong());
 		mwseString& value = virtualMachine.getString(mwse::Stack::getInstance().popLong());
 
-		mwse::FileSystem::getInstance().writeString(fileName.c_str(), value);
+		mwse::FileSystem::getInstance().writeString(fileName, value);
 
 		return 0.0f;
 	}

--- a/MWSE/xFileWriteText.cpp
+++ b/MWSE/xFileWriteText.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 			mwse::log::getLog() << "xFileWriteText: bad format \"" << badCodes << "\" in \"" << format << "\" generating \"" << value << "\"" << badCodes << std::endl;
 		}
 
-		mwse::FileSystem::getInstance().writeString(fileName.c_str(), value, suppressNull);
+		mwse::FileSystem::getInstance().writeString(fileName, value, suppressNull);
 
 		return 0.0f;
 	}

--- a/SharedSE/StringUtil.cpp
+++ b/SharedSE/StringUtil.cpp
@@ -99,7 +99,7 @@ namespace se::string {
 		return true;
 	}
 
-	bool contains(const std::string_view& haystack, const std::string_view& needle) {
+	bool contains(std::string_view haystack, std::string_view needle) {
 		if (needle.empty()) {
 			return true;
 		}
@@ -111,7 +111,7 @@ namespace se::string {
 		return std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end()) != haystack.end();
 	}
 
-	bool cicontains(const std::string_view& haystack, const std::string_view& needle) {
+	bool cicontains(std::string_view haystack, std::string_view needle) {
 		if (needle.empty()) {
 			return true;
 		}
@@ -128,13 +128,13 @@ namespace se::string {
 	// Other string utility functions.
 	//
 
-	void strip_start(std::string& string, const std::string_view& substring) {
+	void strip_start(std::string& string, std::string_view substring) {
 		if (string.starts_with(substring)) {
 			string.erase(0, substring.length());
 		}
 	}
 
-	void strip_end(std::string& string, const std::string_view& substring) {
+	void strip_end(std::string& string, std::string_view substring) {
 		if (string.ends_with(substring)) {
 			string.erase(string.length() - substring.length());
 		}
@@ -627,7 +627,7 @@ namespace se::string {
 	//
 
 #if defined(SE_IS_CS) && SE_IS_CS == 1
-	bool complex_contains(const std::string_view& haystack, const std::string_view& needle, const se::cs::BaseObject::SearchSettings& settings, std::regex* regex) {
+	bool complex_contains(std::string_view haystack, std::string_view needle, const se::cs::BaseObject::SearchSettings& settings, std::regex* regex) {
 		if (settings.use_regex && regex) {
 			return std::regex_search(haystack.data(), *regex);
 		}

--- a/SharedSE/StringUtil.h
+++ b/SharedSE/StringUtil.h
@@ -35,15 +35,15 @@ namespace se::string {
 
 	bool istarts_with(std::string_view string, std::string_view substring);
 
-	bool contains(const std::string_view& haystack, const std::string_view& needle);
-	bool cicontains(const std::string_view& haystack, const std::string_view& needle);
+	bool contains(std::string_view haystack, std::string_view needle);
+	bool cicontains(std::string_view haystack, std::string_view needle);
 
 	//
 	// Other string utility functions.
 	//
 
-	void strip_start(std::string& string, const std::string_view& substring);
-	void strip_end(std::string& string, const std::string_view& substring);
+	void strip_start(std::string& string, std::string_view substring);
+	void strip_end(std::string& string, std::string_view substring);
 
 	bool replace(std::string& str, const std::string_view from, const std::string_view to);
 
@@ -142,7 +142,7 @@ namespace se::string {
 	//
 
 #if defined(SE_IS_CS) && SE_IS_CS == 1
-	bool complex_contains(const std::string_view& haystack, const std::string_view& needle, const se::cs::BaseObject::SearchSettings& settings, std::regex* regex);
+	bool complex_contains(std::string_view haystack, std::string_view needle, const se::cs::BaseObject::SearchSettings& settings, std::regex* regex);
 #endif
 
 }

--- a/SharedSE/StringUtil.h
+++ b/SharedSE/StringUtil.h
@@ -51,7 +51,7 @@ namespace se::string {
 		return std::isprint(c) || std::isspace(c);
 	}
 
-	static inline std::string from_wstring(const std::wstring& wstr) {
+	static inline std::string from_wstring(std::wstring_view wstr) {
 		std::string buf(wstr.size(), '\0');
 		std::use_facet<std::ctype<wchar_t>>(std::locale{}).narrow(wstr.data(), wstr.data() + wstr.size(), '?', buf.data());
 		return buf;


### PR DESCRIPTION
Also converts current string_view arguments that were passed by const reference to be passed by value. Here are some discussions on the topic: [1](https://stackoverflow.com/questions/64214076/why-passing-string-view-by-value-is-faster-than-const-reference) and [2](https://stackoverflow.com/questions/27256377/c-view-types-pass-by-const-or-by-value?noredirect=1&lq=1).