### PR TITLE
Additional string-related updates

### DIFF
--- a/CSSE/CSCell.cpp
+++ b/CSSE/CSCell.cpp
@@ -97,6 +97,6 @@ namespace se::cs {
 			ss << " (" << getGridX() << ", " << getGridY() << ")";
 		}
 
-		return std::move(ss.str());
+		return ss.str();
 	}
 }

--- a/CSSE/CSMagicEffect.cpp
+++ b/CSSE/CSMagicEffect.cpp
@@ -69,7 +69,7 @@ namespace se::cs {
 			ss << "<invalid effect>";
 		}
 
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	int MagicEffect::getNameGMST() const {

--- a/CSSE/DarkMode.cpp
+++ b/CSSE/DarkMode.cpp
@@ -1486,7 +1486,7 @@ namespace se::cs::darkmode {
 		SelectObject(hdc, previousBrush);
 		SelectObject(hdc, previousPen);
 
-		if (text.empty()) {
+		if (!text.empty()) {
 			RECT textRect = { clientRect.left + 8, clientRect.top, clientRect.left + 8 + textSize.cx + 4, clientRect.top + textSize.cy };
 			FillRect(hdc, &textRect, backgroundBrush);
 			textRect.left += 2;

--- a/CSSE/DarkMode.cpp
+++ b/CSSE/DarkMode.cpp
@@ -6,6 +6,7 @@
 #include "LogUtil.h"
 #include "Settings.h"
 #include "WindowsUtil.h"
+#include "WinUIUtil.h"
 
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
@@ -845,10 +846,8 @@ namespace se::cs::darkmode {
 			}
 		}
 
-		char windowText[MAX_PATH] = {};
-		const char* displayText = text.empty() ? windowText : text.data();
 		if (text.empty()) {
-			GetWindowTextA(hWnd, windowText, sizeof(windowText));
+			text = winui::GetWindowTextA(hWnd);
 		}
 
 		itemRect.left += 3;
@@ -857,7 +856,7 @@ namespace se::cs::darkmode {
 		const auto previousFont = SelectObject(hdc, getMessageFont(hWnd));
 		SetBkMode(hdc, TRANSPARENT);
 		SetTextColor(hdc, IsWindowEnabled(hWnd) ? palette::text : palette::textDisabled);
-		DrawTextA(hdc, displayText, -1, &itemRect, DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX);
+		DrawTextA(hdc, text.c_str(), -1, &itemRect, DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS | DT_NOPREFIX);
 		SelectObject(hdc, previousFont);
 
 	}
@@ -1250,12 +1249,8 @@ namespace se::cs::darkmode {
 		GetClientRect(hWnd, &clientRect);
 		FillRect(hdc, &clientRect, surfaceBrush);
 
-		const auto textLength = GetWindowTextLengthA(hWnd);
-		if (textLength > 0) {
-			std::string text(textLength + 1, '\0');
-			GetWindowTextA(hWnd, text.data(), static_cast<int>(text.size()));
-			text.resize(textLength);
-
+		std::string text = winui::GetWindowTextA(hWnd);
+		if (!text.empty()) {
 			const auto firstVisibleLine = SendMessageA(hWnd, EM_GETFIRSTVISIBLELINE, 0, 0);
 			const auto firstVisibleCharacter = SendMessageA(hWnd, EM_LINEINDEX, firstVisibleLine, 0);
 			if (firstVisibleCharacter > 0) {
@@ -1474,14 +1469,13 @@ namespace se::cs::darkmode {
 		RECT clientRect = {};
 		GetClientRect(hWnd, &clientRect);
 
-		char text[MAX_PATH] = {};
-		GetWindowTextA(hWnd, text, sizeof(text));
+		auto text = winui::GetWindowTextA(hWnd);
 
 		const auto font = getMessageFont(hWnd);
 		const auto previousFont = SelectObject(hdc, font);
 
 		SIZE textSize = {};
-		GetTextExtentPoint32A(hdc, text, static_cast<int>(strlen(text)), &textSize);
+		GetTextExtentPoint32A(hdc, text.c_str(), static_cast<int>(text.size()), &textSize);
 
 		// Frame, dropped below the caption's center line.
 		auto frameRect = clientRect;
@@ -1492,13 +1486,13 @@ namespace se::cs::darkmode {
 		SelectObject(hdc, previousBrush);
 		SelectObject(hdc, previousPen);
 
-		if (text[0] != '\0') {
+		if (text.empty()) {
 			RECT textRect = { clientRect.left + 8, clientRect.top, clientRect.left + 8 + textSize.cx + 4, clientRect.top + textSize.cy };
 			FillRect(hdc, &textRect, backgroundBrush);
 			textRect.left += 2;
 			SetBkMode(hdc, TRANSPARENT);
 			SetTextColor(hdc, IsWindowEnabled(hWnd) ? palette::text : palette::textDisabled);
-			DrawTextA(hdc, text, -1, &textRect, DT_LEFT | DT_TOP | DT_SINGLELINE);
+			DrawTextA(hdc, text.c_str(), -1, &textRect, DT_LEFT | DT_TOP | DT_SINGLELINE);
 		}
 
 		SelectObject(hdc, previousFont);

--- a/CSSE/DialogRenderWindow.cpp
+++ b/CSSE/DialogRenderWindow.cpp
@@ -3349,7 +3349,7 @@ namespace se::cs::dialog::render_window {
 			return !outIds.empty();
 		}
 
-		void parseUnicodeText(const std::wstring& text, std::vector<std::string>& outIds) {
+		void parseUnicodeText(std::wstring_view text, std::vector<std::string>& outIds) {
 			// Note: `from_wstring` is lossy but that should be irrelevant for ASCII IDs.
 			const std::string payload = se::string::from_wstring(text);
 			constexpr std::string_view prefix = "cs-object:";

--- a/CSSE/WinUIUtil.cpp
+++ b/CSSE/WinUIUtil.cpp
@@ -150,7 +150,7 @@ namespace se::cs::winui {
 		// GetWindowTextA will cause a null terminator character to be appended to the string, which we need to pop off.
 		text.pop_back();
 
-		return std::move(text);
+		return text;
 	}
 
 	std::optional<int> GetDlgItemSignedInt(HWND hWnd, UINT nIDDlgItem) {

--- a/MWSE/LuaExecutor.cpp
+++ b/MWSE/LuaExecutor.cpp
@@ -119,7 +119,7 @@ namespace mwse::lua {
 		auto result = std::move(outputBuilder.str());
 		outputBuilder.clear();
 		outputBuilderMutex.unlock();
-		return std::move(result);
+		return result;
 	}
 
 	void LuaExecutor::defineLuaBindings() {

--- a/MWSE/LuaUtil.cpp
+++ b/MWSE/LuaUtil.cpp
@@ -144,7 +144,7 @@ namespace mwse::lua {
 			}
 		}
 
-		return std::move(value);
+		return value;
 	}
 
 	TES3::BaseObject* getOptionalParamBaseObject(sol::optional<sol::table> maybeParams, const char* key) {

--- a/MWSE/MGEApiLua.cpp
+++ b/MWSE/MGEApiLua.cpp
@@ -203,7 +203,7 @@ namespace mge::lua {
 			}
 		}
 
-		return std::move(out.str());
+		return out.str();
 	}
 
 	sol::optional<ShaderHandleLua> ShadersConfig::findShader(sol::optional<sol::table> params) {

--- a/MWSE/MGEPostShaders.cpp
+++ b/MWSE/MGEPostShaders.cpp
@@ -39,7 +39,7 @@ namespace mge {
 	std::string ShaderHandleLua::toJson() const {
 		std::ostringstream ss;
 		ss << "\"" << api->shaderGetName(handle) << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	sol::table ShaderHandleLua::listVariables(sol::this_state ts) const {

--- a/MWSE/TES3Birthsign.cpp
+++ b/MWSE/TES3Birthsign.cpp
@@ -18,7 +18,7 @@ namespace TES3 {
 	std::string Birthsign::getAndFreeDescription() {
 		std::string desc = getDescription();
 		freeDescription();
-		return std::move(desc);
+		return desc;
 	}
 }
 

--- a/MWSE/TES3Cell.cpp
+++ b/MWSE/TES3Cell.cpp
@@ -321,7 +321,7 @@ namespace TES3 {
 			ss << " (" << getGridX() << ", " << getGridY() << ")";
 		}
 
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	bool Cell::isPointInCell(float x, float y) const {

--- a/MWSE/TES3Dialogue.cpp
+++ b/MWSE/TES3Dialogue.cpp
@@ -251,7 +251,7 @@ namespace TES3 {
 	std::string Dialogue::toJson() {
 		std::ostringstream ss;
 		ss << "\"tes3dialogue:" << name << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	bool Dialogue::addToJournal_lua(sol::table params) {

--- a/MWSE/TES3DialogueInfo.cpp
+++ b/MWSE/TES3DialogueInfo.cpp
@@ -397,7 +397,7 @@ namespace TES3 {
 	std::string DialogueInfo::toJson() {
 		std::ostringstream ss;
 		ss << "\"tes3dialogueInfo:" << getID().value_or("<invalid>") << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 }
 

--- a/MWSE/TES3GameFile.cpp
+++ b/MWSE/TES3GameFile.cpp
@@ -39,7 +39,7 @@ namespace TES3 {
 		return TES3_TES3File_readChunkData(this, data, size);
 	}
 
-	int GameFile::writeChunkString(unsigned int tag, std::string string) {
+	int GameFile::writeChunkString(unsigned int tag, const std::string& string) {
 		return writeChunkData(tag, string.data(), string.length() + 1);
 	}
 

--- a/MWSE/TES3GameFile.h
+++ b/MWSE/TES3GameFile.h
@@ -82,7 +82,7 @@ namespace TES3 {
 		int writeChunkValue(unsigned int tag, const T* data) {
 			return writeChunkData(tag, data, sizeof(T));
 		}
-		int writeChunkString(unsigned int tag, std::string string);
+		int writeChunkString(unsigned int tag, const std::string& string);
 		int writeChunkData(unsigned int tag, const void * data, unsigned int size);
 		int writeRecordHeader(unsigned int tag, unsigned int flags);
 		int endRecord();

--- a/MWSE/TES3GameSetting.cpp
+++ b/MWSE/TES3GameSetting.cpp
@@ -52,7 +52,7 @@ namespace TES3 {
 	std::string GameSetting::toJson() const {
 		std::ostringstream ss;
 		ss << "\"tes3gameSetting:" << getName() << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	sol::object GameSetting::getDefaultValue_lua(sol::this_state ts) const {

--- a/MWSE/TES3MagicEffect.cpp
+++ b/MWSE/TES3MagicEffect.cpp
@@ -96,7 +96,7 @@ namespace TES3 {
 			ss << "<invalid effect>";
 		}
 
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	int MagicEffect::getNameGMST() const {

--- a/MWSE/TES3MobilePlayer.cpp
+++ b/MWSE/TES3MobilePlayer.cpp
@@ -244,7 +244,7 @@ namespace TES3 {
 			results.push_back(mobile);
 		}
 
-		return std::move(results);
+		return results;
 	}
 
 	float MobilePlayer::getCompanionMaxDistance() const {

--- a/MWSE/TES3Object.cpp
+++ b/MWSE/TES3Object.cpp
@@ -351,7 +351,7 @@ namespace TES3 {
 	std::string BaseObject::toJson() const {
 		std::ostringstream ss;
 		ss << "\"tes3baseObject:" << getObjectID() << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	std::unordered_set<const BaseObject*> sourcelessObjects;

--- a/MWSE/TES3Quest.cpp
+++ b/MWSE/TES3Quest.cpp
@@ -10,7 +10,7 @@ namespace TES3 {
 	std::string Quest::toJson() const {
 		std::ostringstream ss;
 		ss << "\"tes3quest:" << getObjectID() << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	bool Quest::isActive() const {

--- a/MWSE/TES3ScriptLua.cpp
+++ b/MWSE/TES3ScriptLua.cpp
@@ -10,7 +10,7 @@
 #include "TES3Script.h"
 
 namespace mwse::lua {
-	sol::object ScriptContext::index(std::string key) {
+	sol::object ScriptContext::index(const std::string& key) {
 		const auto stateHandle = LuaManager::getInstance().getThreadSafeStateHandle();
 		auto& state = stateHandle.getState();
 

--- a/MWSE/TES3ScriptLua.h
+++ b/MWSE/TES3ScriptLua.h
@@ -12,7 +12,7 @@ namespace mwse::lua {
 
 		}
 
-		sol::object index(std::string);
+		sol::object index(const std::string&);
 		void new_index(std::string, sol::stack_object);
 		size_t length();
 

--- a/MWSE/TES3Skill.cpp
+++ b/MWSE/TES3Skill.cpp
@@ -17,7 +17,7 @@ namespace TES3 {
 	std::string Skill::getIconPath() const {
 		std::string path = "icons\\k\\";
 		path.append(ICON_PATHS[skill]);
-		return std::move(path);
+		return path;
 	}
 
 	std::reference_wrapper<float[4]> Skill::getProgressActions() {

--- a/MWSE/TES3SoulGemData.cpp
+++ b/MWSE/TES3SoulGemData.cpp
@@ -22,7 +22,7 @@ namespace TES3 {
 	std::string SoulGemData::toJson() const {
 		std::ostringstream ss;
 		ss << "\"tes3soulGemData:" << id << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	int SoulGemData::getValue() const {

--- a/MWSE/TES3Sound.cpp
+++ b/MWSE/TES3Sound.cpp
@@ -211,7 +211,7 @@ namespace TES3 {
 	std::string Sound::toJson() const {
 		std::ostringstream ss;
 		ss << "\"tes3sound:" << id << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	bool Sound::play_lua(sol::optional<sol::table> params) {

--- a/MWSE/TES3SoundGenerator.cpp
+++ b/MWSE/TES3SoundGenerator.cpp
@@ -8,7 +8,7 @@ namespace TES3 {
 	std::string SoundGenerator::toJson() const {
 		std::ostringstream ss;
 		ss << "\"tes3soundGenerator:" << name << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 }
 

--- a/MWSE/TES3UIElement.cpp
+++ b/MWSE/TES3UIElement.cpp
@@ -407,7 +407,7 @@ namespace TES3::UI {
 	std::string Element::toJson() const {
 		std::ostringstream ss;
 		ss << "\"tes3uiElement:" << id << ":" << (name.cString ? name.cString : "(unnamed)") << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	sol::table Element::getChildren_lua(sol::this_state ts) const {
@@ -568,10 +568,10 @@ namespace TES3::UI {
 			return WidgetButton::fromElement(this)->getText();
 		}
 		else if (part == propParagraphInput) {
-			return std::move(WidgetParagraphInput::fromElement(this)->getText());
+			return WidgetParagraphInput::fromElement(this)->getText();
 		}
 		else if (part == propTextInput) {
-			return std::move(WidgetTextInput::fromElement(this)->getText());
+			return WidgetTextInput::fromElement(this)->getText();
 		}
 
 		return getText();

--- a/MWSE/TES3UIElement.cpp
+++ b/MWSE/TES3UIElement.cpp
@@ -767,7 +767,7 @@ namespace TES3::UI {
 		return (flow == Property::top_to_bottom) ? "top_to_bottom" : "left_to_right";
 	}
 
-	void Element::setFlowDirectionString(std::string value) {
+	void Element::setFlowDirectionString(const std::string& value) {
 		auto prop = (value == "top_to_bottom") ? Property::top_to_bottom : Property::left_to_right;
 		setProperty(TES3::UI::Property::flow_direction, prop);
 	}
@@ -869,7 +869,7 @@ namespace TES3::UI {
 		return "left";
 	}
 
-	void Element::setJustifyTextString(std::string value) {
+	void Element::setJustifyTextString(const std::string& value) {
 		auto prop = Property::left;
 		if (value == "center") {
 			prop = Property::center;

--- a/MWSE/TES3UIElement.cpp
+++ b/MWSE/TES3UIElement.cpp
@@ -767,7 +767,7 @@ namespace TES3::UI {
 		return (flow == Property::top_to_bottom) ? "top_to_bottom" : "left_to_right";
 	}
 
-	void Element::setFlowDirectionString(const std::string& value) {
+	void Element::setFlowDirectionString(std::string_view value) {
 		auto prop = (value == "top_to_bottom") ? Property::top_to_bottom : Property::left_to_right;
 		setProperty(TES3::UI::Property::flow_direction, prop);
 	}
@@ -869,7 +869,7 @@ namespace TES3::UI {
 		return "left";
 	}
 
-	void Element::setJustifyTextString(const std::string& value) {
+	void Element::setJustifyTextString(std::string_view value) {
 		auto prop = Property::left;
 		if (value == "center") {
 			prop = Property::center;

--- a/MWSE/TES3UIElement.h
+++ b/MWSE/TES3UIElement.h
@@ -252,7 +252,7 @@ namespace TES3::UI {
 		bool getDisabled() const;
 		void setDisabled(bool value);
 		std::string getFlowDirectionString() const;
-		void setFlowDirectionString(std::string value);
+		void setFlowDirectionString(const std::string& value);
 		int getFont() const;
 		void setFont_lua(sol::optional<int> value = 0);
 		int getHeight() const;
@@ -270,7 +270,7 @@ namespace TES3::UI {
 		float getImageScaleY() const;
 		void setImageScaleY(float value);
 		std::string getJustifyTextString() const;
-		void setJustifyTextString(std::string value);
+		void setJustifyTextString(const std::string& value);
 		sol::optional<int> getMaxHeight_lua() const;
 		void setMaxHeight_lua(sol::optional<int> value = INT32_MAX);
 		sol::optional<int> getMaxWidth_lua() const;

--- a/MWSE/TES3UIElement.h
+++ b/MWSE/TES3UIElement.h
@@ -252,7 +252,7 @@ namespace TES3::UI {
 		bool getDisabled() const;
 		void setDisabled(bool value);
 		std::string getFlowDirectionString() const;
-		void setFlowDirectionString(const std::string& value);
+		void setFlowDirectionString(std::string_view value);
 		int getFont() const;
 		void setFont_lua(sol::optional<int> value = 0);
 		int getHeight() const;
@@ -270,7 +270,7 @@ namespace TES3::UI {
 		float getImageScaleY() const;
 		void setImageScaleY(float value);
 		std::string getJustifyTextString() const;
-		void setJustifyTextString(const std::string& value);
+		void setJustifyTextString(std::string_view value);
 		sol::optional<int> getMaxHeight_lua() const;
 		void setMaxHeight_lua(sol::optional<int> value = INT32_MAX);
 		sol::optional<int> getMaxWidth_lua() const;

--- a/MWSE/TES3UIWidgets.cpp
+++ b/MWSE/TES3UIWidgets.cpp
@@ -275,7 +275,7 @@ namespace TES3::UI {
 
 	std::string WidgetParagraphInput::getText() const {
 		auto textInput = WidgetTextInput::fromElement(findChild(uiidParagraphInputText));
-		return std::move(textInput->getText());
+		return textInput->getText();
 	}
 
 	void WidgetParagraphInput::setText(const char* text) {
@@ -579,7 +579,7 @@ namespace TES3::UI {
 		if (i != std::string::npos) {
 			editText.erase(i, 1);
 		}
-		return std::move(editText);
+		return editText;
 	}
 	void WidgetTextInput::setText(const char* text) {
 		// Use standard setText without adding a caret.

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -682,7 +682,7 @@ namespace mwse::lua {
 		}
 	}
 
-	TES3::SoundGenerator* getSoundGenerator(std::string creatureId, unsigned int type) {
+	TES3::SoundGenerator* getSoundGenerator(const std::string& creatureId, unsigned int type) {
 		auto nonDynamicData = TES3::DataHandler::get()->nonDynamicData;
 		auto creature = nonDynamicData->resolveObjectByType<TES3::Creature>(creatureId);
 		if (creature == nullptr) {

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -682,7 +682,7 @@ namespace mwse::lua {
 		}
 	}
 
-	TES3::SoundGenerator* getSoundGenerator(const std::string& creatureId, unsigned int type) {
+	TES3::SoundGenerator* getSoundGenerator(std::string_view creatureId, unsigned int type) {
 		auto nonDynamicData = TES3::DataHandler::get()->nonDynamicData;
 		auto creature = nonDynamicData->resolveObjectByType<TES3::Creature>(creatureId);
 		if (creature == nullptr) {

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -753,7 +753,7 @@ namespace mwse::lua {
 
 		auto attribute = getOptionalParam<int>(params, "attribute", -1);
 		auto skill = getOptionalParam<int>(params, "skill", -1);
-		return std::move(effect->getComplexName(attribute, skill));
+		return effect->getComplexName(attribute, skill);
 	}
 
 	sol::optional<NI::Camera*> getCamera() {

--- a/MWSE/TES3Weather.cpp
+++ b/MWSE/TES3Weather.cpp
@@ -23,7 +23,7 @@ namespace TES3 {
 	std::string Weather::toJson() const {
 		std::ostringstream ss;
 		ss << "\"tes3weather:" << index << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	const char* Weather::getName() const {

--- a/SharedSE/NIBoundingBox.cpp
+++ b/SharedSE/NIBoundingBox.cpp
@@ -47,7 +47,7 @@ namespace NI {
 	std::string BoundingBox::toString() const {
 		std::ostringstream ss;
 		ss << std::fixed << std::setprecision(2) << std::dec << *this;
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	std::string BoundingBox::toJson() const {
@@ -56,7 +56,7 @@ namespace NI {
 			<< "\"min\":" << minimum.toJson() << ","
 			<< "\"max\":" << maximum.toJson()
 			<< "}";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	BoundingBox BoundingBox::copy() const {

--- a/SharedSE/NIColor.cpp
+++ b/SharedSE/NIColor.cpp
@@ -31,7 +31,7 @@ namespace NI {
 	std::string PackedColor::toString() const {
 		std::ostringstream ss;
 		ss << std::fixed << std::setprecision(2) << "<" << int(r) << ", " << int(g) << ", " << int(b) << ", " << int(a) << ">";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	//
@@ -157,13 +157,13 @@ namespace NI {
 	std::string Color::toString() const {
 		std::ostringstream ss;
 		ss << std::fixed << std::setprecision(2) << "<" << r << ", " << g << ", " << b << ">";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	std::string Color::toJson() const {
 		std::ostringstream ss;
 		ss << "{\"r\":" << r << ",\"g\":" << g << ",\"b\":" << b << "}";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	//
@@ -182,6 +182,6 @@ namespace NI {
 	std::string ColorA::toString() const {
 		std::ostringstream ss;
 		ss << std::fixed << std::setprecision(2) << "<" << r << ", " << g << ", " << b << ", " << a << ">";
-		return std::move(ss.str());
+		return ss.str();
 	}
 }

--- a/SharedSE/NIMatrix33.cpp
+++ b/SharedSE/NIMatrix33.cpp
@@ -139,7 +139,7 @@ namespace NI {
 	std::string Matrix33::toString() const {
 		std::ostringstream ss;
 		ss << std::fixed << std::setprecision(2) << std::dec << *this;
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	std::string Matrix33::toJson() const {
@@ -149,7 +149,7 @@ namespace NI {
 			<< "[" << m1.x << "," << m1.y << "," << m1.z << "],"
 			<< "[" << m2.x << "," << m2.y << "," << m2.z << "]"
 			<< "]";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	Matrix33 Matrix33::copy() const {

--- a/SharedSE/NIMatrix44.cpp
+++ b/SharedSE/NIMatrix44.cpp
@@ -87,7 +87,7 @@ namespace NI {
 	std::string Matrix44::toString() const {
 		std::ostringstream ss;
 		ss << std::fixed << std::setprecision(2) << std::dec << *this;
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	std::string Matrix44::toJson() const {
@@ -98,7 +98,7 @@ namespace NI {
 			<< m2.toJson() << ","
 			<< m3.toJson()
 			<< "]";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	Matrix44 Matrix44::copy() const {

--- a/SharedSE/NIObject.cpp
+++ b/SharedSE/NIObject.cpp
@@ -143,7 +143,7 @@ namespace NI {
 			name = static_cast<const ObjectNET*>(this)->name;
 		}
 		ss << getRunTimeTypeInformation()->toString() << ":" << (name ? name : "(unnamed)");
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	std::string Object::toJson() const {
@@ -153,7 +153,7 @@ namespace NI {
 			name = static_cast<const ObjectNET*>(this)->name;
 		}
 		ss << "\"" << getRunTimeTypeInformation()->toString() << ":" << (name ? name : "(unnamed)") << "\"";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 #if defined(SE_USE_LUA) && SE_USE_LUA == 1

--- a/SharedSE/NIPoint2.cpp
+++ b/SharedSE/NIPoint2.cpp
@@ -94,13 +94,13 @@ namespace NI {
 	std::string Point2::toString() const {
 		std::ostringstream ss;
 		ss << std::fixed << std::setprecision(2) << std::dec << *this;
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	std::string Point2::toJson() const {
 		std::ostringstream ss;
 		ss << "{\"x\":" << x << ",\"y\":" << y << "}";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	Point2 Point2::copy() const {

--- a/SharedSE/NIPoint3.cpp
+++ b/SharedSE/NIPoint3.cpp
@@ -134,13 +134,13 @@ namespace NI {
 	std::string Point3::toString() const {
 		std::ostringstream ss;
 		ss << std::fixed << std::setprecision(2) << std::dec << *this;
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	std::string Point3::toJson() const {
 		std::ostringstream ss;
 		ss << "{\"x\":" << x << ",\"y\":" << y << ",\"z\":" << z << "}";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	Point3 Point3::copy() const {

--- a/SharedSE/NIPoint4.cpp
+++ b/SharedSE/NIPoint4.cpp
@@ -57,13 +57,13 @@ namespace NI {
 	std::string Point4::toString() const {
 		std::ostringstream ss;
 		ss << std::fixed << std::setprecision(2) << std::dec << *this;
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	std::string Point4::toJson() const {
 		std::ostringstream ss;
 		ss << "{\"x\":" << x << ",\"y\":" << y << ",\"z\":" << z << ",\"w\":" << w << "}";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	Point4 Point4::copy() const {

--- a/SharedSE/NIQuaternion.cpp
+++ b/SharedSE/NIQuaternion.cpp
@@ -48,13 +48,13 @@ namespace NI {
 	std::string Quaternion::toString() const {
 		std::ostringstream ss;
 		ss << std::fixed << std::setprecision(2) << std::dec << *this;
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	std::string Quaternion::toJson() const {
 		std::ostringstream ss;
 		ss << "{\"w\":" << w << ",\"x\":" << x << ",\"y\":" << y << ",\"z\":" << z << "}";
-		return std::move(ss.str());
+		return ss.str();
 	}
 
 	Quaternion Quaternion::copy() const {

--- a/SharedSE/NIStream.cpp
+++ b/SharedSE/NIStream.cpp
@@ -162,6 +162,6 @@ namespace NI {
 		se::memory::_delete(string);
 #endif
 
-		return std::move(out_string);
+		return out_string;
 	}
 }

--- a/SharedSE/StringUtil.cpp
+++ b/SharedSE/StringUtil.cpp
@@ -618,7 +618,7 @@ namespace se::string {
 			start = end;
 		}
 
-		return std::move(result);
+		return result;
 	}
 #endif
 


### PR DESCRIPTION
Split into different commits for easier review. The main change here is the removal of the `return std::move(localVar)` construct. In such cases, the compiler would perform (Named) Return Value Optimization RVO/NRVO if the value wasn't moved. The compiler can perform RVO when a local variable of the same type as the function's return type is returned and directly construct the variable in its final destination. A call to std::move inhibits that. 

References: [1](https://stackoverflow.com/questions/19267408/why-does-stdmove-prevent-rvo-return-value-optimization), [2](https://www.youtube.com/watch?v=AKtHxKJRwp4&t=2284s), [3](https://stackoverflow.com/questions/39750660/initializing-a-stdstring-with-function-return-value-is-there-a-copy) and what [the standard](https://en.cppreference.com/cpp/language/copy_elision) says on copy elision.

I don't expect any of these changes to improve performance.