### PR TITLE
Refactor MWSE-mwscript code

### DIFF
--- a/MWSE/InstructionStore.h
+++ b/MWSE/InstructionStore.h
@@ -42,7 +42,7 @@ namespace mwse {
 			unsigned int primary_index = (opcode >> 8) & 0xFF;
 			unsigned int secondary_index = opcode & 0xFF;
 			InstructionInterface_t** secondary_table = opCode_primary_table[primary_index];
-			if (secondary_table == NULL || secondary_table[secondary_index] == NULL) {
+			if (secondary_table == nullptr || secondary_table[secondary_index] == nullptr) {
 				// FIXME: This should probably be in the VM, where it can report script name and offset.
 				log::getLog() << "Illegal or unimplemented opcode " << std::hex << opcode << std::endl;
 				throw IllegalOpCode(opcode);
@@ -56,7 +56,7 @@ namespace mwse {
 			unsigned int secondary_index = opcode & 0xFF;
 			InstructionInterface_t** secondary_table = opCode_primary_table[primary_index];
 
-			return (secondary_table != NULL) && (secondary_table[secondary_index] != NULL);
+			return (secondary_table != nullptr) && (secondary_table[secondary_index] != nullptr);
 		}
 	};
 }

--- a/MWSE/LuaCalcMovementSpeedEvent.cpp
+++ b/MWSE/LuaCalcMovementSpeedEvent.cpp
@@ -8,7 +8,7 @@
 
 namespace mwse::lua::event {
 	CalculateMovementSpeed::CalculateMovementSpeed(MovementType type, TES3::MobileActor* mobile, float speed) :
-		ObjectFilteredEvent(NULL, mobile->reference),
+		ObjectFilteredEvent(nullptr, mobile->reference),
 		m_Type(type),
 		m_MobileActor(mobile),
 		m_Speed(speed)

--- a/MWSE/LuaLoadGameEvent.cpp
+++ b/MWSE/LuaLoadGameEvent.cpp
@@ -9,7 +9,7 @@ namespace mwse::lua::event {
 		m_QuickLoad(quickLoad),
 		m_NewGame(newGame)
 	{
-		if (m_FileName == NULL && !m_NewGame) {
+		if (m_FileName == nullptr && !m_NewGame) {
 			m_QuickLoad = true;
 			m_FileName = "quiksave.ess";
 		}

--- a/MWSE/LuaLoadedGameEvent.cpp
+++ b/MWSE/LuaLoadedGameEvent.cpp
@@ -14,7 +14,7 @@ namespace mwse::lua::event {
 		m_QuickLoad(quickLoad),
 		m_NewGame(newGame)
 	{
-		if (m_FileName == NULL && !m_NewGame) {
+		if (m_FileName == nullptr && !m_NewGame) {
 			m_QuickLoad = true;
 			m_FileName = "quiksave.ess";
 		}

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -347,7 +347,7 @@ namespace mwse::lua {
 	static std::unordered_map<unsigned long, sol::object> scriptOverrides;
 
 	// The currently executing overwritten script.
-	static LuaScript* currentOverwrittenScript = NULL;
+	static LuaScript* currentOverwrittenScript = nullptr;
 
 	// We still abort the program if an unprotected lua error happens. Here we at least
 	// get it in the log so it can be debugged.
@@ -1787,7 +1787,7 @@ namespace mwse::lua {
 
 	TES3::Object* __fastcall OnInterruptRest(TES3::LeveledCreature* leveledCreature, DWORD _UNUSED_) {
 		// Creature that we return.
-		TES3::Object* creature = NULL;
+		TES3::Object* creature = nullptr;
 
 		// Fire off an event and change the determined creature.
 		if (event::RestInterruptEvent::getEventEnabled()) {
@@ -1799,7 +1799,7 @@ namespace mwse::lua {
 				if (eventData.get_or("block", false)) {
 					tes3::setRestInterruptCount(0);
 					tes3::setRestHoursInterrupted(-1);
-					return NULL;
+					return nullptr;
 				}
 
 				// Allow overriding the spawn.

--- a/MWSE/LuaUtil.cpp
+++ b/MWSE/LuaUtil.cpp
@@ -230,7 +230,7 @@ namespace mwse::lua {
 			}
 		}
 
-		return NULL;
+		return nullptr;
 	}
 
 	TES3::Reference* getOptionalParamReference(sol::optional<sol::table> maybeParams, const char* key) {

--- a/MWSE/LuaUtil.h
+++ b/MWSE/LuaUtil.h
@@ -47,7 +47,7 @@ namespace mwse::lua {
 
 	template <typename T>
 	T* getOptionalParamObject(sol::optional<sol::table> maybeParams, const char* key) {
-		T* value = NULL;
+		T* value = nullptr;
 
 		if (maybeParams) {
 			sol::table params = maybeParams.value();

--- a/MWSE/ScriptUtil.cpp
+++ b/MWSE/ScriptUtil.cpp
@@ -10,7 +10,7 @@
 #include "TES3Sound.h"
 
 namespace mwse::mwscript {
-	TES3::Reference* lastCreatedPlaceAtPCReference = NULL;
+	TES3::Reference* lastCreatedPlaceAtPCReference = nullptr;
 
 	int getInstructionPointer() {
 		return *reinterpret_cast<int*>(TES3_IP_IMAGE);
@@ -30,7 +30,7 @@ namespace mwse::mwscript {
 
 	void setScriptTargetReference(TES3::Reference* reference) {
 		*reinterpret_cast<TES3::Reference**>(TES3_SCRIPTTARGETREF_IMAGE) = reference;
-		if (reference != NULL) {
+		if (reference) {
 			setScriptTargetTemplate(reference->baseObject);
 		}
 		else {
@@ -392,15 +392,15 @@ namespace mwse::mwscript {
 	}
 
 	bool GetPCJumping(TES3::Script* script) {
-		return RunOriginalOpCode(script, NULL, OpCode::GetPCJumping) == 1;
+		return RunOriginalOpCode(script, nullptr, OpCode::GetPCJumping) == 1;
 	}
 
 	bool GetPCRunning(TES3::Script* script) {
-		return RunOriginalOpCode(script, NULL, OpCode::GetPCRunning) == 1;
+		return RunOriginalOpCode(script, nullptr, OpCode::GetPCRunning) == 1;
 	}
 
 	bool GetPCSneaking(TES3::Script* script) {
-		return RunOriginalOpCode(script, NULL, OpCode::GetPCSneaking) == 1;
+		return RunOriginalOpCode(script, nullptr, OpCode::GetPCSneaking) == 1;
 	}
 
 	bool GetSpellEffects(TES3::Script* script, TES3::Reference* reference, TES3::BaseObject* spellTemplate) {
@@ -532,7 +532,7 @@ namespace mwse::mwscript {
 
 	bool ScriptRunning(TES3::Script* script, TES3::Script* targetScript) {
 		// Run original opcode.
-		float value = RunOriginalOpCode(script, NULL, OpCode::ScriptRunning, reinterpret_cast<TES3::BaseObject*>(targetScript));
+		float value = RunOriginalOpCode(script, nullptr, OpCode::ScriptRunning, reinterpret_cast<TES3::BaseObject*>(targetScript));
 
 		return value != 0.0f;
 	}
@@ -583,7 +583,7 @@ namespace mwse::mwscript {
 
 		// Prepare variables and run original opcode.
 		setScriptSecondObject(reinterpret_cast<TES3::BaseObject*>(targetScript));
-		RunOriginalOpCode(script, NULL, OpCode::StopScript);
+		RunOriginalOpCode(script, nullptr, OpCode::StopScript);
 
 		// Restore original script variables.
 		setScriptSecondObject(cachedSecondObject);

--- a/MWSE/TES3Class.h
+++ b/MWSE/TES3Class.h
@@ -29,7 +29,9 @@ namespace TES3 {
 		};
 
 		constexpr auto OffersBarteringMask = BartersWeapons | BartersArmor | BartersClothing | BartersBooks | BartersIngredients | BartersLockpicks | BartersProbes | BartersLights | BartersApparatus | BartersRepairTools | BartersMiscItems | BartersAlchemy;
+		constexpr auto AllServicesMask = OffersBarteringMask | OffersSpells | BartersEnchantedItems | OffersTraining | OffersSpellmaking | OffersEnchanting | OffersRepairs;
 		static_assert(OffersBarteringMask == 0x27FF, "Bartering mask does not match game code. Was a new bartering type added?");
+		static_assert(AllServicesMask == 0x3FFFF, "Services mask does not match MWSE-mwscript code. Was a new bartering type added?");
 	}
 
 	struct Class : BaseObject {

--- a/MWSE/TES3DataHandler.cpp
+++ b/MWSE/TES3DataHandler.cpp
@@ -241,7 +241,7 @@ namespace TES3 {
 			luaManager.restorePersistentTimers();
 
 			if (mwse::lua::event::LoadedGameEvent::getEventEnabled()) {
-				luaManager.getThreadSafeStateHandle().triggerEvent(new mwse::lua::event::LoadedGameEvent(eventFileName.c_str(), fileName == NULL));
+				luaManager.getThreadSafeStateHandle().triggerEvent(new mwse::lua::event::LoadedGameEvent(eventFileName.c_str(), fileName == nullptr));
 			}
 
 			// Extra things we want to do if we're successfully loading.

--- a/MWSE/TES3SpellList.cpp
+++ b/MWSE/TES3SpellList.cpp
@@ -28,7 +28,7 @@ namespace TES3 {
 	}
 
 	bool SpellList::remove(const char* id) {
-		for (auto itt = list.head; itt != NULL; itt = itt->next) {
+		for (auto itt = list.head; itt != nullptr; itt = itt->next) {
 			const char* thisId = itt->data->getObjectID();
 			if (_strcmpi(thisId, id) == 0) {
 				return remove(itt->data);
@@ -95,7 +95,7 @@ namespace TES3 {
 	}
 
 	bool SpellList::containsType(SpellCastType::value_type type) {
-		for (auto itt = list.head; itt != NULL; itt = itt->next) {
+		for (auto itt = list.head; itt != nullptr; itt = itt->next) {
 			if (itt->data->castType == type) {
 				return true;
 			}

--- a/MWSE/TES3Util.cpp
+++ b/MWSE/TES3Util.cpp
@@ -71,7 +71,7 @@ namespace mwse::tes3 {
 		long skillAttributeId, long range, long area, long duration,
 		long minimumMagnitude, long maximumMagnitude) {
 		// Validate effect pointer.
-		if (effects == NULL) {
+		if (effects == nullptr) {
 			mwse::log::getLog() << __FUNCTION__ << ": No effect passed." << std::endl;
 			return false;
 		}
@@ -244,11 +244,11 @@ namespace mwse::tes3 {
 		customArmorSlots[data->slot] = data;
 	}
 
-	TES3::Reference* exteriorRefs[9] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
+	TES3::Reference* exteriorRefs[9] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
 
 	void clearExteriorRefs() {
 		for (size_t i = 0; i < 9; ++i) {
-			exteriorRefs[i] = NULL;
+			exteriorRefs[i] = nullptr;
 		}
 	}
 
@@ -257,7 +257,7 @@ namespace mwse::tes3 {
 		// Call our load event.
 		auto& luaManager = mwse::lua::LuaManager::getInstance();
 		if (mwse::lua::event::LoadGameEvent::getEventEnabled()) {
-			luaManager.getThreadSafeStateHandle().triggerEvent(new mwse::lua::event::LoadGameEvent(NULL, false, true));
+			luaManager.getThreadSafeStateHandle().triggerEvent(new mwse::lua::event::LoadGameEvent(nullptr, false, true));
 		}
 
 		// Call original function.
@@ -269,7 +269,7 @@ namespace mwse::tes3 {
 
 		// Call our post-load event.
 		if (mwse::lua::event::LoadedGameEvent::getEventEnabled()) {
-			luaManager.getThreadSafeStateHandle().triggerEvent(new mwse::lua::event::LoadedGameEvent(NULL, false, true));
+			luaManager.getThreadSafeStateHandle().triggerEvent(new mwse::lua::event::LoadedGameEvent(nullptr, false, true));
 		}
 	}
 

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -642,7 +642,7 @@ namespace mwse::lua {
 		TES3::Reference* reference = getOptionalParamExecutionReference(params);
 		TES3::Item* item = getOptionalParamObject<TES3::Item>(params, "item");
 		auto state = getOptionalParam<bool>(params, "pickup", true) ? TES3::ItemSoundState::Up : TES3::ItemSoundState::Down;
-		if (item == NULL) {
+		if (!item) {
 			return;
 		}
 
@@ -1148,7 +1148,7 @@ namespace mwse::lua {
 
 	TES3::EquipmentStack* getEquippedItem(sol::table params) {
 		// Find our equipment based on the object given.
-		NI::IteratedList<TES3::EquipmentStack*>* equipment = NULL;
+		NI::IteratedList<TES3::EquipmentStack*>* equipment = nullptr;
 		sol::object actor = params["actor"];
 		if (actor.valid()) {
 			if (actor.is<TES3::Reference*>()) {

--- a/MWSE/VirtualMachine.cpp
+++ b/MWSE/VirtualMachine.cpp
@@ -22,7 +22,7 @@ using namespace mwse;
 
 VirtualMachine::VirtualMachine()
 	: context(),
-	oldscript(NULL)
+	oldscript(nullptr)
 {
 	// Holds the current location in the script. when you read parameters from the script stream, you need to add the number of bytes read to this.
 	mwScriptIP = reinterpret_cast<long*>(TES3_IP_IMAGE);
@@ -36,7 +36,7 @@ void VirtualMachine::loadParametersForOperation(OpCode::OpCode_t opcode, HookCon
 	setScript(script);
 
 	// Call OnScriptChange if we're running a different script.
-	if (oldscript != NULL && oldscript != script) {
+	if (oldscript && oldscript != script) {
 		OnScriptChange();
 	}
 	oldscript = script;
@@ -109,7 +109,7 @@ TES3::Reference* VirtualMachine::getReference(const char* id)
 
 void VirtualMachine::setReference(TES3::Reference* reference)
 {
-	if (reference == NULL || reference->baseObject == NULL) {
+	if (!reference || !reference->baseObject) {
 #if _DEBUG
 		mwse::log::getLog() << __FUNCTION__ << ": Attempted to set to invalid reference." << std::endl;
 #endif
@@ -195,7 +195,7 @@ void VirtualMachine::setLongVariable(const char* id, long value)
 void VirtualMachine::setLongVariable(int index, long value, TES3::Reference& reference)
 {
 	auto attachment = reference.getAttachedItemData();
-	if (attachment == NULL) {
+	if (!attachment) {
 		return;
 	}
 
@@ -262,7 +262,7 @@ void VirtualMachine::setShortVariable(const char* id, short value)
 void VirtualMachine::setShortVariable(int index, short value, TES3::Reference& reference)
 {
 	auto attachment = reference.getAttachedItemData();
-	if (attachment == NULL) {
+	if (!attachment) {
 		return;
 	}
 
@@ -329,7 +329,7 @@ void VirtualMachine::setFloatVariable(const char* id, float value)
 void VirtualMachine::setFloatVariable(int index, float value, TES3::Reference& reference)
 {
 	auto attachment = reference.getAttachedItemData();
-	if (attachment == NULL) {
+	if (!attachment) {
 		return;
 	}
 
@@ -344,7 +344,7 @@ void VirtualMachine::setFloatVariable(int index, float value, TES3::Reference& r
 long VirtualMachine::getLongGlobal(const char* id)
 {
 	TES3::GlobalVariable* globalVar = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(id);
-	if (globalVar == NULL) {
+	if (!globalVar) {
 #if _DEBUG
 		mwse::log::getLog() << "Could not find global variable '" << id << "'." << std::endl;
 #endif
@@ -362,7 +362,7 @@ long VirtualMachine::getLongGlobal(const char* id)
 void VirtualMachine::setLongGlobal(const char* id, long value)
 {
 	TES3::GlobalVariable* globalVar = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(id);
-	if (globalVar == NULL) {
+	if (!globalVar) {
 #if _DEBUG
 		mwse::log::getLog() << "Could not find global variable '" << id << "'." << std::endl;
 #endif
@@ -381,7 +381,7 @@ void VirtualMachine::setLongGlobal(const char* id, long value)
 short VirtualMachine::getShortGlobal(const char* id)
 {
 	TES3::GlobalVariable* globalVar = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(id);
-	if (globalVar == NULL) {
+	if (!globalVar) {
 #if _DEBUG
 		mwse::log::getLog() << "Could not find global variable '" << id << "'." << std::endl;
 #endif
@@ -399,7 +399,7 @@ short VirtualMachine::getShortGlobal(const char* id)
 void VirtualMachine::setShortGlobal(const char* id, short value)
 {
 	TES3::GlobalVariable* globalVar = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(id);
-	if (globalVar == NULL) {
+	if (!globalVar) {
 #if _DEBUG
 		mwse::log::getLog() << "Could not find global variable '" << id << "'." << std::endl;
 #endif
@@ -418,7 +418,7 @@ void VirtualMachine::setShortGlobal(const char* id, short value)
 float VirtualMachine::getFloatGlobal(const char* id)
 {
 	TES3::GlobalVariable* globalVar = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(id);
-	if (globalVar == NULL) {
+	if (!globalVar) {
 #if _DEBUG
 		mwse::log::getLog() << "Could not find global variable '" << id << "'." << std::endl;
 #endif
@@ -436,7 +436,7 @@ float VirtualMachine::getFloatGlobal(const char* id)
 void VirtualMachine::setFloatGlobal(const char* id, float value)
 {
 	TES3::GlobalVariable* globalVar = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(id);
-	if (globalVar == NULL) {
+	if (!globalVar) {
 #if _DEBUG
 		mwse::log::getLog() << "Could not find global variable '" << id << "'." << std::endl;
 #endif

--- a/MWSE/main.cpp
+++ b/MWSE/main.cpp
@@ -15,7 +15,7 @@
 #include "LuaManager.h"
 #include "TES3Game.h"
 
-TES3MACHINE* mge_virtual_machine = NULL;
+TES3MACHINE* mge_virtual_machine = nullptr;
 
 const auto TES3_Game_ctor = reinterpret_cast<TES3::Game * (__thiscall*)(TES3::Game*)>(0x417280);
 TES3::Game* __fastcall OnGameStructCreated(TES3::Game* game) {

--- a/MWSE/xAITravel.cpp
+++ b/MWSE/xAITravel.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAITravel: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xAITravel.cpp
+++ b/MWSE/xAITravel.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAITravel: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xAITravel.cpp
+++ b/MWSE/xAITravel.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAITravel: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xActivate.cpp
+++ b/MWSE/xActivate.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Verify that the script is called on a valid reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				log::getLog() << __FUNCTION__ << ": Called on invalid reference." << std::endl;
 			}
@@ -42,7 +42,7 @@ namespace mwse {
 		}
 
 		// Determine if the target is a reference.
-		TES3::Reference* target = NULL;
+		TES3::Reference* target = nullptr;
 		try {
 			TES3::Reference* potential = reinterpret_cast<TES3::Reference*>(parameter);
 			if (potential && potential->objectType == TES3::ObjectType::Reference) {
@@ -57,7 +57,7 @@ namespace mwse {
 		}
 
 		// Verify that the target reference was found.
-		if (target == NULL) {
+		if (target == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				log::getLog() << __FUNCTION__ << ": Target reference is invalid." << std::endl;
 			}
@@ -66,11 +66,11 @@ namespace mwse {
 
 		// Set up the attachment node.
 		auto activator = static_cast<TES3::ActionAttachment*>(target->getAttachment(TES3::AttachmentType::Action));
-		if (activator == NULL) {
+		if (activator == nullptr) {
 			activator = se::memory::malloc<TES3::ActionAttachment>();
 			activator->type = TES3::AttachmentType::Action;
-			activator->next = NULL;
-			activator->reference = NULL;
+			activator->next = nullptr;
+			activator->reference = nullptr;
 			activator->flags = 1;
 
 			target->insertAttachment(activator);

--- a/MWSE/xActivate.cpp
+++ b/MWSE/xActivate.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Verify that the script is called on a valid reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				log::getLog() << __FUNCTION__ << ": Called on invalid reference." << std::endl;
 			}
@@ -42,7 +42,7 @@ namespace mwse {
 		}
 
 		// Determine if the target is a reference.
-		TES3::Reference* target = NULL;
+		TES3::Reference* target = nullptr;
 		try {
 			TES3::Reference* potential = reinterpret_cast<TES3::Reference*>(parameter);
 			if (potential && potential->objectType == TES3::ObjectType::Reference) {
@@ -57,7 +57,7 @@ namespace mwse {
 		}
 
 		// Verify that the target reference was found.
-		if (target == NULL) {
+		if (!target) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				log::getLog() << __FUNCTION__ << ": Target reference is invalid." << std::endl;
 			}
@@ -66,11 +66,11 @@ namespace mwse {
 
 		// Set up the attachment node.
 		auto activator = static_cast<TES3::ActionAttachment*>(target->getAttachment(TES3::AttachmentType::Action));
-		if (activator == NULL) {
+		if (!activator) {
 			activator = se::memory::malloc<TES3::ActionAttachment>();
 			activator->type = TES3::AttachmentType::Action;
-			activator->next = NULL;
-			activator->reference = NULL;
+			activator->next = nullptr;
+			activator->reference = nullptr;
 			activator->flags = 1;
 
 			target->insertAttachment(activator);

--- a/MWSE/xActivate.cpp
+++ b/MWSE/xActivate.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Verify that the script is called on a valid reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				log::getLog() << __FUNCTION__ << ": Called on invalid reference." << std::endl;
 			}
@@ -42,7 +42,7 @@ namespace mwse {
 		}
 
 		// Determine if the target is a reference.
-		TES3::Reference* target = nullptr;
+		TES3::Reference* target = NULL;
 		try {
 			TES3::Reference* potential = reinterpret_cast<TES3::Reference*>(parameter);
 			if (potential && potential->objectType == TES3::ObjectType::Reference) {
@@ -57,7 +57,7 @@ namespace mwse {
 		}
 
 		// Verify that the target reference was found.
-		if (!target) {
+		if (target == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				log::getLog() << __FUNCTION__ << ": Target reference is invalid." << std::endl;
 			}
@@ -66,11 +66,11 @@ namespace mwse {
 
 		// Set up the attachment node.
 		auto activator = static_cast<TES3::ActionAttachment*>(target->getAttachment(TES3::AttachmentType::Action));
-		if (!activator) {
+		if (activator == NULL) {
 			activator = se::memory::malloc<TES3::ActionAttachment>();
 			activator->type = TES3::AttachmentType::Action;
-			activator->next = nullptr;
-			activator->reference = nullptr;
+			activator->next = NULL;
+			activator->reference = NULL;
 			activator->flags = 1;
 
 			target->insertAttachment(activator);

--- a/MWSE/xAddEffect.cpp
+++ b/MWSE/xAddEffect.cpp
@@ -33,7 +33,7 @@ namespace mwse {
 		size_t effectCount = 0;
 
 		// Get the desired effect.
-		TES3::Effect* effects = nullptr;
+		TES3::Effect* effects = NULL;
 		if (type == TES3::ObjectType::Spell) {
 			const auto spell = TES3::DataHandler::get()->nonDynamicData->getSpellById(id.c_str());
 			if (spell) {

--- a/MWSE/xAddEffect.cpp
+++ b/MWSE/xAddEffect.cpp
@@ -33,7 +33,7 @@ namespace mwse {
 		size_t effectCount = 0;
 
 		// Get the desired effect.
-		TES3::Effect* effects = NULL;
+		TES3::Effect* effects = nullptr;
 		if (type == TES3::ObjectType::Spell) {
 			const auto spell = TES3::DataHandler::get()->nonDynamicData->getSpellById(id.c_str());
 			if (spell) {

--- a/MWSE/xAddItem.cpp
+++ b/MWSE/xAddItem.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (!itemTemplate) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xAddItem.cpp
+++ b/MWSE/xAddItem.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (!itemTemplate) {
+		if (itemTemplate == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xAddItem.cpp
+++ b/MWSE/xAddItem.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (itemTemplate == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xAddSpell.cpp
+++ b/MWSE/xAddSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddSpell: Called on invalid reference." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (spellTemplate == NULL) {
+		if (spellTemplate == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xAddSpell.cpp
+++ b/MWSE/xAddSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddSpell: Called on invalid reference." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (spellTemplate == NULL) {
+		if (!spellTemplate) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xAddSpell.cpp
+++ b/MWSE/xAddSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddSpell: Called on invalid reference." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (!spellTemplate) {
+		if (spellTemplate == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xCast.cpp
+++ b/MWSE/xCast.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAITravel: Called on invalid reference." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::Spell* spell = TES3::DataHandler::get()->nonDynamicData->getSpellById(spellId.c_str());
-		if (!spell) {
+		if (spell == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xCast: No template found with id '" << spellId << "'." << std::endl;
 			}
@@ -44,7 +44,7 @@ namespace mwse {
 
 		// Get the target by id.
 		TES3::Reference* target = virtualMachine.getReference(targetId.c_str());
-		if (!target) {
+		if (target == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xCast: Could not find valid target by id '" << targetId << "'." << std::endl;
 			}

--- a/MWSE/xCast.cpp
+++ b/MWSE/xCast.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAITravel: Called on invalid reference." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::Spell* spell = TES3::DataHandler::get()->nonDynamicData->getSpellById(spellId.c_str());
-		if (spell == NULL) {
+		if (spell == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xCast: No template found with id '" << spellId << "'." << std::endl;
 			}
@@ -44,7 +44,7 @@ namespace mwse {
 
 		// Get the target by id.
 		TES3::Reference* target = virtualMachine.getReference(targetId.c_str());
-		if (target == NULL) {
+		if (target == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xCast: Could not find valid target by id '" << targetId << "'." << std::endl;
 			}

--- a/MWSE/xCast.cpp
+++ b/MWSE/xCast.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAITravel: Called on invalid reference." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::Spell* spell = TES3::DataHandler::get()->nonDynamicData->getSpellById(spellId.c_str());
-		if (spell == NULL) {
+		if (!spell) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xCast: No template found with id '" << spellId << "'." << std::endl;
 			}
@@ -44,7 +44,7 @@ namespace mwse {
 
 		// Get the target by id.
 		TES3::Reference* target = virtualMachine.getReference(targetId.c_str());
-		if (target == NULL) {
+		if (!target) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xCast: Could not find valid target by id '" << targetId << "'." << std::endl;
 			}

--- a/MWSE/xContentList.cpp
+++ b/MWSE/xContentList.cpp
@@ -57,12 +57,12 @@ namespace mwse {
 		if (node && node->data && node->data->object) {
 			TES3::Object* object = node->data->object;
 
-			id = object->vTable.object->getObjectID(object);
+			id = object->getObjectID();
 			count = node->data->count;
 			type = object->objectType;
-			value = object->vTable.object->getValue(object);
-			weight = object->vTable.object->getWeight(object);
-			name = object->vTable.object->getName(object);
+			value = object->getValue();
+			weight = object->getWeight();
+			name = object->getName();
 
 			next = node->next;
 		}

--- a/MWSE/xContentList.cpp
+++ b/MWSE/xContentList.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xContentList: Called on invalid reference." << std::endl;
 			}
@@ -40,16 +40,16 @@ namespace mwse {
 		}
 
 		// Results.
-		const char* id = NULL;
+		const char* id = nullptr;
 		long count = 0;
 		long type = 0;
 		long value = 0;
 		float weight = 0;
-		const char* name = NULL;
-		NI::IteratedList<TES3::ItemStack*>::Node* next = NULL;
+		const char* name = nullptr;
+		NI::IteratedList<TES3::ItemStack*>::Node* next = nullptr;
 
 		// If we aren't given a node, get the first one.
-		if (node == NULL && reference->baseObject->isActor()) {
+		if (!node && reference->baseObject->isActor()) {
 			node = static_cast<TES3::Actor*>(reference->baseObject)->inventory.itemStacks.head;
 		}
 

--- a/MWSE/xContentList.cpp
+++ b/MWSE/xContentList.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xContentList: Called on invalid reference." << std::endl;
 			}
@@ -40,16 +40,16 @@ namespace mwse {
 		}
 
 		// Results.
-		const char* id = NULL;
+		const char* id = nullptr;
 		long count = 0;
 		long type = 0;
 		long value = 0;
 		float weight = 0;
-		const char* name = NULL;
-		NI::IteratedList<TES3::ItemStack*>::Node* next = NULL;
+		const char* name = nullptr;
+		NI::IteratedList<TES3::ItemStack*>::Node* next = nullptr;
 
 		// If we aren't given a node, get the first one.
-		if (node == NULL && reference->baseObject->isActor()) {
+		if (node == nullptr && reference->baseObject->isActor()) {
 			node = static_cast<TES3::Actor*>(reference->baseObject)->inventory.itemStacks.head;
 		}
 

--- a/MWSE/xContentList.cpp
+++ b/MWSE/xContentList.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xContentList: Called on invalid reference." << std::endl;
 			}
@@ -40,16 +40,16 @@ namespace mwse {
 		}
 
 		// Results.
-		const char* id = nullptr;
+		const char* id = NULL;
 		long count = 0;
 		long type = 0;
 		long value = 0;
 		float weight = 0;
-		const char* name = nullptr;
-		NI::IteratedList<TES3::ItemStack*>::Node* next = nullptr;
+		const char* name = NULL;
+		NI::IteratedList<TES3::ItemStack*>::Node* next = NULL;
 
 		// If we aren't given a node, get the first one.
-		if (!node && reference->baseObject->isActor()) {
+		if (node == NULL && reference->baseObject->isActor()) {
 			node = static_cast<TES3::Actor*>(reference->baseObject)->inventory.itemStacks.head;
 		}
 

--- a/MWSE/xContentListFiltered.cpp
+++ b/MWSE/xContentListFiltered.cpp
@@ -71,7 +71,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xContentListFiltered: Called on invalid reference." << std::endl;
 			}
@@ -94,16 +94,16 @@ namespace mwse {
 		}
 
 		// Results.
-		const char* id = nullptr;
+		const char* id = NULL;
 		long count = 0;
 		long type = 0;
 		long value = 0;
 		float weight = 0;
-		const char* name = nullptr;
-		NI::IteratedList<TES3::ItemStack*>::Node* next = nullptr;
+		const char* name = NULL;
+		NI::IteratedList<TES3::ItemStack*>::Node* next = NULL;
 
 		// If we aren't given a node, get the first one.
-		if (!node) {
+		if (node == NULL) {
 			node = static_cast<TES3::Actor*>(reference->baseObject)->inventory.itemStacks.head;
 
 			// Pass over any records that don't match the current filter.

--- a/MWSE/xContentListFiltered.cpp
+++ b/MWSE/xContentListFiltered.cpp
@@ -71,7 +71,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xContentListFiltered: Called on invalid reference." << std::endl;
 			}
@@ -94,16 +94,16 @@ namespace mwse {
 		}
 
 		// Results.
-		const char* id = NULL;
+		const char* id = nullptr;
 		long count = 0;
 		long type = 0;
 		long value = 0;
 		float weight = 0;
-		const char* name = NULL;
-		NI::IteratedList<TES3::ItemStack*>::Node* next = NULL;
+		const char* name = nullptr;
+		NI::IteratedList<TES3::ItemStack*>::Node* next = nullptr;
 
 		// If we aren't given a node, get the first one.
-		if (node == NULL) {
+		if (!node) {
 			node = static_cast<TES3::Actor*>(reference->baseObject)->inventory.itemStacks.head;
 
 			// Pass over any records that don't match the current filter.

--- a/MWSE/xContentListFiltered.cpp
+++ b/MWSE/xContentListFiltered.cpp
@@ -116,12 +116,12 @@ namespace mwse {
 		if (node && node->data && node->data->object) {
 			TES3::Object* object = node->data->object;
 
-			id = object->vTable.object->getObjectID(object);
+			id = object->getObjectID();
 			count = node->data->count;
 			type = object->objectType;
-			value = object->vTable.object->getValue(object);
-			weight = object->vTable.object->getWeight(object);
-			name = object->vTable.object->getName(object);
+			value = object->getValue();
+			weight = object->getWeight();
+			name = object->getName();
 
 			// Get next node. Pass over any records that don't match the given filter.
 			next = node->next;
@@ -180,7 +180,7 @@ namespace mwse {
 		// If we're filtering by enchantment, verify that the record has one.
 		if (filter & FILTER_ENCH) {
 			try {
-				if (object->vTable.object->getEnchantment(object) == NULL) {
+				if (!object->getEnchantment()) {
 					return false;
 				}
 			}

--- a/MWSE/xContentListFiltered.cpp
+++ b/MWSE/xContentListFiltered.cpp
@@ -15,7 +15,7 @@ namespace mwse {
 		virtual float execute(VMExecuteInterface& virtualMachine);
 
 	private:
-		long getBitMaskForRecordType(long recordType);
+		long getBitMaskForRecordType(TES3::ObjectType::ObjectType recordType);
 		bool passesFilter(TES3::Object* record, long filter);
 
 		enum FilterMask {
@@ -142,7 +142,7 @@ namespace mwse {
 		return 0.0f;
 	}
 
-	long xContentListFiltered::getBitMaskForRecordType(long recordType) {
+	long xContentListFiltered::getBitMaskForRecordType(TES3::ObjectType::ObjectType recordType) {
 		switch (recordType) {
 		case TES3::ObjectType::Activator: return FILTER_ACTI;
 		case TES3::ObjectType::Alchemy: return FILTER_ALCH;

--- a/MWSE/xContentListFiltered.cpp
+++ b/MWSE/xContentListFiltered.cpp
@@ -71,7 +71,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xContentListFiltered: Called on invalid reference." << std::endl;
 			}
@@ -94,16 +94,16 @@ namespace mwse {
 		}
 
 		// Results.
-		const char* id = NULL;
+		const char* id = nullptr;
 		long count = 0;
 		long type = 0;
 		long value = 0;
 		float weight = 0;
-		const char* name = NULL;
-		NI::IteratedList<TES3::ItemStack*>::Node* next = NULL;
+		const char* name = nullptr;
+		NI::IteratedList<TES3::ItemStack*>::Node* next = nullptr;
 
 		// If we aren't given a node, get the first one.
-		if (node == NULL) {
+		if (node == nullptr) {
 			node = static_cast<TES3::Actor*>(reference->baseObject)->inventory.itemStacks.head;
 
 			// Pass over any records that don't match the current filter.

--- a/MWSE/xCreateSpell.cpp
+++ b/MWSE/xCreateSpell.cpp
@@ -46,7 +46,7 @@ namespace mwse {
 		}
 
 		// Verify that a spell of this id doesn't already exist.
-		if (TES3::DataHandler::get()->nonDynamicData->getSpellById(spellId.c_str())) {
+		if (TES3::DataHandler::get()->nonDynamicData->getSpellById(spellId.c_str()) != NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xCreateSpell: A spell of the given id '" << spellId << "' already exists." << std::endl;
 			}

--- a/MWSE/xCreateSpell.cpp
+++ b/MWSE/xCreateSpell.cpp
@@ -46,7 +46,7 @@ namespace mwse {
 		}
 
 		// Verify that a spell of this id doesn't already exist.
-		if (TES3::DataHandler::get()->nonDynamicData->getSpellById(spellId.c_str()) != NULL) {
+		if (TES3::DataHandler::get()->nonDynamicData->getSpellById(spellId.c_str())) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xCreateSpell: A spell of the given id '" << spellId << "' already exists." << std::endl;
 			}

--- a/MWSE/xCreateSpell.cpp
+++ b/MWSE/xCreateSpell.cpp
@@ -46,7 +46,7 @@ namespace mwse {
 		}
 
 		// Verify that a spell of this id doesn't already exist.
-		if (TES3::DataHandler::get()->nonDynamicData->getSpellById(spellId.c_str()) != NULL) {
+		if (TES3::DataHandler::get()->nonDynamicData->getSpellById(spellId.c_str()) != nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xCreateSpell: A spell of the given id '" << spellId << "' already exists." << std::endl;
 			}

--- a/MWSE/xDeleteEffect.cpp
+++ b/MWSE/xDeleteEffect.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 		size_t effectCount = 0;
 
 		// Get the desired effect.
-		TES3::Effect* effects = nullptr;
+		TES3::Effect* effects = NULL;
 		if (type == TES3::ObjectType::Spell) {
 			const auto spell = TES3::DataHandler::get()->nonDynamicData->getSpellById(id.c_str());
 			if (spell) {

--- a/MWSE/xDeleteEffect.cpp
+++ b/MWSE/xDeleteEffect.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 		size_t effectCount = 0;
 
 		// Get the desired effect.
-		TES3::Effect* effects = NULL;
+		TES3::Effect* effects = nullptr;
 		if (type == TES3::ObjectType::Spell) {
 			const auto spell = TES3::DataHandler::get()->nonDynamicData->getSpellById(id.c_str());
 			if (spell) {

--- a/MWSE/xDeleteSpell.cpp
+++ b/MWSE/xDeleteSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get spell.
 		TES3::Spell* spell = TES3::DataHandler::get()->nonDynamicData->getSpellById(id.c_str());
-		if (spell == NULL) {
+		if (spell == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xDeleteSpell: No spell found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xDeleteSpell.cpp
+++ b/MWSE/xDeleteSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get spell.
 		TES3::Spell* spell = TES3::DataHandler::get()->nonDynamicData->getSpellById(id.c_str());
-		if (spell == NULL) {
+		if (!spell) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xDeleteSpell: No spell found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xDeleteSpell.cpp
+++ b/MWSE/xDeleteSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get spell.
 		TES3::Spell* spell = TES3::DataHandler::get()->nonDynamicData->getSpellById(id.c_str());
-		if (!spell) {
+		if (spell == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xDeleteSpell: No spell found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xDistance.cpp
+++ b/MWSE/xDistance.cpp
@@ -17,7 +17,7 @@ namespace mwse {
 	float xDistance::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get target reference
 		TES3::Reference* targetref = reinterpret_cast<TES3::Reference*>(mwse::Stack::getInstance().popLong());
-		if (targetref == NULL) {
+		if (!targetref) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModProgressSkill: Target reference is invalid." << std::endl;
 			}
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get script reference.
 		TES3::Reference* thisref = virtualMachine.getReference();
-		if (thisref == NULL) {
+		if (!thisref) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModProgressSkill: Script reference is invalid." << std::endl;
 			}

--- a/MWSE/xDistance.cpp
+++ b/MWSE/xDistance.cpp
@@ -35,11 +35,7 @@ namespace mwse {
 			return 0.0f;
 		}
 
-		float dx = targetref->position.x - thisref->position.x;
-		float dy = targetref->position.y - thisref->position.y;
-		float dz = targetref->position.z - thisref->position.z;
-		float xDistance = std::sqrt(dx * dx + dy * dy + dz * dz);
-
+		float xDistance = targetref->position.distance(&thisref->position);
 		mwse::Stack::getInstance().pushFloat(xDistance);
 
 		return 0.0f;

--- a/MWSE/xDistance.cpp
+++ b/MWSE/xDistance.cpp
@@ -17,7 +17,7 @@ namespace mwse {
 	float xDistance::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get target reference
 		TES3::Reference* targetref = reinterpret_cast<TES3::Reference*>(mwse::Stack::getInstance().popLong());
-		if (targetref == NULL) {
+		if (targetref == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModProgressSkill: Target reference is invalid." << std::endl;
 			}
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get script reference.
 		TES3::Reference* thisref = virtualMachine.getReference();
-		if (thisref == NULL) {
+		if (thisref == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModProgressSkill: Script reference is invalid." << std::endl;
 			}

--- a/MWSE/xDistance.cpp
+++ b/MWSE/xDistance.cpp
@@ -17,7 +17,7 @@ namespace mwse {
 	float xDistance::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get target reference
 		TES3::Reference* targetref = reinterpret_cast<TES3::Reference*>(mwse::Stack::getInstance().popLong());
-		if (!targetref) {
+		if (targetref == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModProgressSkill: Target reference is invalid." << std::endl;
 			}
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get script reference.
 		TES3::Reference* thisref = virtualMachine.getReference();
-		if (!thisref) {
+		if (thisref == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModProgressSkill: Script reference is invalid." << std::endl;
 			}

--- a/MWSE/xDrop.cpp
+++ b/MWSE/xDrop.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (!itemTemplate) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xDrop.cpp
+++ b/MWSE/xDrop.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (!itemTemplate) {
+		if (itemTemplate == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xDrop.cpp
+++ b/MWSE/xDrop.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (itemTemplate == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddItem: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xEquip.cpp
+++ b/MWSE/xEquip.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xEquip: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (!itemTemplate) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xEquip.cpp
+++ b/MWSE/xEquip.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xEquip: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (itemTemplate == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xEquip.cpp
+++ b/MWSE/xEquip.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xEquip: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (!itemTemplate) {
+		if (itemTemplate == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xAddSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xEquipmentList.cpp
+++ b/MWSE/xEquipmentList.cpp
@@ -18,6 +18,9 @@ namespace mwse {
 		virtual float execute(VMExecuteInterface& virtualMachine);
 
 	private:
+		const long NO_ITEM_SUBTYPE = -1l;
+		const long NO_ITEM_SUBTYPE_OFFSET = NO_ITEM_SUBTYPE - 1l;
+
 		bool nodeMatchesFilter(NI::IteratedList<TES3::EquipmentStack*>::Node* node, long typeFilter, long subtypeFilter);
 		long getItemSubType(TES3::Object* object);
 	};
@@ -83,7 +86,7 @@ namespace mwse {
 		const char* id = nullptr;
 		long count = 0;
 		long type = 0;
-		long subtype = -1;
+		long subtype = NO_ITEM_SUBTYPE;
 		long value = 0;
 		float weight = 0;
 		const char* name = nullptr;
@@ -163,12 +166,14 @@ namespace mwse {
 		return true;
 	}
 
+
+
 	long xEquipmentList::getItemSubType(TES3::Object* object) {
 		if (object == nullptr) {
-			return -2;
+			return NO_ITEM_SUBTYPE_OFFSET;
 		}
 
-		long subtype = -2;
+		long subtype = NO_ITEM_SUBTYPE_OFFSET;
 
 		auto type = object->objectType;
 		if (type == TES3::ObjectType::Armor || type == TES3::ObjectType::Apparatus ||

--- a/MWSE/xEquipmentList.cpp
+++ b/MWSE/xEquipmentList.cpp
@@ -11,6 +11,11 @@
 #include "TES3Reference.h"
 #include "TES3Weapon.h"
 
+enum class ItemSubtype : long {
+	NoItemSubtype = -1,
+	NoItemSubtypeZeroIndexed = -2,
+};
+
 namespace mwse {
 	class xEquipmentList : InstructionInterface_t {
 	public:
@@ -18,11 +23,8 @@ namespace mwse {
 		virtual float execute(VMExecuteInterface& virtualMachine);
 
 	private:
-		const long NO_ITEM_SUBTYPE = -1l;
-		const long NO_ITEM_SUBTYPE_OFFSET = NO_ITEM_SUBTYPE - 1l;
-
 		bool nodeMatchesFilter(NI::IteratedList<TES3::EquipmentStack*>::Node* node, long typeFilter, long subtypeFilter);
-		long getItemSubType(TES3::Object* object);
+		long getItemSubType(const TES3::Object* object);
 	};
 
 	static xEquipmentList xEquipmentListInstance;
@@ -86,7 +88,7 @@ namespace mwse {
 		const char* id = nullptr;
 		long count = 0;
 		long type = 0;
-		long subtype = NO_ITEM_SUBTYPE;
+		long subtype = (long)ItemSubtype::NoItemSubtype;
 		long value = 0;
 		float weight = 0;
 		const char* name = nullptr;
@@ -168,12 +170,12 @@ namespace mwse {
 
 
 
-	long xEquipmentList::getItemSubType(TES3::Object* object) {
+	long xEquipmentList::getItemSubType(const TES3::Object* object) {
 		if (object == nullptr) {
-			return NO_ITEM_SUBTYPE_OFFSET;
+			return (long)ItemSubtype::NoItemSubtypeZeroIndexed;
 		}
 
-		long subtype = NO_ITEM_SUBTYPE_OFFSET;
+		long subtype = (long)ItemSubtype::NoItemSubtypeZeroIndexed;
 
 		auto type = object->objectType;
 		if (type == TES3::ObjectType::Armor || type == TES3::ObjectType::Apparatus ||

--- a/MWSE/xEquipmentList.cpp
+++ b/MWSE/xEquipmentList.cpp
@@ -106,9 +106,9 @@ namespace mwse {
 
 			id = reinterpret_cast<TES3::PhysicalObject*>(object)->objectID;
 			type = object->objectType;
-			value = object->vTable.object->getValue(object);
-			weight = object->vTable.object->getWeight(object);
-			name = object->vTable.object->getName(object);
+			value = object->getValue();
+			weight = object->getWeight();
+			name = object->getName();
 
 			// Get subtype. We can't directly use the vtable here to get the type,
 			// because types are zero-indexed.
@@ -123,7 +123,7 @@ namespace mwse {
 			}
 
 			// Get enchantment id.
-			TES3::Enchantment* enchantment = object->vTable.object->getEnchantment(object);
+			TES3::Enchantment* enchantment = object->getEnchantment();
 			if (enchantment) {
 				enchantId = enchantment->objectID;
 			}
@@ -170,11 +170,11 @@ namespace mwse {
 
 		long subtype = -2;
 
-		long type = object->objectType;
+		auto type = object->objectType;
 		if (type == TES3::ObjectType::Armor || type == TES3::ObjectType::Apparatus ||
 			type == TES3::ObjectType::Clothing || type == TES3::ObjectType::Weapon)
 		{
-			subtype = object->vTable.object->getType(object);
+			subtype = object->getType();
 		}
 
 		return subtype;

--- a/MWSE/xEquipmentList.cpp
+++ b/MWSE/xEquipmentList.cpp
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			mwse::log::getLog() << "xEquipmentList: Called without refrence." << std::endl;
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);
@@ -80,18 +80,18 @@ namespace mwse {
 		}
 
 		// Results.
-		const char* id = NULL;
+		const char* id = nullptr;
 		long count = 0;
 		long type = 0;
 		long subtype = -1;
 		long value = 0;
 		float weight = 0;
-		const char* name = NULL;
-		const char* enchantId = NULL;
-		NI::IteratedList<TES3::EquipmentStack*>::Node* next = NULL;
+		const char* name = nullptr;
+		const char* enchantId = nullptr;
+		NI::IteratedList<TES3::EquipmentStack*>::Node* next = nullptr;
 
 		// If we aren't given a node, get the first one.
-		if (node == NULL) {
+		if (!node) {
 			node = actor->equipment.head;
 
 			// Pass over any records that don't match the current filters.
@@ -164,7 +164,7 @@ namespace mwse {
 	}
 
 	long xEquipmentList::getItemSubType(TES3::Object* object) {
-		if (object == NULL) {
+		if (!object) {
 			return -2;
 		}
 

--- a/MWSE/xEquipmentList.cpp
+++ b/MWSE/xEquipmentList.cpp
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			mwse::log::getLog() << "xEquipmentList: Called without refrence." << std::endl;
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);
@@ -80,18 +80,18 @@ namespace mwse {
 		}
 
 		// Results.
-		const char* id = nullptr;
+		const char* id = NULL;
 		long count = 0;
 		long type = 0;
 		long subtype = -1;
 		long value = 0;
 		float weight = 0;
-		const char* name = nullptr;
-		const char* enchantId = nullptr;
-		NI::IteratedList<TES3::EquipmentStack*>::Node* next = nullptr;
+		const char* name = NULL;
+		const char* enchantId = NULL;
+		NI::IteratedList<TES3::EquipmentStack*>::Node* next = NULL;
 
 		// If we aren't given a node, get the first one.
-		if (!node) {
+		if (node == NULL) {
 			node = actor->equipment.head;
 
 			// Pass over any records that don't match the current filters.
@@ -164,7 +164,7 @@ namespace mwse {
 	}
 
 	long xEquipmentList::getItemSubType(TES3::Object* object) {
-		if (!object) {
+		if (object == NULL) {
 			return -2;
 		}
 

--- a/MWSE/xEquipmentList.cpp
+++ b/MWSE/xEquipmentList.cpp
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			mwse::log::getLog() << "xEquipmentList: Called without refrence." << std::endl;
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);
@@ -80,18 +80,18 @@ namespace mwse {
 		}
 
 		// Results.
-		const char* id = NULL;
+		const char* id = nullptr;
 		long count = 0;
 		long type = 0;
 		long subtype = -1;
 		long value = 0;
 		float weight = 0;
-		const char* name = NULL;
-		const char* enchantId = NULL;
-		NI::IteratedList<TES3::EquipmentStack*>::Node* next = NULL;
+		const char* name = nullptr;
+		const char* enchantId = nullptr;
+		NI::IteratedList<TES3::EquipmentStack*>::Node* next = nullptr;
 
 		// If we aren't given a node, get the first one.
-		if (node == NULL) {
+		if (node == nullptr) {
 			node = actor->equipment.head;
 
 			// Pass over any records that don't match the current filters.
@@ -164,7 +164,7 @@ namespace mwse {
 	}
 
 	long xEquipmentList::getItemSubType(TES3::Object* object) {
-		if (object == NULL) {
+		if (object == nullptr) {
 			return -2;
 		}
 

--- a/MWSE/xExplodeSpell.cpp
+++ b/MWSE/xExplodeSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xExplodeSpell: Called on invalid reference." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (spellTemplate == NULL) {
+		if (spellTemplate == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xExplodeSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xExplodeSpell.cpp
+++ b/MWSE/xExplodeSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xExplodeSpell: Called on invalid reference." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (!spellTemplate) {
+		if (spellTemplate == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xExplodeSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xExplodeSpell.cpp
+++ b/MWSE/xExplodeSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xExplodeSpell: Called on invalid reference." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (spellTemplate == NULL) {
+		if (!spellTemplate) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xExplodeSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xFileReadText.cpp
+++ b/MWSE/xFileReadText.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		maxResults++;
 
 		// Store results so we can push them on in reverse.
-		long* results = new long[maxResults];
+		std::vector<long> results(maxResults);
 
 		// Read the string from the file. If we can't read a string back, push 0s.
 		std::string readString = mwse::FileSystem::getInstance().readString(fileName, stopAtEndOfLine);
@@ -43,7 +43,7 @@ namespace mwse {
 		}
 
 		// If we did get a string back, secernate and return.
-		se::string::secernate(format.c_str(), readString.c_str(), results, maxResults);
+		se::string::secernate(format.c_str(), readString.c_str(), results.data(), maxResults);
 		while (maxResults--) {
 			mwse::Stack::getInstance().pushLong(results[maxResults]);
 		}

--- a/MWSE/xFirstItem.cpp
+++ b/MWSE/xFirstItem.cpp
@@ -48,7 +48,7 @@ namespace mwse {
 					}
 				}
 
-				// Make sure that we end our list with a NULL, so we know we're done.
+				// Make sure that we end our list with a nullptr, so we know we're done.
 				mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
 
 				// Make sure the reference in the center cell is valid.

--- a/MWSE/xFirstItem.cpp
+++ b/MWSE/xFirstItem.cpp
@@ -48,7 +48,7 @@ namespace mwse {
 					}
 				}
 
-				// Make sure that we end our list with a nullptr, so we know we're done.
+				// Make sure that we end our list with a NULL, so we know we're done.
 				mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
 
 				// Make sure the reference in the center cell is valid.

--- a/MWSE/xFirstNPC.cpp
+++ b/MWSE/xFirstNPC.cpp
@@ -21,9 +21,9 @@ namespace mwse {
 		// Clear elements in our stored exterior ref list.
 		mwse::tes3::clearExteriorRefs();
 
-		TES3::Reference* reference = NULL;
+		TES3::Reference* reference = nullptr;
 		auto dataHandler = TES3::DataHandler::get();
-		if (dataHandler->currentInteriorCell != NULL) {
+		if (dataHandler->currentInteriorCell != nullptr) {
 			reference = static_cast<TES3::Reference*>(dataHandler->currentInteriorCell->actors.head->skipDeletedObjects());
 		}
 		else {
@@ -40,22 +40,22 @@ namespace mwse {
 					cellPointer = dataHandler->exteriorCellData[i];
 					if (cellPointer->isFullyLoaded()) {
 						TES3::Reference* tempReference = static_cast<TES3::Reference*>(cellPointer->cell->actors.head->skipDeletedObjects());
-						if (tempReference != NULL) {
+						if (tempReference != nullptr) {
 							mwse::tes3::exteriorRefs[exteriorCount] = tempReference;
 							exteriorCount++;
 						}
 					}
 				}
 
-				// Make sure that we end our list with a NULL, so we know we're done.
-				mwse::tes3::exteriorRefs[exteriorCount] = NULL;
+				// Make sure that we end our list with a nullptr, so we know we're done.
+				mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
 
 				// Make sure the reference in the center cell is valid.
 				// If not, use the reference from another exterior cell.
-				if (reference == NULL && exteriorCount > 0) {
+				if (reference == nullptr && exteriorCount > 0) {
 					exteriorCount--;
 					reference = mwse::tes3::exteriorRefs[exteriorCount];
-					mwse::tes3::exteriorRefs[exteriorCount] = NULL;
+					mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
 				}
 			}
 		}

--- a/MWSE/xFirstNPC.cpp
+++ b/MWSE/xFirstNPC.cpp
@@ -21,9 +21,9 @@ namespace mwse {
 		// Clear elements in our stored exterior ref list.
 		mwse::tes3::clearExteriorRefs();
 
-		TES3::Reference* reference = nullptr;
+		TES3::Reference* reference = NULL;
 		auto dataHandler = TES3::DataHandler::get();
-		if (dataHandler->currentInteriorCell) {
+		if (dataHandler->currentInteriorCell != NULL) {
 			reference = static_cast<TES3::Reference*>(dataHandler->currentInteriorCell->actors.head->skipDeletedObjects());
 		}
 		else {
@@ -40,22 +40,22 @@ namespace mwse {
 					cellPointer = dataHandler->exteriorCellData[i];
 					if (cellPointer->isFullyLoaded()) {
 						TES3::Reference* tempReference = static_cast<TES3::Reference*>(cellPointer->cell->actors.head->skipDeletedObjects());
-						if (tempReference) {
+						if (tempReference != NULL) {
 							mwse::tes3::exteriorRefs[exteriorCount] = tempReference;
 							exteriorCount++;
 						}
 					}
 				}
 
-				// Make sure that we end our list with a nullptr, so we know we're done.
-				mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
+				// Make sure that we end our list with a NULL, so we know we're done.
+				mwse::tes3::exteriorRefs[exteriorCount] = NULL;
 
 				// Make sure the reference in the center cell is valid.
 				// If not, use the reference from another exterior cell.
-				if (!reference && exteriorCount > 0) {
+				if (reference == NULL && exteriorCount > 0) {
 					exteriorCount--;
 					reference = mwse::tes3::exteriorRefs[exteriorCount];
-					mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
+					mwse::tes3::exteriorRefs[exteriorCount] = NULL;
 				}
 			}
 		}

--- a/MWSE/xFirstNPC.cpp
+++ b/MWSE/xFirstNPC.cpp
@@ -21,9 +21,9 @@ namespace mwse {
 		// Clear elements in our stored exterior ref list.
 		mwse::tes3::clearExteriorRefs();
 
-		TES3::Reference* reference = NULL;
+		TES3::Reference* reference = nullptr;
 		auto dataHandler = TES3::DataHandler::get();
-		if (dataHandler->currentInteriorCell != NULL) {
+		if (dataHandler->currentInteriorCell) {
 			reference = static_cast<TES3::Reference*>(dataHandler->currentInteriorCell->actors.head->skipDeletedObjects());
 		}
 		else {
@@ -40,22 +40,22 @@ namespace mwse {
 					cellPointer = dataHandler->exteriorCellData[i];
 					if (cellPointer->isFullyLoaded()) {
 						TES3::Reference* tempReference = static_cast<TES3::Reference*>(cellPointer->cell->actors.head->skipDeletedObjects());
-						if (tempReference != NULL) {
+						if (tempReference) {
 							mwse::tes3::exteriorRefs[exteriorCount] = tempReference;
 							exteriorCount++;
 						}
 					}
 				}
 
-				// Make sure that we end our list with a NULL, so we know we're done.
-				mwse::tes3::exteriorRefs[exteriorCount] = NULL;
+				// Make sure that we end our list with a nullptr, so we know we're done.
+				mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
 
 				// Make sure the reference in the center cell is valid.
 				// If not, use the reference from another exterior cell.
-				if (reference == NULL && exteriorCount > 0) {
+				if (!reference && exteriorCount > 0) {
 					exteriorCount--;
 					reference = mwse::tes3::exteriorRefs[exteriorCount];
-					mwse::tes3::exteriorRefs[exteriorCount] = NULL;
+					mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
 				}
 			}
 		}

--- a/MWSE/xFirstStatic.cpp
+++ b/MWSE/xFirstStatic.cpp
@@ -21,9 +21,9 @@ namespace mwse {
 		// Clear elements in our stored exterior ref list.
 		mwse::tes3::clearExteriorRefs();
 
-		TES3::Reference* reference = NULL;
+		TES3::Reference* reference = nullptr;
 		auto dataHandler = TES3::DataHandler::get();
-		if (dataHandler->currentInteriorCell != NULL) {
+		if (dataHandler->currentInteriorCell) {
 			reference = static_cast<TES3::Reference*>(dataHandler->currentInteriorCell->persistentRefs.head->skipDeletedObjects());
 		}
 		else {
@@ -40,22 +40,22 @@ namespace mwse {
 					cellPointer = dataHandler->exteriorCellData[i];
 					if (cellPointer->isFullyLoaded()) {
 						TES3::Reference* tempReference = static_cast<TES3::Reference*>(cellPointer->cell->persistentRefs.head->skipDeletedObjects());
-						if (tempReference != NULL) {
+						if (tempReference) {
 							mwse::tes3::exteriorRefs[exteriorCount] = tempReference;
 							exteriorCount++;
 						}
 					}
 				}
 
-				// Make sure that we end our list with a NULL, so we know we're done.
-				mwse::tes3::exteriorRefs[exteriorCount] = NULL;
+				// Make sure that we end our list with a nullptr, so we know we're done.
+				mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
 
 				// Make sure the reference in the center cell is valid.
 				// If not, use the reference from another exterior cell.
-				if (reference == NULL && exteriorCount > 0) {
+				if (reference && exteriorCount > 0) {
 					exteriorCount--;
 					reference = mwse::tes3::exteriorRefs[exteriorCount];
-					mwse::tes3::exteriorRefs[exteriorCount] = NULL;
+					mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
 				}
 			}
 		}

--- a/MWSE/xFirstStatic.cpp
+++ b/MWSE/xFirstStatic.cpp
@@ -21,9 +21,9 @@ namespace mwse {
 		// Clear elements in our stored exterior ref list.
 		mwse::tes3::clearExteriorRefs();
 
-		TES3::Reference* reference = nullptr;
+		TES3::Reference* reference = NULL;
 		auto dataHandler = TES3::DataHandler::get();
-		if (dataHandler->currentInteriorCell) {
+		if (dataHandler->currentInteriorCell != NULL) {
 			reference = static_cast<TES3::Reference*>(dataHandler->currentInteriorCell->persistentRefs.head->skipDeletedObjects());
 		}
 		else {
@@ -40,22 +40,22 @@ namespace mwse {
 					cellPointer = dataHandler->exteriorCellData[i];
 					if (cellPointer->isFullyLoaded()) {
 						TES3::Reference* tempReference = static_cast<TES3::Reference*>(cellPointer->cell->persistentRefs.head->skipDeletedObjects());
-						if (tempReference) {
+						if (tempReference != NULL) {
 							mwse::tes3::exteriorRefs[exteriorCount] = tempReference;
 							exteriorCount++;
 						}
 					}
 				}
 
-				// Make sure that we end our list with a nullptr, so we know we're done.
-				mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
+				// Make sure that we end our list with a NULL, so we know we're done.
+				mwse::tes3::exteriorRefs[exteriorCount] = NULL;
 
 				// Make sure the reference in the center cell is valid.
 				// If not, use the reference from another exterior cell.
-				if (reference && exteriorCount > 0) {
+				if (reference == NULL && exteriorCount > 0) {
 					exteriorCount--;
 					reference = mwse::tes3::exteriorRefs[exteriorCount];
-					mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
+					mwse::tes3::exteriorRefs[exteriorCount] = NULL;
 				}
 			}
 		}

--- a/MWSE/xFirstStatic.cpp
+++ b/MWSE/xFirstStatic.cpp
@@ -21,9 +21,9 @@ namespace mwse {
 		// Clear elements in our stored exterior ref list.
 		mwse::tes3::clearExteriorRefs();
 
-		TES3::Reference* reference = NULL;
+		TES3::Reference* reference = nullptr;
 		auto dataHandler = TES3::DataHandler::get();
-		if (dataHandler->currentInteriorCell != NULL) {
+		if (dataHandler->currentInteriorCell != nullptr) {
 			reference = static_cast<TES3::Reference*>(dataHandler->currentInteriorCell->persistentRefs.head->skipDeletedObjects());
 		}
 		else {
@@ -40,22 +40,22 @@ namespace mwse {
 					cellPointer = dataHandler->exteriorCellData[i];
 					if (cellPointer->isFullyLoaded()) {
 						TES3::Reference* tempReference = static_cast<TES3::Reference*>(cellPointer->cell->persistentRefs.head->skipDeletedObjects());
-						if (tempReference != NULL) {
+						if (tempReference != nullptr) {
 							mwse::tes3::exteriorRefs[exteriorCount] = tempReference;
 							exteriorCount++;
 						}
 					}
 				}
 
-				// Make sure that we end our list with a NULL, so we know we're done.
-				mwse::tes3::exteriorRefs[exteriorCount] = NULL;
+				// Make sure that we end our list with a nullptr, so we know we're done.
+				mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
 
 				// Make sure the reference in the center cell is valid.
 				// If not, use the reference from another exterior cell.
-				if (reference == NULL && exteriorCount > 0) {
+				if (reference == nullptr && exteriorCount > 0) {
 					exteriorCount--;
 					reference = mwse::tes3::exteriorRefs[exteriorCount];
-					mwse::tes3::exteriorRefs[exteriorCount] = NULL;
+					mwse::tes3::exteriorRefs[exteriorCount] = nullptr;
 				}
 			}
 		}

--- a/MWSE/xGetBaseAgi.cpp
+++ b/MWSE/xGetBaseAgi.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAgi: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAgi.cpp
+++ b/MWSE/xGetBaseAgi.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAgi: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAgi.cpp
+++ b/MWSE/xGetBaseAgi.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAgi: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAlchemy.cpp
+++ b/MWSE/xGetBaseAlchemy.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAlchemy: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAlchemy.cpp
+++ b/MWSE/xGetBaseAlchemy.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAlchemy: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAlchemy.cpp
+++ b/MWSE/xGetBaseAlchemy.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAlchemy: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAlteration.cpp
+++ b/MWSE/xGetBaseAlteration.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAlteration: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAlteration.cpp
+++ b/MWSE/xGetBaseAlteration.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAlteration: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAlteration.cpp
+++ b/MWSE/xGetBaseAlteration.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAlteration: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseArmorer.cpp
+++ b/MWSE/xGetBaseArmorer.cpp
@@ -33,7 +33,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseArmorer: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseArmorer.cpp
+++ b/MWSE/xGetBaseArmorer.cpp
@@ -33,7 +33,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseArmorer: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseArmorer.cpp
+++ b/MWSE/xGetBaseArmorer.cpp
@@ -33,7 +33,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseArmorer: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAthletics.cpp
+++ b/MWSE/xGetBaseAthletics.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAthletics: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAthletics.cpp
+++ b/MWSE/xGetBaseAthletics.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAthletics: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAthletics.cpp
+++ b/MWSE/xGetBaseAthletics.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAthletics: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAttribute.cpp
+++ b/MWSE/xGetBaseAttribute.cpp
@@ -49,7 +49,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAttribute: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAttribute.cpp
+++ b/MWSE/xGetBaseAttribute.cpp
@@ -49,7 +49,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAttribute: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAttribute.cpp
+++ b/MWSE/xGetBaseAttribute.cpp
@@ -49,7 +49,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAttribute: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAxe.cpp
+++ b/MWSE/xGetBaseAxe.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAxe: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAxe.cpp
+++ b/MWSE/xGetBaseAxe.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAxe: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseAxe.cpp
+++ b/MWSE/xGetBaseAxe.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseAxe: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseBlock.cpp
+++ b/MWSE/xGetBaseBlock.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseBlock: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseBlock.cpp
+++ b/MWSE/xGetBaseBlock.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseBlock: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseBlock.cpp
+++ b/MWSE/xGetBaseBlock.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseBlock: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseBluntWeapon.cpp
+++ b/MWSE/xGetBaseBluntWeapon.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseBluntWeapon: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseBluntWeapon.cpp
+++ b/MWSE/xGetBaseBluntWeapon.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseBluntWeapon: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseBluntWeapon.cpp
+++ b/MWSE/xGetBaseBluntWeapon.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseBluntWeapon: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseConjuration.cpp
+++ b/MWSE/xGetBaseConjuration.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseConjuration: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseConjuration.cpp
+++ b/MWSE/xGetBaseConjuration.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseConjuration: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseConjuration.cpp
+++ b/MWSE/xGetBaseConjuration.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseConjuration: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseDestruction.cpp
+++ b/MWSE/xGetBaseDestruction.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseDestruction: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseDestruction.cpp
+++ b/MWSE/xGetBaseDestruction.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseDestruction: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseDestruction.cpp
+++ b/MWSE/xGetBaseDestruction.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseDestruction: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseEnchant.cpp
+++ b/MWSE/xGetBaseEnchant.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseEnchant: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseEnchant.cpp
+++ b/MWSE/xGetBaseEnchant.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseEnchant: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseEnchant.cpp
+++ b/MWSE/xGetBaseEnchant.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseEnchant: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseEnd.cpp
+++ b/MWSE/xGetBaseEnd.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseEnd: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseEnd.cpp
+++ b/MWSE/xGetBaseEnd.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseEnd: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseEnd.cpp
+++ b/MWSE/xGetBaseEnd.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseEnd: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseFatigue.cpp
+++ b/MWSE/xGetBaseFatigue.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseFatigue: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseFatigue.cpp
+++ b/MWSE/xGetBaseFatigue.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseFatigue: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseFatigue.cpp
+++ b/MWSE/xGetBaseFatigue.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseFatigue: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseGold.cpp
+++ b/MWSE/xGetBaseGold.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetBaseGold::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseGold: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xGetBaseGold.cpp
+++ b/MWSE/xGetBaseGold.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetBaseGold::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseGold: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xGetBaseGold.cpp
+++ b/MWSE/xGetBaseGold.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetBaseGold::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseGold: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xGetBaseHandToHand.cpp
+++ b/MWSE/xGetBaseHandToHand.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseHandToHand: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseHandToHand.cpp
+++ b/MWSE/xGetBaseHandToHand.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseHandToHand: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseHandToHand.cpp
+++ b/MWSE/xGetBaseHandToHand.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseHandToHand: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseHealth.cpp
+++ b/MWSE/xGetBaseHealth.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseHealth: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseHealth.cpp
+++ b/MWSE/xGetBaseHealth.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseHealth: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseHealth.cpp
+++ b/MWSE/xGetBaseHealth.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseHealth: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseHeavyArmor.cpp
+++ b/MWSE/xGetBaseHeavyArmor.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseHeavyArmor: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseHeavyArmor.cpp
+++ b/MWSE/xGetBaseHeavyArmor.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseHeavyArmor: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseHeavyArmor.cpp
+++ b/MWSE/xGetBaseHeavyArmor.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseHeavyArmor: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseID.cpp
+++ b/MWSE/xGetBaseID.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 	float xGetBaseID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseID: Called without reference." << std::endl;
 			}

--- a/MWSE/xGetBaseID.cpp
+++ b/MWSE/xGetBaseID.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 	float xGetBaseID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseID: Called without reference." << std::endl;
 			}

--- a/MWSE/xGetBaseID.cpp
+++ b/MWSE/xGetBaseID.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 	float xGetBaseID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseID: Called without reference." << std::endl;
 			}

--- a/MWSE/xGetBaseIllusion.cpp
+++ b/MWSE/xGetBaseIllusion.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseIllusion: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseIllusion.cpp
+++ b/MWSE/xGetBaseIllusion.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseIllusion: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseIllusion.cpp
+++ b/MWSE/xGetBaseIllusion.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseIllusion: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseInt.cpp
+++ b/MWSE/xGetBaseInt.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseInt: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseInt.cpp
+++ b/MWSE/xGetBaseInt.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseInt: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseInt.cpp
+++ b/MWSE/xGetBaseInt.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseInt: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseLightArmor.cpp
+++ b/MWSE/xGetBaseLightArmor.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseLightArmor: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseLightArmor.cpp
+++ b/MWSE/xGetBaseLightArmor.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseLightArmor: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseLightArmor.cpp
+++ b/MWSE/xGetBaseLightArmor.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseLightArmor: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseLongBlade.cpp
+++ b/MWSE/xGetBaseLongBlade.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseLongBlade: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseLongBlade.cpp
+++ b/MWSE/xGetBaseLongBlade.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseLongBlade: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseLongBlade.cpp
+++ b/MWSE/xGetBaseLongBlade.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseLongBlade: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseLuc.cpp
+++ b/MWSE/xGetBaseLuc.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseLuc: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseLuc.cpp
+++ b/MWSE/xGetBaseLuc.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseLuc: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseLuc.cpp
+++ b/MWSE/xGetBaseLuc.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseLuc: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMagicka.cpp
+++ b/MWSE/xGetBaseMagicka.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMagicka: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMagicka.cpp
+++ b/MWSE/xGetBaseMagicka.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMagicka: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMagicka.cpp
+++ b/MWSE/xGetBaseMagicka.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMagicka: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMarksman.cpp
+++ b/MWSE/xGetBaseMarksman.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMarksman: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMarksman.cpp
+++ b/MWSE/xGetBaseMarksman.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMarksman: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMarksman.cpp
+++ b/MWSE/xGetBaseMarksman.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMarksman: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMediumArmor.cpp
+++ b/MWSE/xGetBaseMediumArmor.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMediumArmor: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMediumArmor.cpp
+++ b/MWSE/xGetBaseMediumArmor.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMediumArmor: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMediumArmor.cpp
+++ b/MWSE/xGetBaseMediumArmor.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMediumArmor: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMercantile.cpp
+++ b/MWSE/xGetBaseMercantile.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMercantile: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMercantile.cpp
+++ b/MWSE/xGetBaseMercantile.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMercantile: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMercantile.cpp
+++ b/MWSE/xGetBaseMercantile.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMercantile: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMysticism.cpp
+++ b/MWSE/xGetBaseMysticism.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMysticism: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMysticism.cpp
+++ b/MWSE/xGetBaseMysticism.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMysticism: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseMysticism.cpp
+++ b/MWSE/xGetBaseMysticism.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseMysticism: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBasePer.cpp
+++ b/MWSE/xGetBasePer.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBasePer: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBasePer.cpp
+++ b/MWSE/xGetBasePer.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBasePer: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBasePer.cpp
+++ b/MWSE/xGetBasePer.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBasePer: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseRestoration.cpp
+++ b/MWSE/xGetBaseRestoration.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseRestoration: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseRestoration.cpp
+++ b/MWSE/xGetBaseRestoration.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseRestoration: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseRestoration.cpp
+++ b/MWSE/xGetBaseRestoration.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseRestoration: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSecurity.cpp
+++ b/MWSE/xGetBaseSecurity.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSecurity: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSecurity.cpp
+++ b/MWSE/xGetBaseSecurity.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSecurity: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSecurity.cpp
+++ b/MWSE/xGetBaseSecurity.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSecurity: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseShortBlade.cpp
+++ b/MWSE/xGetBaseShortBlade.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseShortBlade: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseShortBlade.cpp
+++ b/MWSE/xGetBaseShortBlade.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseShortBlade: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseShortBlade.cpp
+++ b/MWSE/xGetBaseShortBlade.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseShortBlade: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSkill.cpp
+++ b/MWSE/xGetBaseSkill.cpp
@@ -48,7 +48,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSkill: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSkill.cpp
+++ b/MWSE/xGetBaseSkill.cpp
@@ -48,7 +48,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSkill: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSkill.cpp
+++ b/MWSE/xGetBaseSkill.cpp
@@ -48,7 +48,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSkill: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSneak.cpp
+++ b/MWSE/xGetBaseSneak.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSneak: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSneak.cpp
+++ b/MWSE/xGetBaseSneak.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSneak: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSneak.cpp
+++ b/MWSE/xGetBaseSneak.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSneak: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSpe.cpp
+++ b/MWSE/xGetBaseSpe.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSpe: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSpe.cpp
+++ b/MWSE/xGetBaseSpe.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSpe: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSpe.cpp
+++ b/MWSE/xGetBaseSpe.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSpe: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSpear.cpp
+++ b/MWSE/xGetBaseSpear.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSpear: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSpear.cpp
+++ b/MWSE/xGetBaseSpear.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSpear: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSpear.cpp
+++ b/MWSE/xGetBaseSpear.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSpear: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSpeechcraft.cpp
+++ b/MWSE/xGetBaseSpeechcraft.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSpeechcraft: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSpeechcraft.cpp
+++ b/MWSE/xGetBaseSpeechcraft.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSpeechcraft: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseSpeechcraft.cpp
+++ b/MWSE/xGetBaseSpeechcraft.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseSpeechcraft: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseStr.cpp
+++ b/MWSE/xGetBaseStr.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseStr: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseStr.cpp
+++ b/MWSE/xGetBaseStr.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseStr: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseStr.cpp
+++ b/MWSE/xGetBaseStr.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseStr: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseUnarmored.cpp
+++ b/MWSE/xGetBaseUnarmored.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseUnarmored: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseUnarmored.cpp
+++ b/MWSE/xGetBaseUnarmored.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseUnarmored: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseUnarmored.cpp
+++ b/MWSE/xGetBaseUnarmored.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseUnarmored: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseWil.cpp
+++ b/MWSE/xGetBaseWil.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseWil: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseWil.cpp
+++ b/MWSE/xGetBaseWil.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseWil: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetBaseWil.cpp
+++ b/MWSE/xGetBaseWil.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetBaseWil: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetCharge.cpp
+++ b/MWSE/xGetCharge.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCharge: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (!object) {
+		if (object == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xGetCharge.cpp
+++ b/MWSE/xGetCharge.cpp
@@ -50,7 +50,7 @@ namespace mwse {
 			charge = varNode->charge;
 		}
 		else {
-			TES3::Enchantment* enchantment = object->vTable.object->getEnchantment(object);
+			TES3::Enchantment* enchantment = object->getEnchantment();
 			if (enchantment) {
 				charge = enchantment->maxCharge;
 			}

--- a/MWSE/xGetCharge.cpp
+++ b/MWSE/xGetCharge.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCharge: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (object == NULL) {
+		if (!object) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xGetCharge.cpp
+++ b/MWSE/xGetCharge.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCharge: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (object == NULL) {
+		if (object == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xGetClass.cpp
+++ b/MWSE/xGetClass.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetClass::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetClass: No reference provided." << std::endl;
 			}
@@ -37,7 +37,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (!object) {
+		if (object == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetClass: No object found for reference." << std::endl;
 			}

--- a/MWSE/xGetClass.cpp
+++ b/MWSE/xGetClass.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetClass::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetClass: No reference provided." << std::endl;
 			}
@@ -37,7 +37,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (object == NULL) {
+		if (object == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetClass: No object found for reference." << std::endl;
 			}

--- a/MWSE/xGetClass.cpp
+++ b/MWSE/xGetClass.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetClass::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetClass: No reference provided." << std::endl;
 			}
@@ -37,7 +37,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (object == NULL) {
+		if (!object) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetClass: No object found for reference." << std::endl;
 			}

--- a/MWSE/xGetClass.cpp
+++ b/MWSE/xGetClass.cpp
@@ -70,7 +70,7 @@ namespace mwse {
 		long minorMask = mwse::Stack::getInstance().popLong();
 
 		// Get the class record.
-		TES3::Class* classRecord = object->vTable.object->getClass(object);
+		TES3::Class* classRecord = object->getClass();
 
 		// Get basic class details.
 		char* id = classRecord->id;

--- a/MWSE/xGetCombat.cpp
+++ b/MWSE/xGetCombat.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 	float xGetCombat::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCombat: No reference provided." << std::endl;
 			}
@@ -28,7 +28,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCombat: No mach node found." << std::endl;
 			}

--- a/MWSE/xGetCombat.cpp
+++ b/MWSE/xGetCombat.cpp
@@ -28,7 +28,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCombat: No mach node found." << std::endl;
 			}

--- a/MWSE/xGetCombat.cpp
+++ b/MWSE/xGetCombat.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 	float xGetCombat::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == nullptr) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCombat: No reference provided." << std::endl;
 			}
@@ -28,7 +28,7 @@ namespace mwse {
 		}
 
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCombat: No mach node found." << std::endl;
 			}

--- a/MWSE/xGetCondition.cpp
+++ b/MWSE/xGetCondition.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xGetCondition::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCondition: No reference provided." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get associated varnode, and the condition from it.
 		auto varNode = reference->getAttachedItemData();
-		if (varNode != NULL) {
+		if (varNode) {
 			value = varNode->condition;
 		}
 		else {

--- a/MWSE/xGetCondition.cpp
+++ b/MWSE/xGetCondition.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xGetCondition::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCondition: No reference provided." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get associated varnode, and the condition from it.
 		auto varNode = reference->getAttachedItemData();
-		if (varNode) {
+		if (varNode != NULL) {
 			value = varNode->condition;
 		}
 		else {

--- a/MWSE/xGetCondition.cpp
+++ b/MWSE/xGetCondition.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xGetCondition::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetCondition: No reference provided." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get associated varnode, and the condition from it.
 		auto varNode = reference->getAttachedItemData();
-		if (varNode != NULL) {
+		if (varNode != nullptr) {
 			value = varNode->condition;
 		}
 		else {

--- a/MWSE/xGetEffectInfo.cpp
+++ b/MWSE/xGetEffectInfo.cpp
@@ -40,7 +40,7 @@ namespace mwse {
 		// Validate effect index.
 		if (effectIndex >= 1 && effectIndex <= 8) {
 			// Get the desired effect.
-			TES3::Effect* effect = nullptr;
+			TES3::Effect* effect = NULL;
 			if (effectType == TES3::ObjectType::Spell) {
 				const auto spell = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Spell>(effectId.c_str());
 				if (spell) {

--- a/MWSE/xGetEffectInfo.cpp
+++ b/MWSE/xGetEffectInfo.cpp
@@ -40,7 +40,7 @@ namespace mwse {
 		// Validate effect index.
 		if (effectIndex >= 1 && effectIndex <= 8) {
 			// Get the desired effect.
-			TES3::Effect* effect = NULL;
+			TES3::Effect* effect = nullptr;
 			if (effectType == TES3::ObjectType::Spell) {
 				const auto spell = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Spell>(effectId.c_str());
 				if (spell) {

--- a/MWSE/xGetEnchant.cpp
+++ b/MWSE/xGetEnchant.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 	float xGetEnchant::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Return values.
-		char* enchId = NULL;
+		char* enchId = nullptr;
 		long type = 0;
 		long cost = 0;
 		float currCharge = 0.0f;

--- a/MWSE/xGetEnchant.cpp
+++ b/MWSE/xGetEnchant.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 	float xGetEnchant::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Return values.
-		char* enchId = nullptr;
+		char* enchId = NULL;
 		long type = 0;
 		long cost = 0;
 		float currCharge = 0.0f;

--- a/MWSE/xGetEnchant.cpp
+++ b/MWSE/xGetEnchant.cpp
@@ -36,14 +36,14 @@ namespace mwse {
 		TES3::Reference* reference = virtualMachine.getReference();
 		if (reference) {
 			// Get data from ENCH record.
-			TES3::Enchantment* enchantment = reference->baseObject->vTable.object->getEnchantment(reference->baseObject);
+			TES3::Enchantment* enchantment = reference->baseObject->getEnchantment();
 			if (enchantment) {
 				enchId = enchantment->objectID;
 				type = int(enchantment->castType);
 				cost = enchantment->chargeCost;
 				maxCharge = enchantment->maxCharge;
 				effects = enchantment->getActiveEffectCount();
-				autocalc = enchantment->vTable.object->getAutoCalc(enchantment);
+				autocalc = enchantment->getAutoCalc();
 
 				// Get the current charge.
 				auto varNode = reference->getAttachedItemData();

--- a/MWSE/xGetEnchantInfo.cpp
+++ b/MWSE/xGetEnchantInfo.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 
 		// Validate effect index.
 		const auto enchantment = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Enchantment>(enchantId);
-		if (enchantment) {
+		if (enchantment != NULL) {
 			type = int(enchantment->castType);
 			cost = enchantment->chargeCost;
 			maxCharge = enchantment->maxCharge;

--- a/MWSE/xGetEnchantInfo.cpp
+++ b/MWSE/xGetEnchantInfo.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 
 		// Validate effect index.
 		const auto enchantment = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Enchantment>(enchantId);
-		if (enchantment != NULL) {
+		if (enchantment) {
 			type = int(enchantment->castType);
 			cost = enchantment->chargeCost;
 			maxCharge = enchantment->maxCharge;

--- a/MWSE/xGetEnchantInfo.cpp
+++ b/MWSE/xGetEnchantInfo.cpp
@@ -30,7 +30,7 @@ namespace mwse {
 
 		// Validate effect index.
 		const auto enchantment = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Enchantment>(enchantId);
-		if (enchantment != NULL) {
+		if (enchantment != nullptr) {
 			type = int(enchantment->castType);
 			cost = enchantment->chargeCost;
 			maxCharge = enchantment->maxCharge;

--- a/MWSE/xGetEnchantInfo.cpp
+++ b/MWSE/xGetEnchantInfo.cpp
@@ -35,7 +35,7 @@ namespace mwse {
 			cost = enchantment->chargeCost;
 			maxCharge = enchantment->maxCharge;
 			effects = enchantment->getActiveEffectCount();
-			autocalc = enchantment->vTable.object->getAutoCalc(enchantment);
+			autocalc = enchantment->getAutoCalc();
 		}
 		else {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {

--- a/MWSE/xGetEncumb.cpp
+++ b/MWSE/xGetEncumb.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetEncumb::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference to target.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumb: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetEncumb.cpp
+++ b/MWSE/xGetEncumb.cpp
@@ -42,6 +42,10 @@ namespace mwse {
 
 		// Loop through the inventory nodes of the reference, adding weight for each item found.
 		for (const auto stack : static_cast<TES3::Actor*>(reference->baseObject)->inventory) {
+			if (!stack) {
+				continue;
+			}
+
 			totalWeight += stack->object->getWeight() * std::abs(stack->count);
 
 			// Keep track if we've run across leveled content.

--- a/MWSE/xGetEncumb.cpp
+++ b/MWSE/xGetEncumb.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetEncumb::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference to target.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumb: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetEncumb.cpp
+++ b/MWSE/xGetEncumb.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetEncumb::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference to target.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumb: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetEncumb.cpp
+++ b/MWSE/xGetEncumb.cpp
@@ -41,19 +41,13 @@ namespace mwse {
 		float totalWeight = 0.0f;
 
 		// Loop through the inventory nodes of the reference, adding weight for each item found.
-		NI::IteratedList<TES3::ItemStack*>::Node* inventoryListNode = static_cast<TES3::Actor*>(reference->baseObject)->inventory.itemStacks.head;
-		while (inventoryListNode) {
-			TES3::ItemStack* inventoryNode = inventoryListNode->data;
-			if (inventoryNode) {
-				totalWeight += inventoryNode->object->vTable.object->getWeight(inventoryNode->object) * std::abs(inventoryNode->count);
+		for (const auto stack : static_cast<TES3::Actor*>(reference->baseObject)->inventory) {
+			totalWeight += stack->object->getWeight() * std::abs(stack->count);
 
-				// Keep track if we've run across leveled content.
-				if (!hasLeveledContent && inventoryNode->object->objectType == TES3::ObjectType::LeveledItem) {
-					hasLeveledContent = true;
-				}
+			// Keep track if we've run across leveled content.
+			if (!hasLeveledContent && stack->object->objectType == TES3::ObjectType::LeveledItem) {
+				hasLeveledContent = true;
 			}
-
-			inventoryListNode = inventoryListNode->next;
 		}
 
 		// If we ran into leveled content, make our weight negative.

--- a/MWSE/xGetEncumbrance.cpp
+++ b/MWSE/xGetEncumbrance.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get reference to target.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumbrance: No reference provided." << std::endl;
 			}
@@ -42,7 +42,7 @@ namespace mwse {
 
 		// Get record for reference.
 		TES3::BaseObject* record = reference->baseObject;
-		if (record == NULL) {
+		if (!record) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumbrance: No record found for reference." << std::endl;
 			}
@@ -63,7 +63,7 @@ namespace mwse {
 
 		// Get associated MACP node.
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumbrance: No associated macp record found for reference." << std::endl;
 			}

--- a/MWSE/xGetEncumbrance.cpp
+++ b/MWSE/xGetEncumbrance.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get reference to target.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumbrance: No reference provided." << std::endl;
 			}
@@ -42,7 +42,7 @@ namespace mwse {
 
 		// Get record for reference.
 		TES3::BaseObject* record = reference->baseObject;
-		if (record == NULL) {
+		if (record == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumbrance: No record found for reference." << std::endl;
 			}
@@ -63,7 +63,7 @@ namespace mwse {
 
 		// Get associated MACP node.
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumbrance: No associated macp record found for reference." << std::endl;
 			}

--- a/MWSE/xGetEncumbrance.cpp
+++ b/MWSE/xGetEncumbrance.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get reference to target.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumbrance: No reference provided." << std::endl;
 			}
@@ -42,7 +42,7 @@ namespace mwse {
 
 		// Get record for reference.
 		TES3::BaseObject* record = reference->baseObject;
-		if (!record) {
+		if (record == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumbrance: No record found for reference." << std::endl;
 			}
@@ -63,7 +63,7 @@ namespace mwse {
 
 		// Get associated MACP node.
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetEncumbrance: No associated macp record found for reference." << std::endl;
 			}

--- a/MWSE/xGetGSString.cpp
+++ b/MWSE/xGetGSString.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		if (gmstId < 0) {
 			mwse::log::getLog() << "xGetGSString: Invalid GMST id." << std::endl;
-			mwse::Stack::getInstance().pushLong(nullptr);
+			mwse::Stack::getInstance().pushLong(NULL);
 			return 0.0f;
 		}
 

--- a/MWSE/xGetGSString.cpp
+++ b/MWSE/xGetGSString.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		if (gmstId < 0) {
 			mwse::log::getLog() << "xGetGSString: Invalid GMST id." << std::endl;
-			mwse::Stack::getInstance().pushLong(NULL);
+			mwse::Stack::getInstance().pushLong(nullptr);
 			return 0.0f;
 		}
 

--- a/MWSE/xGetGlobal.cpp
+++ b/MWSE/xGetGlobal.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get global.
 		const TES3::GlobalVariable* global = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(variable.c_str());
-		if (!global) {
+		if (global == NULL) {
 			mwse::log::getLog() << "xGetGlobal: Global '" << variable << "' could not be found." << std::endl;
 			mwse::Stack::getInstance().pushFloat(0.0f);
 			mwse::Stack::getInstance().pushLong(false);

--- a/MWSE/xGetGlobal.cpp
+++ b/MWSE/xGetGlobal.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get global.
 		const TES3::GlobalVariable* global = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(variable.c_str());
-		if (global == NULL) {
+		if (global == nullptr) {
 			mwse::log::getLog() << "xGetGlobal: Global '" << variable << "' could not be found." << std::endl;
 			mwse::Stack::getInstance().pushFloat(0.0f);
 			mwse::Stack::getInstance().pushLong(false);

--- a/MWSE/xGetGlobal.cpp
+++ b/MWSE/xGetGlobal.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get global.
 		const TES3::GlobalVariable* global = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(variable.c_str());
-		if (global == NULL) {
+		if (!global) {
 			mwse::log::getLog() << "xGetGlobal: Global '" << variable << "' could not be found." << std::endl;
 			mwse::Stack::getInstance().pushFloat(0.0f);
 			mwse::Stack::getInstance().pushLong(false);

--- a/MWSE/xGetGold.cpp
+++ b/MWSE/xGetGold.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetGold::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetGold: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xGetGold.cpp
+++ b/MWSE/xGetGold.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetGold::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetGold: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xGetGold.cpp
+++ b/MWSE/xGetGold.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetGold::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetGold: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xGetIngredientEffect.cpp
+++ b/MWSE/xGetIngredientEffect.cpp
@@ -28,7 +28,7 @@ namespace mwse {
 
 		// Get the ingredient.
 		const auto ingredient = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Ingredient>(id);
-		if (ingredient == NULL) {
+		if (!ingredient) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetIngredientEffect: No ingredient record found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xGetIngredientEffect.cpp
+++ b/MWSE/xGetIngredientEffect.cpp
@@ -28,7 +28,7 @@ namespace mwse {
 
 		// Get the ingredient.
 		const auto ingredient = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Ingredient>(id);
-		if (!ingredient) {
+		if (ingredient == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetIngredientEffect: No ingredient record found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xGetIngredientEffect.cpp
+++ b/MWSE/xGetIngredientEffect.cpp
@@ -28,7 +28,7 @@ namespace mwse {
 
 		// Get the ingredient.
 		const auto ingredient = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Ingredient>(id);
-		if (ingredient == NULL) {
+		if (ingredient == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetIngredientEffect: No ingredient record found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xGetItemCount.cpp
+++ b/MWSE/xGetItemCount.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 		// Get who we're getting the item count of. mwscript's GetItemCount validates the
 		// object type for us, we don't need to.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetItemCount: No reference found for function call." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Get template for the item we want to get the count of.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (itemTemplate == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetItemCount: No template found with id " << id << "." << std::endl;
 			}

--- a/MWSE/xGetItemCount.cpp
+++ b/MWSE/xGetItemCount.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 		// Get who we're getting the item count of. mwscript's GetItemCount validates the
 		// object type for us, we don't need to.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetItemCount: No reference found for function call." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Get template for the item we want to get the count of.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (!itemTemplate) {
+		if (itemTemplate == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetItemCount: No template found with id " << id << "." << std::endl;
 			}

--- a/MWSE/xGetItemCount.cpp
+++ b/MWSE/xGetItemCount.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 		// Get who we're getting the item count of. mwscript's GetItemCount validates the
 		// object type for us, we don't need to.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetItemCount: No reference found for function call." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Get template for the item we want to get the count of.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (!itemTemplate) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetItemCount: No template found with id " << id << "." << std::endl;
 			}

--- a/MWSE/xGetLockLevel.cpp
+++ b/MWSE/xGetLockLevel.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 
 		// Get reference to what we're finding the lock level of.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetLockLevel: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetLockLevel.cpp
+++ b/MWSE/xGetLockLevel.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 
 		// Get reference to what we're finding the lock level of.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetLockLevel: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetLockLevel.cpp
+++ b/MWSE/xGetLockLevel.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 
 		// Get reference to what we're finding the lock level of.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetLockLevel: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetMagic.cpp
+++ b/MWSE/xGetMagic.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetMagic::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Return values.
 		long type = 0;
-		const char* id = NULL;
+		const char* id = nullptr;
 
 		// Get reference to what we're finding enchantment information for.
 		TES3::Reference* reference = virtualMachine.getReference();

--- a/MWSE/xGetMagic.cpp
+++ b/MWSE/xGetMagic.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetMagic::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Return values.
 		long type = 0;
-		const char* id = nullptr;
+		const char* id = NULL;
 
 		// Get reference to what we're finding enchantment information for.
 		TES3::Reference* reference = virtualMachine.getReference();

--- a/MWSE/xGetMaxCharge.cpp
+++ b/MWSE/xGetMaxCharge.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxCharge: No reference provided." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (!object) {
+		if (object == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxCharge.cpp
+++ b/MWSE/xGetMaxCharge.cpp
@@ -42,7 +42,7 @@ namespace mwse {
 		}
 
 		// Get  the maximum charge from the enchantment record.
-		TES3::Enchantment* enchantment = object->vTable.object->getEnchantment(object);
+		TES3::Enchantment* enchantment = object->getEnchantment();
 		if (enchantment) {
 			charge = enchantment->maxCharge;
 		}

--- a/MWSE/xGetMaxCharge.cpp
+++ b/MWSE/xGetMaxCharge.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxCharge: No reference provided." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (object == NULL) {
+		if (object == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxCharge.cpp
+++ b/MWSE/xGetMaxCharge.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxCharge: No reference provided." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (object == NULL) {
+		if (!object) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxCondition.cpp
+++ b/MWSE/xGetMaxCondition.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 	float xGetMaxCondition::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxCondition: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetMaxCondition.cpp
+++ b/MWSE/xGetMaxCondition.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 	float xGetMaxCondition::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxCondition: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetMaxCondition.cpp
+++ b/MWSE/xGetMaxCondition.cpp
@@ -28,7 +28,7 @@ namespace mwse {
 
 		// Get the max condition.
 		TES3::Object* object = reference->baseObject;
-		long value = object->vTable.object->getDurability(object);
+		long value = object->getDurability();
 
 		mwse::Stack::getInstance().pushLong(value);
 

--- a/MWSE/xGetMaxCondition.cpp
+++ b/MWSE/xGetMaxCondition.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 	float xGetMaxCondition::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxCondition: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetMaxFatigue.cpp
+++ b/MWSE/xGetMaxFatigue.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxFatigue: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxFatigue.cpp
+++ b/MWSE/xGetMaxFatigue.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxFatigue: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxFatigue.cpp
+++ b/MWSE/xGetMaxFatigue.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxFatigue: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxHealth.cpp
+++ b/MWSE/xGetMaxHealth.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxHealth: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxHealth.cpp
+++ b/MWSE/xGetMaxHealth.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxHealth: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxHealth.cpp
+++ b/MWSE/xGetMaxHealth.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxHealth: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxMagicka.cpp
+++ b/MWSE/xGetMaxMagicka.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxMagicka: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxMagicka.cpp
+++ b/MWSE/xGetMaxMagicka.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxMagicka: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetMaxMagicka.cpp
+++ b/MWSE/xGetMaxMagicka.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		// Get the associated MACP record.
 		TES3::Reference* reference = virtualMachine.getReference();
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetMaxMagicka: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetModel.cpp
+++ b/MWSE/xGetModel.cpp
@@ -35,7 +35,7 @@ namespace mwse {
 				mwse::Stack::getInstance().pushLong(0);
 				return 0.0f;
 			}
-			model = record->vTable.object->getModelPath(record);
+			model = record->getModelPath();
 		}
 
 		// If we were not given a value, we try to use the function's given reference.
@@ -48,7 +48,7 @@ namespace mwse {
 				mwse::Stack::getInstance().pushLong(0);
 				return 0.0f;
 			}
-			model = reference->baseObject->vTable.object->getModelPath(reference->baseObject);
+			model = reference->baseObject->getModelPath();
 		}
 
 		// Push the model back to the stack.

--- a/MWSE/xGetModel.cpp
+++ b/MWSE/xGetModel.cpp
@@ -21,14 +21,14 @@ namespace mwse {
 		// Get our parameter.
 		long param = Stack::getInstance().popLong();
 
-		const char* model = NULL;
+		const char* model = nullptr;
 
 		// If we were given a value, it's supposed to be a string, and we'll get a record by this ID.
 		if (param) {
 			// Get the record by id string.
 			mwseString& id = virtualMachine.getString(param);
 			const auto record = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Object>(id);
-			if (record == NULL) {
+			if (record == nullptr) {
 				if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 					log::getLog() << "xGetModel: No record found for id '" << id << "'." << std::endl;
 				}
@@ -41,7 +41,7 @@ namespace mwse {
 		// If we were not given a value, we try to use the function's given reference.
 		else {
 			TES3::Reference* reference = virtualMachine.getReference();
-			if (reference == NULL) {
+			if (reference == nullptr) {
 				if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 					log::getLog() << "xGetModel: Invalid reference." << std::endl;
 				}

--- a/MWSE/xGetModel.cpp
+++ b/MWSE/xGetModel.cpp
@@ -21,14 +21,14 @@ namespace mwse {
 		// Get our parameter.
 		long param = Stack::getInstance().popLong();
 
-		const char* model = NULL;
+		const char* model = nullptr;
 
 		// If we were given a value, it's supposed to be a string, and we'll get a record by this ID.
 		if (param) {
 			// Get the record by id string.
 			mwseString& id = virtualMachine.getString(param);
 			const auto record = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Object>(id);
-			if (record == NULL) {
+			if (!record) {
 				if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 					log::getLog() << "xGetModel: No record found for id '" << id << "'." << std::endl;
 				}
@@ -41,7 +41,7 @@ namespace mwse {
 		// If we were not given a value, we try to use the function's given reference.
 		else {
 			TES3::Reference* reference = virtualMachine.getReference();
-			if (reference == NULL) {
+			if (!reference) {
 				if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 					log::getLog() << "xGetModel: Invalid reference." << std::endl;
 				}

--- a/MWSE/xGetModel.cpp
+++ b/MWSE/xGetModel.cpp
@@ -21,14 +21,14 @@ namespace mwse {
 		// Get our parameter.
 		long param = Stack::getInstance().popLong();
 
-		const char* model = nullptr;
+		const char* model = NULL;
 
 		// If we were given a value, it's supposed to be a string, and we'll get a record by this ID.
 		if (param) {
 			// Get the record by id string.
 			mwseString& id = virtualMachine.getString(param);
 			const auto record = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Object>(id);
-			if (!record) {
+			if (record == NULL) {
 				if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 					log::getLog() << "xGetModel: No record found for id '" << id << "'." << std::endl;
 				}
@@ -41,7 +41,7 @@ namespace mwse {
 		// If we were not given a value, we try to use the function's given reference.
 		else {
 			TES3::Reference* reference = virtualMachine.getReference();
-			if (!reference) {
+			if (reference == NULL) {
 				if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 					log::getLog() << "xGetModel: Invalid reference." << std::endl;
 				}

--- a/MWSE/xGetName.cpp
+++ b/MWSE/xGetName.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 	float xGetName::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetName: No reference provided." << std::endl;
 			}
@@ -26,7 +26,7 @@ namespace mwse {
 			return 0.0f;
 		}
 
-		const char* name = NULL;
+		const char* name = nullptr;
 
 		// Get the base record.
 		TES3::BaseObject* record = reference->baseObject;

--- a/MWSE/xGetName.cpp
+++ b/MWSE/xGetName.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 		// Get the base record.
 		TES3::BaseObject* record = reference->baseObject;
 		if (record) {
-			name = reference->baseObject->vTable.object->getName(reference->baseObject);
+			name = reference->baseObject->getName();
 		}
 		else {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {

--- a/MWSE/xGetName.cpp
+++ b/MWSE/xGetName.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 	float xGetName::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetName: No reference provided." << std::endl;
 			}
@@ -26,7 +26,7 @@ namespace mwse {
 			return 0.0f;
 		}
 
-		const char* name = nullptr;
+		const char* name = NULL;
 
 		// Get the base record.
 		TES3::BaseObject* record = reference->baseObject;

--- a/MWSE/xGetName.cpp
+++ b/MWSE/xGetName.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 	float xGetName::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetName: No reference provided." << std::endl;
 			}
@@ -26,7 +26,7 @@ namespace mwse {
 			return 0.0f;
 		}
 
-		const char* name = NULL;
+		const char* name = nullptr;
 
 		// Get the base record.
 		TES3::BaseObject* record = reference->baseObject;

--- a/MWSE/xGetOwner.cpp
+++ b/MWSE/xGetOwner.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetOwner::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetOwner: No reference provided." << std::endl;
 			}
@@ -29,7 +29,7 @@ namespace mwse {
 			return 0.0f;
 		}
 
-		const char* owner = NULL;
+		const char* owner = nullptr;
 
 		// Get the attached varnode.
 		auto node = reference->getAttachedItemData();

--- a/MWSE/xGetOwner.cpp
+++ b/MWSE/xGetOwner.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetOwner::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetOwner: No reference provided." << std::endl;
 			}
@@ -29,7 +29,7 @@ namespace mwse {
 			return 0.0f;
 		}
 
-		const char* owner = nullptr;
+		const char* owner = NULL;
 
 		// Get the attached varnode.
 		auto node = reference->getAttachedItemData();

--- a/MWSE/xGetOwner.cpp
+++ b/MWSE/xGetOwner.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetOwner::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetOwner: No reference provided." << std::endl;
 			}
@@ -29,7 +29,7 @@ namespace mwse {
 			return 0.0f;
 		}
 
-		const char* owner = NULL;
+		const char* owner = nullptr;
 
 		// Get the attached varnode.
 		auto node = reference->getAttachedItemData();

--- a/MWSE/xGetOwnerInfo.cpp
+++ b/MWSE/xGetOwnerInfo.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	xGetOwnerInfo::xGetOwnerInfo() : mwse::InstructionInterface_t(OpCode::xGetOwnerInfo) {}
 
 	float xGetOwnerInfo::execute(mwse::VMExecuteInterface& virtualMachine) {
-		const char* id = nullptr;
+		const char* id = NULL;
 		long rank = 0;
 		long type = 0;
 

--- a/MWSE/xGetOwnerInfo.cpp
+++ b/MWSE/xGetOwnerInfo.cpp
@@ -34,7 +34,7 @@ namespace mwse {
 				if (owner) {
 					type = owner->objectType;
 					if (type == TES3::ObjectType::NPC) {
-						id = owner->vTable.object->getObjectID(owner);
+						id = owner->getObjectID();
 						if (varNode->requiredVariable) {
 							rank = se::string::store::getOrCreate(varNode->requiredVariable->name);
 						}

--- a/MWSE/xGetOwnerInfo.cpp
+++ b/MWSE/xGetOwnerInfo.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	xGetOwnerInfo::xGetOwnerInfo() : mwse::InstructionInterface_t(OpCode::xGetOwnerInfo) {}
 
 	float xGetOwnerInfo::execute(mwse::VMExecuteInterface& virtualMachine) {
-		const char* id = NULL;
+		const char* id = nullptr;
 		long rank = 0;
 		long type = 0;
 

--- a/MWSE/xGetProgressLevel.cpp
+++ b/MWSE/xGetProgressLevel.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetProgressLevel::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get the player's associated MACP record.
 		auto mobileObject = TES3::WorldController::get()->getMobilePlayer();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetProgressLevel: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetProgressLevel.cpp
+++ b/MWSE/xGetProgressLevel.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetProgressLevel::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get the player's associated MACP record.
 		auto mobileObject = TES3::WorldController::get()->getMobilePlayer();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetProgressLevel: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetProgressLevel.cpp
+++ b/MWSE/xGetProgressLevel.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetProgressLevel::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get the player's associated MACP record.
 		auto mobileObject = TES3::WorldController::get()->getMobilePlayer();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetProgressLevel: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetQuality.cpp
+++ b/MWSE/xGetQuality.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xGetQuality::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetQuality: No reference provided." << std::endl;
 			}
@@ -30,7 +30,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::Object* object = reference->baseObject;
-		if (object == NULL) {
+		if (object == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetQuality: No base record found." << std::endl;
 			}

--- a/MWSE/xGetQuality.cpp
+++ b/MWSE/xGetQuality.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xGetQuality::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetQuality: No reference provided." << std::endl;
 			}
@@ -30,7 +30,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::Object* object = reference->baseObject;
-		if (!object) {
+		if (object == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetQuality: No base record found." << std::endl;
 			}

--- a/MWSE/xGetQuality.cpp
+++ b/MWSE/xGetQuality.cpp
@@ -38,7 +38,7 @@ namespace mwse {
 			return 0.0f;
 		}
 
-		mwse::Stack::getInstance().pushFloat(object->vTable.object->getQuality(object));
+		mwse::Stack::getInstance().pushFloat(object->getQuality());
 
 		return 0.0f;
 	}

--- a/MWSE/xGetQuality.cpp
+++ b/MWSE/xGetQuality.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xGetQuality::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetQuality: No reference provided." << std::endl;
 			}
@@ -30,7 +30,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::Object* object = reference->baseObject;
-		if (object == NULL) {
+		if (!object) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetQuality: No base record found." << std::endl;
 			}

--- a/MWSE/xGetRace.cpp
+++ b/MWSE/xGetRace.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 	float xGetRace::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetRace: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::NPCInstance* object = reinterpret_cast<TES3::NPCInstance*>(reference->baseObject);
-		if (!object) {
+		if (object == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetRace: No record found for reference." << std::endl;
 			}

--- a/MWSE/xGetRace.cpp
+++ b/MWSE/xGetRace.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 	float xGetRace::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetRace: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::NPCInstance* object = reinterpret_cast<TES3::NPCInstance*>(reference->baseObject);
-		if (object == NULL) {
+		if (object == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetRace: No record found for reference." << std::endl;
 			}

--- a/MWSE/xGetRace.cpp
+++ b/MWSE/xGetRace.cpp
@@ -49,7 +49,7 @@ namespace mwse {
 		}
 
 		// Get the NPC's race.
-		TES3::Race* race = object->vTable.object->getRace(object);
+		TES3::Race* race = object->getRace();
 
 		// Get argument: return variable type.
 		short returnTypeParam = mwse::Stack::getInstance().popShort();

--- a/MWSE/xGetRace.cpp
+++ b/MWSE/xGetRace.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 	float xGetRace::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetRace: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::NPCInstance* object = reinterpret_cast<TES3::NPCInstance*>(reference->baseObject);
-		if (object == NULL) {
+		if (!object) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetRace: No record found for reference." << std::endl;
 			}

--- a/MWSE/xGetService.cpp
+++ b/MWSE/xGetService.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 	float xGetService::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetRace: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetService.cpp
+++ b/MWSE/xGetService.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 	float xGetService::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetRace: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetService.cpp
+++ b/MWSE/xGetService.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 	float xGetService::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetRace: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetService.cpp
+++ b/MWSE/xGetService.cpp
@@ -34,7 +34,7 @@ namespace mwse {
 		long mask = mwse::Stack::getInstance().popLong();
 
 		// Get the AI configuration from the NPC;
-		TES3::AIConfig* aiConfig = reference->baseObject->vTable.object->getAIConfig(reference->baseObject);
+		TES3::AIConfig* aiConfig = reference->baseObject->getAIConfig();
 		if (aiConfig) {
 			flags = aiConfig->merchantFlags & mask;
 		}

--- a/MWSE/xGetSkill.cpp
+++ b/MWSE/xGetSkill.cpp
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSkill: Call on invalid reference." << std::endl;
 			}
@@ -52,7 +52,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSkill: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetSkill.cpp
+++ b/MWSE/xGetSkill.cpp
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSkill: Call on invalid reference." << std::endl;
 			}
@@ -52,7 +52,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSkill: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetSkill.cpp
+++ b/MWSE/xGetSkill.cpp
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSkill: Call on invalid reference." << std::endl;
 			}
@@ -52,7 +52,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = reference->getAttachedMobileNPC();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSkill: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xGetSpell.cpp
+++ b/MWSE/xGetSpell.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSpell: Could not find reference." << std::endl;
 			}

--- a/MWSE/xGetSpell.cpp
+++ b/MWSE/xGetSpell.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSpell: Could not find reference." << std::endl;
 			}

--- a/MWSE/xGetSpell.cpp
+++ b/MWSE/xGetSpell.cpp
@@ -43,14 +43,8 @@ namespace mwse {
 		}
 
 		TES3::NPC* npc = reinterpret_cast<TES3::NPCInstance*>(reference->baseObject)->baseNPC;
-		NI::IteratedList<TES3::Spell*>::Node* currentNode = npc->spellList.list.head;
-		while (currentNode != NULL) {
-			TES3::Spell* spell = currentNode->data;
-			if (strcmp(spell->objectID, spellId.c_str()) == 0) {
-				result = 1;
-				break;
-			}
-			currentNode = currentNode->next;
+		if (npc->spellList.contains(spellId)) {
+			result = 1;
 		}
 
 		mwse::Stack::getInstance().pushShort(result);

--- a/MWSE/xGetSpell.cpp
+++ b/MWSE/xGetSpell.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSpell: Could not find reference." << std::endl;
 			}

--- a/MWSE/xGetSpellEffects.cpp
+++ b/MWSE/xGetSpellEffects.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSpellEffects: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (spellTemplate == NULL) {
+		if (!spellTemplate) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSpellEffects: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xGetSpellEffects.cpp
+++ b/MWSE/xGetSpellEffects.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSpellEffects: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (!spellTemplate) {
+		if (spellTemplate == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSpellEffects: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xGetSpellEffects.cpp
+++ b/MWSE/xGetSpellEffects.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSpellEffects: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (spellTemplate == NULL) {
+		if (spellTemplate == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetSpellEffects: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xGetSpellInfo.cpp
+++ b/MWSE/xGetSpellInfo.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		mwseString& spellId = virtualMachine.getString(Stack::getInstance().popLong());
 
 		// Return values.
-		char* name = nullptr;
+		char* name = NULL;
 		long type = 0;
 		long cost = 0;
 		long effects = 0;
@@ -31,7 +31,7 @@ namespace mwse {
 
 		// Get spell data by id.
 		const auto spell = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Spell>(spellId);;
-		if (spell) {
+		if (spell != NULL) {
 			name = spell->name;
 			type = long(spell->castType);
 			cost = spell->magickaCost;

--- a/MWSE/xGetSpellInfo.cpp
+++ b/MWSE/xGetSpellInfo.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		mwseString& spellId = virtualMachine.getString(Stack::getInstance().popLong());
 
 		// Return values.
-		char* name = NULL;
+		char* name = nullptr;
 		long type = 0;
 		long cost = 0;
 		long effects = 0;
@@ -31,7 +31,7 @@ namespace mwse {
 
 		// Get spell data by id.
 		const auto spell = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Spell>(spellId);;
-		if (spell != NULL) {
+		if (spell != nullptr) {
 			name = spell->name;
 			type = long(spell->castType);
 			cost = spell->magickaCost;

--- a/MWSE/xGetSpellInfo.cpp
+++ b/MWSE/xGetSpellInfo.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 		mwseString& spellId = virtualMachine.getString(Stack::getInstance().popLong());
 
 		// Return values.
-		char* name = NULL;
+		char* name = nullptr;
 		long type = 0;
 		long cost = 0;
 		long effects = 0;
@@ -31,7 +31,7 @@ namespace mwse {
 
 		// Get spell data by id.
 		const auto spell = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Spell>(spellId);;
-		if (spell != NULL) {
+		if (spell) {
 			name = spell->name;
 			type = long(spell->castType);
 			cost = spell->magickaCost;

--- a/MWSE/xGetStackSize.cpp
+++ b/MWSE/xGetStackSize.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xGetStackSize::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetStackSize: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetStackSize.cpp
+++ b/MWSE/xGetStackSize.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xGetStackSize::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetStackSize: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetStackSize.cpp
+++ b/MWSE/xGetStackSize.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xGetStackSize::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetStackSize: No reference provided." << std::endl;
 			}

--- a/MWSE/xGetTrap.cpp
+++ b/MWSE/xGetTrap.cpp
@@ -18,13 +18,13 @@ namespace mwse {
 	xGetTrap::xGetTrap() : mwse::InstructionInterface_t(OpCode::xGetTrap) {}
 
 	float xGetTrap::execute(mwse::VMExecuteInterface& virtualMachine) {
-		char* id = NULL;
-		char* name = NULL;
+		char* id = nullptr;
+		char* name = nullptr;
 		short cost = 0;
 
 		// Get reference to what we're finding the trap of.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetTrap: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xGetTrap.cpp
+++ b/MWSE/xGetTrap.cpp
@@ -18,13 +18,13 @@ namespace mwse {
 	xGetTrap::xGetTrap() : mwse::InstructionInterface_t(OpCode::xGetTrap) {}
 
 	float xGetTrap::execute(mwse::VMExecuteInterface& virtualMachine) {
-		char* id = nullptr;
-		char* name = nullptr;
+		char* id = NULL;
+		char* name = NULL;
 		short cost = 0;
 
 		// Get reference to what we're finding the trap of.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetTrap: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xGetTrap.cpp
+++ b/MWSE/xGetTrap.cpp
@@ -18,13 +18,13 @@ namespace mwse {
 	xGetTrap::xGetTrap() : mwse::InstructionInterface_t(OpCode::xGetTrap) {}
 
 	float xGetTrap::execute(mwse::VMExecuteInterface& virtualMachine) {
-		char* id = NULL;
-		char* name = NULL;
+		char* id = nullptr;
+		char* name = nullptr;
 		short cost = 0;
 
 		// Get reference to what we're finding the trap of.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetTrap: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xGetValue.cpp
+++ b/MWSE/xGetValue.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetValue::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetValue: No reference provided." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 		try {
 			// Get record.
 			auto object = reference->baseObject;
-			if (!object) {
+			if (object == NULL) {
 				throw std::exception("No base record found.");
 			}
 

--- a/MWSE/xGetValue.cpp
+++ b/MWSE/xGetValue.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetValue::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetValue: No reference provided." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 		try {
 			// Get record.
 			auto object = reference->baseObject;
-			if (object == NULL) {
+			if (object == nullptr) {
 				throw std::exception("No base record found.");
 			}
 

--- a/MWSE/xGetValue.cpp
+++ b/MWSE/xGetValue.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetValue::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetValue: No reference provided." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 		try {
 			// Get record.
 			auto object = reference->baseObject;
-			if (object == NULL) {
+			if (!object) {
 				throw std::exception("No base record found.");
 			}
 

--- a/MWSE/xGetWeight.cpp
+++ b/MWSE/xGetWeight.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetWeight::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetWeight: No reference provided." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 		try {
 			// Get record.
 			auto object = reference->baseObject;
-			if (object == NULL) {
+			if (!object) {
 				throw std::exception("No base object found.");
 			}
 

--- a/MWSE/xGetWeight.cpp
+++ b/MWSE/xGetWeight.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetWeight::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetWeight: No reference provided." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 		try {
 			// Get record.
 			auto object = reference->baseObject;
-			if (object == NULL) {
+			if (object == nullptr) {
 				throw std::exception("No base object found.");
 			}
 

--- a/MWSE/xGetWeight.cpp
+++ b/MWSE/xGetWeight.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xGetWeight::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xGetWeight: No reference provided." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 		try {
 			// Get record.
 			auto object = reference->baseObject;
-			if (!object) {
+			if (object == NULL) {
 				throw std::exception("No base object found.");
 			}
 

--- a/MWSE/xHasItemEquipped.cpp
+++ b/MWSE/xHasItemEquipped.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get script reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xHasItemEquipped: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get item template.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (!itemTemplate) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xHasItemEquipped: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xHasItemEquipped.cpp
+++ b/MWSE/xHasItemEquipped.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get script reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xHasItemEquipped: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get item template.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (!itemTemplate) {
+		if (itemTemplate == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xHasItemEquipped: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xHasItemEquipped.cpp
+++ b/MWSE/xHasItemEquipped.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get script reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xHasItemEquipped: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get item template.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (itemTemplate == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xHasItemEquipped: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xInventory.cpp
+++ b/MWSE/xInventory.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xInventory::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xInventory: Invalid reference attachment." << std::endl;
 			}
@@ -39,7 +39,7 @@ namespace mwse {
 		}
 
 		NI::IteratedList<TES3::ItemStack*>::Node* firstItem = static_cast<TES3::Actor*>(reference->baseObject)->inventory.itemStacks.head;
-		if (firstItem == NULL) {
+		if (firstItem == nullptr) {
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);

--- a/MWSE/xInventory.cpp
+++ b/MWSE/xInventory.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xInventory::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xInventory: Invalid reference attachment." << std::endl;
 			}
@@ -39,7 +39,7 @@ namespace mwse {
 		}
 
 		NI::IteratedList<TES3::ItemStack*>::Node* firstItem = static_cast<TES3::Actor*>(reference->baseObject)->inventory.itemStacks.head;
-		if (!firstItem) {
+		if (firstItem == NULL) {
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);

--- a/MWSE/xInventory.cpp
+++ b/MWSE/xInventory.cpp
@@ -48,7 +48,7 @@ namespace mwse {
 
 		mwse::Stack::getInstance().pushLong((long)firstItem->next);
 		mwse::Stack::getInstance().pushLong(firstItem->data->count);
-		mwse::Stack::getInstance().pushString(firstItem->data->object->vTable.object->getObjectID(firstItem->data->object));
+		mwse::Stack::getInstance().pushString(firstItem->data->object->getObjectID());
 
 		return 0.0f;
 	}

--- a/MWSE/xInventory.cpp
+++ b/MWSE/xInventory.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xInventory::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xInventory: Invalid reference attachment." << std::endl;
 			}
@@ -39,7 +39,7 @@ namespace mwse {
 		}
 
 		NI::IteratedList<TES3::ItemStack*>::Node* firstItem = static_cast<TES3::Actor*>(reference->baseObject)->inventory.itemStacks.head;
-		if (firstItem == NULL) {
+		if (!firstItem) {
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);

--- a/MWSE/xIsFemale.cpp
+++ b/MWSE/xIsFemale.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xIsFemale::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsFemale: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsFemale.cpp
+++ b/MWSE/xIsFemale.cpp
@@ -28,7 +28,7 @@ namespace mwse {
 			return 0.0f;
 		}
 
-		long isFemale = reference->baseObject->vTable.object->isFemale(reference->baseObject);
+		long isFemale = reference->baseObject->isFemale();
 		mwse::Stack::getInstance().pushLong(isFemale);
 
 		return 0.0f;

--- a/MWSE/xIsFemale.cpp
+++ b/MWSE/xIsFemale.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xIsFemale::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsFemale: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsFemale.cpp
+++ b/MWSE/xIsFemale.cpp
@@ -20,7 +20,7 @@ namespace mwse {
 	float xIsFemale::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsFemale: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsProvider.cpp
+++ b/MWSE/xIsProvider.cpp
@@ -33,12 +33,12 @@ namespace mwse {
 		long classServiceFlags = 0;
 
 		// Get the gold based on the base record type.
-		TES3::AIConfig* aiConfig = reference->baseObject->vTable.object->getAIConfig(reference->baseObject);
+		TES3::AIConfig* aiConfig = reference->baseObject->getAIConfig();
 		if (aiConfig) {
 			npcServiceFlags = aiConfig->merchantFlags & 0x00038800;
 
 			// Get the class flags.
-			TES3::Class* npcClass = reference->baseObject->vTable.object->getClass(reference->baseObject);
+			TES3::Class* npcClass = reference->baseObject->getClass();
 			if (npcClass) {
 				npcServiceFlags = npcClass->services & 0x00038800;
 			}

--- a/MWSE/xIsProvider.cpp
+++ b/MWSE/xIsProvider.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xIsProvider::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsProvider: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsProvider.cpp
+++ b/MWSE/xIsProvider.cpp
@@ -31,16 +31,20 @@ namespace mwse {
 
 		long npcServiceFlags = 0;
 		long classServiceFlags = 0;
-
+		
+		using namespace TES3::ServiceFlag;
+		constexpr auto providerMask = OffersSpells | OffersSpellmaking | OffersEnchanting | OffersRepairs;
+		static_assert(providerMask == 0x38800);
+		
 		// Get the gold based on the base record type.
 		TES3::AIConfig* aiConfig = reference->baseObject->getAIConfig();
 		if (aiConfig) {
-			npcServiceFlags = aiConfig->merchantFlags & 0x00038800;
+			npcServiceFlags = aiConfig->merchantFlags & providerMask;
 
 			// Get the class flags.
 			TES3::Class* npcClass = reference->baseObject->getClass();
 			if (npcClass) {
-				npcServiceFlags = npcClass->services & 0x00038800;
+				npcServiceFlags = npcClass->services & providerMask;
 			}
 		}
 		else {

--- a/MWSE/xIsProvider.cpp
+++ b/MWSE/xIsProvider.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xIsProvider::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsProvider: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsProvider.cpp
+++ b/MWSE/xIsProvider.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xIsProvider::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsProvider: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsTrader.cpp
+++ b/MWSE/xIsTrader.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xIsTrader::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsTrader: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsTrader.cpp
+++ b/MWSE/xIsTrader.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xIsTrader::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsTrader: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsTrader.cpp
+++ b/MWSE/xIsTrader.cpp
@@ -31,16 +31,18 @@ namespace mwse {
 
 		long npcServiceFlags = 0;
 		long classServiceFlags = 0;
+		constexpr auto traderMask = TES3::ServiceFlag::OffersBarteringMask | TES3::ServiceFlag::BartersEnchantedItems;
+		static_assert(traderMask == 0x37FF);
 
 		// Get the gold based on the base record type.
 		TES3::AIConfig* aiConfig = reference->baseObject->getAIConfig();
 		if (aiConfig) {
-			npcServiceFlags = aiConfig->merchantFlags & 0x000037FF;
+			npcServiceFlags = aiConfig->merchantFlags & traderMask;
 
 			// Get the class flags.
 			TES3::Class* npcClass = reference->baseObject->getClass();
 			if (npcClass) {
-				npcServiceFlags = npcClass->services & 0x000037FF;
+				npcServiceFlags = npcClass->services & traderMask;
 			}
 		}
 		else {

--- a/MWSE/xIsTrader.cpp
+++ b/MWSE/xIsTrader.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xIsTrader::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsTrader: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsTrader.cpp
+++ b/MWSE/xIsTrader.cpp
@@ -33,12 +33,12 @@ namespace mwse {
 		long classServiceFlags = 0;
 
 		// Get the gold based on the base record type.
-		TES3::AIConfig* aiConfig = reference->baseObject->vTable.object->getAIConfig(reference->baseObject);
+		TES3::AIConfig* aiConfig = reference->baseObject->getAIConfig();
 		if (aiConfig) {
 			npcServiceFlags = aiConfig->merchantFlags & 0x000037FF;
 
 			// Get the class flags.
-			TES3::Class* npcClass = reference->baseObject->vTable.object->getClass(reference->baseObject);
+			TES3::Class* npcClass = reference->baseObject->getClass();
 			if (npcClass) {
 				npcServiceFlags = npcClass->services & 0x000037FF;
 			}

--- a/MWSE/xIsTrainer.cpp
+++ b/MWSE/xIsTrainer.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xIsTrainer::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsTrader: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsTrainer.cpp
+++ b/MWSE/xIsTrainer.cpp
@@ -33,12 +33,12 @@ namespace mwse {
 		long classServiceFlags = 0;
 
 		// Get the gold based on the base record type.
-		TES3::AIConfig* aiConfig = reference->baseObject->vTable.object->getAIConfig(reference->baseObject);
+		TES3::AIConfig* aiConfig = reference->baseObject->getAIConfig();
 		if (aiConfig) {
 			npcServiceFlags = aiConfig->merchantFlags & 0x00004000;
 
 			// Get the class flags.
-			TES3::Class* npcClass = reference->baseObject->vTable.object->getClass(reference->baseObject);
+			TES3::Class* npcClass = reference->baseObject->getClass();
 			if (npcClass) {
 				npcServiceFlags = npcClass->services & 0x00004000;
 			}

--- a/MWSE/xIsTrainer.cpp
+++ b/MWSE/xIsTrainer.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xIsTrainer::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsTrader: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xIsTrainer.cpp
+++ b/MWSE/xIsTrainer.cpp
@@ -35,12 +35,12 @@ namespace mwse {
 		// Get the gold based on the base record type.
 		TES3::AIConfig* aiConfig = reference->baseObject->getAIConfig();
 		if (aiConfig) {
-			npcServiceFlags = aiConfig->merchantFlags & 0x00004000;
+			npcServiceFlags = aiConfig->merchantFlags & TES3::ServiceFlag::OffersTraining;
 
 			// Get the class flags.
 			TES3::Class* npcClass = reference->baseObject->getClass();
 			if (npcClass) {
-				npcServiceFlags = npcClass->services & 0x00004000;
+				npcServiceFlags = npcClass->services & TES3::ServiceFlag::OffersTraining;
 			}
 		}
 		else {

--- a/MWSE/xIsTrainer.cpp
+++ b/MWSE/xIsTrainer.cpp
@@ -21,7 +21,7 @@ namespace mwse {
 	float xIsTrainer::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xIsTrader: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xModAttribute.cpp
+++ b/MWSE/xModAttribute.cpp
@@ -38,7 +38,7 @@ namespace mwse {
 
 		// Get script reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModAttribute: Called on invalid reference." << std::endl;
 			}
@@ -58,7 +58,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModAttribute: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xModAttribute.cpp
+++ b/MWSE/xModAttribute.cpp
@@ -38,7 +38,7 @@ namespace mwse {
 
 		// Get script reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModAttribute: Called on invalid reference." << std::endl;
 			}
@@ -58,7 +58,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModAttribute: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xModAttribute.cpp
+++ b/MWSE/xModAttribute.cpp
@@ -38,7 +38,7 @@ namespace mwse {
 
 		// Get script reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModAttribute: Called on invalid reference." << std::endl;
 			}
@@ -58,7 +58,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = reference->getAttachedMobileActor();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModAttribute: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xModService.cpp
+++ b/MWSE/xModService.cpp
@@ -29,7 +29,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModService: Called on invalid reference." << std::endl;
 			}
@@ -58,7 +58,7 @@ namespace mwse {
 		}
 
 		long services = aiConfig->merchantFlags | classRecord->services;
-
+		
 		// Want to remove services.
 		if (data < 0) {
 			services = services & (~(0 - data));

--- a/MWSE/xModService.cpp
+++ b/MWSE/xModService.cpp
@@ -29,7 +29,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModService: Called on invalid reference." << std::endl;
 			}
@@ -58,7 +58,7 @@ namespace mwse {
 		}
 
 		long services = aiConfig->merchantFlags | classRecord->services;
-		
+
 		// Want to remove services.
 		if (data < 0) {
 			services = services & (~(0 - data));

--- a/MWSE/xModService.cpp
+++ b/MWSE/xModService.cpp
@@ -29,7 +29,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModService: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xModService.cpp
+++ b/MWSE/xModService.cpp
@@ -38,7 +38,7 @@ namespace mwse {
 		}
 
 		// Get AI configuration.
-		TES3::AIConfig* aiConfig = reference->baseObject->vTable.object->getAIConfig(reference->baseObject);
+		TES3::AIConfig* aiConfig = reference->baseObject->getAIConfig();
 		if (!aiConfig) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModService: Called on non-NPC reference." << std::endl;
@@ -48,7 +48,7 @@ namespace mwse {
 		}
 
 		// Get the NPC's class.
-		TES3::Class* classRecord = reference->baseObject->vTable.object->getClass(reference->baseObject);
+		TES3::Class* classRecord = reference->baseObject->getClass();
 		if (!classRecord) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xModService: Failed to obtain NPC's class." << std::endl;

--- a/MWSE/xModService.cpp
+++ b/MWSE/xModService.cpp
@@ -65,7 +65,7 @@ namespace mwse {
 		}
 		// Want to add services.
 		else {
-			services = services | (data & 0x0003FFFF);
+			services = services | (data & TES3::ServiceFlag::AllServicesMask);
 		}
 
 		aiConfig->merchantFlags = services;

--- a/MWSE/xMyCellID.cpp
+++ b/MWSE/xMyCellID.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 
 	float xMyCellID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xMyCellID: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xMyCellID.cpp
+++ b/MWSE/xMyCellID.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 
 	float xMyCellID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xMyCellID: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xMyCellID.cpp
+++ b/MWSE/xMyCellID.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 
 	float xMyCellID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xMyCellID: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xNextRef.cpp
+++ b/MWSE/xNextRef.cpp
@@ -22,14 +22,14 @@ namespace mwse {
 		TES3::Reference* reference = (TES3::Reference*)mwse::Stack::getInstance().popLong();
 
 		// Start looking for our next reference.
-		TES3::Reference* next = NULL;
+		TES3::Reference* next = nullptr;
 		__try {
 			if (reference) {
 				// Try to get the next non-removed reference linked down from the passed one.
 				next = static_cast<TES3::Reference*>(reference->nextInCollection->skipDeletedObjects());
 
 				// If we found nothing, check the stored exterior references.
-				if (next == NULL && mwse::tes3::exteriorRefs[0] != NULL) {
+				if (!next && mwse::tes3::exteriorRefs[0] != nullptr) {
 					next = mwse::tes3::exteriorRefs[0];
 					for (auto i = 0; i < 8; ++i) {
 						mwse::tes3::exteriorRefs[i] = mwse::tes3::exteriorRefs[i + 1];
@@ -47,7 +47,7 @@ namespace mwse {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xNextRef: Invalid object given in script " << script->sourceMod->filename << "/" << script->header.name << ". Fix script to not save variables across saves!" << std::endl;
 			}
-			next = NULL;
+			next = nullptr;
 		}
 
 		mwse::Stack::getInstance().pushLong((long)next);

--- a/MWSE/xNextRef.cpp
+++ b/MWSE/xNextRef.cpp
@@ -22,14 +22,14 @@ namespace mwse {
 		TES3::Reference* reference = (TES3::Reference*)mwse::Stack::getInstance().popLong();
 
 		// Start looking for our next reference.
-		TES3::Reference* next = NULL;
+		TES3::Reference* next = nullptr;
 		__try {
 			if (reference) {
 				// Try to get the next non-removed reference linked down from the passed one.
 				next = static_cast<TES3::Reference*>(reference->nextInCollection->skipDeletedObjects());
 
 				// If we found nothing, check the stored exterior references.
-				if (next == NULL && mwse::tes3::exteriorRefs[0] != NULL) {
+				if (next == nullptr && mwse::tes3::exteriorRefs[0] != nullptr) {
 					next = mwse::tes3::exteriorRefs[0];
 					for (auto i = 0; i < 8; ++i) {
 						mwse::tes3::exteriorRefs[i] = mwse::tes3::exteriorRefs[i + 1];
@@ -47,7 +47,7 @@ namespace mwse {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xNextRef: Invalid object given in script " << script->sourceMod->filename << "/" << script->header.name << ". Fix script to not save variables across saves!" << std::endl;
 			}
-			next = NULL;
+			next = nullptr;
 		}
 
 		mwse::Stack::getInstance().pushLong((long)next);

--- a/MWSE/xNextRef.cpp
+++ b/MWSE/xNextRef.cpp
@@ -22,14 +22,14 @@ namespace mwse {
 		TES3::Reference* reference = (TES3::Reference*)mwse::Stack::getInstance().popLong();
 
 		// Start looking for our next reference.
-		TES3::Reference* next = nullptr;
+		TES3::Reference* next = NULL;
 		__try {
 			if (reference) {
 				// Try to get the next non-removed reference linked down from the passed one.
 				next = static_cast<TES3::Reference*>(reference->nextInCollection->skipDeletedObjects());
 
 				// If we found nothing, check the stored exterior references.
-				if (!next && mwse::tes3::exteriorRefs[0] != nullptr) {
+				if (next == NULL && mwse::tes3::exteriorRefs[0] != NULL) {
 					next = mwse::tes3::exteriorRefs[0];
 					for (auto i = 0; i < 8; ++i) {
 						mwse::tes3::exteriorRefs[i] = mwse::tes3::exteriorRefs[i + 1];
@@ -47,7 +47,7 @@ namespace mwse {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xNextRef: Invalid object given in script " << script->sourceMod->filename << "/" << script->header.name << ". Fix script to not save variables across saves!" << std::endl;
 			}
-			next = nullptr;
+			next = NULL;
 		}
 
 		mwse::Stack::getInstance().pushLong((long)next);

--- a/MWSE/xNextStack.cpp
+++ b/MWSE/xNextStack.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 	float xNextStack::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get the passed node.
 		auto node = reinterpret_cast<NI::IteratedList<TES3::ItemStack*>::Node*>(mwse::Stack::getInstance().popLong());
-		if (node == NULL) {
+		if (node == nullptr) {
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);

--- a/MWSE/xNextStack.cpp
+++ b/MWSE/xNextStack.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 	float xNextStack::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get the passed node.
 		auto node = reinterpret_cast<NI::IteratedList<TES3::ItemStack*>::Node*>(mwse::Stack::getInstance().popLong());
-		if (node == NULL) {
+		if (!node) {
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);

--- a/MWSE/xNextStack.cpp
+++ b/MWSE/xNextStack.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 	float xNextStack::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get the passed node.
 		auto node = reinterpret_cast<NI::IteratedList<TES3::ItemStack*>::Node*>(mwse::Stack::getInstance().popLong());
-		if (!node) {
+		if (node == NULL) {
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);
 			mwse::Stack::getInstance().pushLong(0);

--- a/MWSE/xNextStack.cpp
+++ b/MWSE/xNextStack.cpp
@@ -28,7 +28,7 @@ namespace mwse {
 
 		mwse::Stack::getInstance().pushLong((long)node->next);
 		mwse::Stack::getInstance().pushLong(node->data->count);
-		mwse::Stack::getInstance().pushString(node->data->object->vTable.object->getObjectID(node->data->object));
+		mwse::Stack::getInstance().pushString(node->data->object->getObjectID());
 
 		return 0.0f;
 	}

--- a/MWSE/xPCCellID.cpp
+++ b/MWSE/xPCCellID.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 
 	float xPCCellID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::DataHandler* masterCell = TES3::DataHandler::get();
-		if (!masterCell) {
+		if (masterCell == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPCCellID: Cell master could not be found." << std::endl;
 			}
@@ -29,7 +29,7 @@ namespace mwse {
 
 		// Determine the PC cell -- either the interior cell if we have one, or the center cell.
 		TES3::Cell* cell = masterCell->currentInteriorCell;
-		if (!cell) {
+		if (cell == NULL) {
 			cell = masterCell->exteriorCellData[TES3::CellGrid::Center]->cell;
 		}
 

--- a/MWSE/xPCCellID.cpp
+++ b/MWSE/xPCCellID.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 
 	float xPCCellID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::DataHandler* masterCell = TES3::DataHandler::get();
-		if (masterCell == NULL) {
+		if (!masterCell) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPCCellID: Cell master could not be found." << std::endl;
 			}
@@ -29,7 +29,7 @@ namespace mwse {
 
 		// Determine the PC cell -- either the interior cell if we have one, or the center cell.
 		TES3::Cell* cell = masterCell->currentInteriorCell;
-		if (cell == NULL) {
+		if (!cell) {
 			cell = masterCell->exteriorCellData[TES3::CellGrid::Center]->cell;
 		}
 

--- a/MWSE/xPCCellID.cpp
+++ b/MWSE/xPCCellID.cpp
@@ -19,7 +19,7 @@ namespace mwse {
 
 	float xPCCellID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::DataHandler* masterCell = TES3::DataHandler::get();
-		if (masterCell == NULL) {
+		if (masterCell == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPCCellID: Cell master could not be found." << std::endl;
 			}
@@ -29,7 +29,7 @@ namespace mwse {
 
 		// Determine the PC cell -- either the interior cell if we have one, or the center cell.
 		TES3::Cell* cell = masterCell->currentInteriorCell;
-		if (cell == NULL) {
+		if (cell == nullptr) {
 			cell = masterCell->exteriorCellData[TES3::CellGrid::Center]->cell;
 		}
 

--- a/MWSE/xPlace.cpp
+++ b/MWSE/xPlace.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference("player");
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPlace: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get the template we're supposed to place.
 		TES3::BaseObject* templateToPlace = virtualMachine.getTemplate(id.c_str());
-		if (templateToPlace == NULL) {
+		if (!templateToPlace) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPlace: No template found for id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xPlace.cpp
+++ b/MWSE/xPlace.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference("player");
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPlace: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get the template we're supposed to place.
 		TES3::BaseObject* templateToPlace = virtualMachine.getTemplate(id.c_str());
-		if (templateToPlace == NULL) {
+		if (templateToPlace == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPlace: No template found for id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xPlace.cpp
+++ b/MWSE/xPlace.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference("player");
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPlace: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get the template we're supposed to place.
 		TES3::BaseObject* templateToPlace = virtualMachine.getTemplate(id.c_str());
-		if (!templateToPlace) {
+		if (templateToPlace == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPlace: No template found for id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xPosition.cpp
+++ b/MWSE/xPosition.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get other context information for original opcode.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPosition: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xPosition.cpp
+++ b/MWSE/xPosition.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get other context information for original opcode.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPosition: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xPosition.cpp
+++ b/MWSE/xPosition.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get other context information for original opcode.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPosition: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xPositionCell.cpp
+++ b/MWSE/xPositionCell.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get other context information for original opcode.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPositionCell: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xPositionCell.cpp
+++ b/MWSE/xPositionCell.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get other context information for original opcode.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPositionCell: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xPositionCell.cpp
+++ b/MWSE/xPositionCell.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get other context information for original opcode.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xPositionCell: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xRefID.cpp
+++ b/MWSE/xRefID.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 
 	float xRefID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRefID: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xRefID.cpp
+++ b/MWSE/xRefID.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 
 	float xRefID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRefID: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xRefID.cpp
+++ b/MWSE/xRefID.cpp
@@ -18,7 +18,7 @@ namespace mwse {
 
 	float xRefID::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRefID: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xRefType.cpp
+++ b/MWSE/xRefType.cpp
@@ -17,7 +17,7 @@ namespace mwse {
 
 	float xRefType::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::Reference* refr = virtualMachine.getReference();
-		if (refr == NULL) {
+		if (!refr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRefType: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xRefType.cpp
+++ b/MWSE/xRefType.cpp
@@ -17,7 +17,7 @@ namespace mwse {
 
 	float xRefType::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::Reference* refr = virtualMachine.getReference();
-		if (!refr) {
+		if (refr == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRefType: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xRefType.cpp
+++ b/MWSE/xRefType.cpp
@@ -17,7 +17,7 @@ namespace mwse {
 
 	float xRefType::execute(mwse::VMExecuteInterface& virtualMachine) {
 		TES3::Reference* refr = virtualMachine.getReference();
-		if (refr == NULL) {
+		if (refr == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRefType: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xRemoveItem.cpp
+++ b/MWSE/xRemoveItem.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveItem: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (!itemTemplate) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveItem: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xRemoveItem.cpp
+++ b/MWSE/xRemoveItem.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveItem: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (itemTemplate == NULL) {
+		if (itemTemplate == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveItem: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xRemoveItem.cpp
+++ b/MWSE/xRemoveItem.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveItem: Called on invalid reference." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* itemTemplate = virtualMachine.getTemplate(id.c_str());
-		if (!itemTemplate) {
+		if (itemTemplate == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveItem: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xRemoveSpell.cpp
+++ b/MWSE/xRemoveSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveSpell: Called on invalid reference." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (spellTemplate == NULL) {
+		if (spellTemplate == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xRemoveSpell.cpp
+++ b/MWSE/xRemoveSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveSpell: Called on invalid reference." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (spellTemplate == NULL) {
+		if (!spellTemplate) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xRemoveSpell.cpp
+++ b/MWSE/xRemoveSpell.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveSpell: Called on invalid reference." << std::endl;
 			}
@@ -32,7 +32,7 @@ namespace mwse {
 
 		// Get spell template by the id.
 		TES3::BaseObject* spellTemplate = virtualMachine.getTemplate(id.c_str());
-		if (!spellTemplate) {
+		if (spellTemplate == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xRemoveSpell: No template found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xScriptRunning.cpp
+++ b/MWSE/xScriptRunning.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Try to get the target script.
 		TES3::Script* targetScript = TES3::DataHandler::get()->nonDynamicData->findScriptByName(scriptName.c_str());
-		if (!targetScript) {
+		if (targetScript == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xScriptRunning: No script could be found with name '" << scriptName << "'." << std::endl;
 			}

--- a/MWSE/xScriptRunning.cpp
+++ b/MWSE/xScriptRunning.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Try to get the target script.
 		TES3::Script* targetScript = TES3::DataHandler::get()->nonDynamicData->findScriptByName(scriptName.c_str());
-		if (targetScript == NULL) {
+		if (!targetScript) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xScriptRunning: No script could be found with name '" << scriptName << "'." << std::endl;
 			}

--- a/MWSE/xScriptRunning.cpp
+++ b/MWSE/xScriptRunning.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Try to get the target script.
 		TES3::Script* targetScript = TES3::DataHandler::get()->nonDynamicData->findScriptByName(scriptName.c_str());
-		if (targetScript == NULL) {
+		if (targetScript == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xScriptRunning: No script could be found with name '" << scriptName << "'." << std::endl;
 			}

--- a/MWSE/xSetBaseGold.cpp
+++ b/MWSE/xSetBaseGold.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetBaseGold: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xSetBaseGold.cpp
+++ b/MWSE/xSetBaseGold.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetBaseGold: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xSetBaseGold.cpp
+++ b/MWSE/xSetBaseGold.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetBaseGold: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xSetCharge.cpp
+++ b/MWSE/xSetCharge.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetCharge: No reference provided." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (!record) {
+		if (record == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xSetCharge.cpp
+++ b/MWSE/xSetCharge.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetCharge: No reference provided." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (record == NULL) {
+		if (record == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xSetCharge.cpp
+++ b/MWSE/xSetCharge.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetCharge: No reference provided." << std::endl;
 			}
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (record == NULL) {
+		if (!record) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xSetCondition.cpp
+++ b/MWSE/xSetCondition.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				log::getLog() << "xSetCondition: No reference provided." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get associated varnode, and the condition from it.
 		auto varNode = reference->getAttachedItemData();
-		if (varNode != NULL) {
+		if (varNode != nullptr) {
 			varNode->condition = value;
 		}
 		else {

--- a/MWSE/xSetCondition.cpp
+++ b/MWSE/xSetCondition.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				log::getLog() << "xSetCondition: No reference provided." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get associated varnode, and the condition from it.
 		auto varNode = reference->getAttachedItemData();
-		if (varNode != NULL) {
+		if (varNode) {
 			varNode->condition = value;
 		}
 		else {

--- a/MWSE/xSetCondition.cpp
+++ b/MWSE/xSetCondition.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				log::getLog() << "xSetCondition: No reference provided." << std::endl;
 			}
@@ -33,7 +33,7 @@ namespace mwse {
 
 		// Get associated varnode, and the condition from it.
 		auto varNode = reference->getAttachedItemData();
-		if (varNode) {
+		if (varNode != NULL) {
 			varNode->condition = value;
 		}
 		else {

--- a/MWSE/xSetEffectInfo.cpp
+++ b/MWSE/xSetEffectInfo.cpp
@@ -37,7 +37,7 @@ namespace mwse {
 		// Validate effect index.
 		if (effectIndex >= 1 && effectIndex <= 8) {
 			// Get the desired effect.
-			TES3::Effect* effects = nullptr;
+			TES3::Effect* effects = NULL;
 			if (targetType == TES3::ObjectType::Spell) {
 				TES3::Spell* spell = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Spell>(targetId);
 				if (spell) {

--- a/MWSE/xSetEffectInfo.cpp
+++ b/MWSE/xSetEffectInfo.cpp
@@ -37,7 +37,7 @@ namespace mwse {
 		// Validate effect index.
 		if (effectIndex >= 1 && effectIndex <= 8) {
 			// Get the desired effect.
-			TES3::Effect* effects = NULL;
+			TES3::Effect* effects = nullptr;
 			if (targetType == TES3::ObjectType::Spell) {
 				TES3::Spell* spell = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Spell>(targetId);
 				if (spell) {

--- a/MWSE/xSetEnchantInfo.cpp
+++ b/MWSE/xSetEnchantInfo.cpp
@@ -47,7 +47,7 @@ namespace mwse {
 		enchant->castType = static_cast<TES3::EnchantmentCastType>(type);
 		enchant->chargeCost = static_cast<unsigned short>(cost);
 		enchant->maxCharge = static_cast<unsigned short>(charge);
-		enchant->vTable.object->setAutoCalc(enchant, autocalc);
+		enchant->setAutoCalc(autocalc);
 
 		mwse::Stack::getInstance().pushLong(true);
 		return 0.0f;

--- a/MWSE/xSetEnchantInfo.cpp
+++ b/MWSE/xSetEnchantInfo.cpp
@@ -35,7 +35,7 @@ namespace mwse {
 		}
 
 		const auto enchant = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Enchantment>(enchantId);
-		if (enchant == NULL) {
+		if (!enchant) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetEnchantInfo: No effect found given id '" << enchantId << "'." << std::endl;
 			}

--- a/MWSE/xSetEnchantInfo.cpp
+++ b/MWSE/xSetEnchantInfo.cpp
@@ -35,7 +35,7 @@ namespace mwse {
 		}
 
 		const auto enchant = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Enchantment>(enchantId);
-		if (enchant == NULL) {
+		if (enchant == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetEnchantInfo: No effect found given id '" << enchantId << "'." << std::endl;
 			}

--- a/MWSE/xSetEnchantInfo.cpp
+++ b/MWSE/xSetEnchantInfo.cpp
@@ -35,7 +35,7 @@ namespace mwse {
 		}
 
 		const auto enchant = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Enchantment>(enchantId);
-		if (!enchant) {
+		if (enchant == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetEnchantInfo: No effect found given id '" << enchantId << "'." << std::endl;
 			}

--- a/MWSE/xSetGlobal.cpp
+++ b/MWSE/xSetGlobal.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		float value = Stack::getInstance().popFloat();
 
 		TES3::GlobalVariable* global = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(variable.c_str());
-		if (!global) {
+		if (global == NULL) {
 			mwse::log::getLog() << "xSetGlobal: No global could be found with id '" << variable << "'." << std::endl;
 			mwse::Stack::getInstance().pushLong(false);
 			return 0.0f;

--- a/MWSE/xSetGlobal.cpp
+++ b/MWSE/xSetGlobal.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		float value = Stack::getInstance().popFloat();
 
 		TES3::GlobalVariable* global = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(variable.c_str());
-		if (global == NULL) {
+		if (!global) {
 			mwse::log::getLog() << "xSetGlobal: No global could be found with id '" << variable << "'." << std::endl;
 			mwse::Stack::getInstance().pushLong(false);
 			return 0.0f;

--- a/MWSE/xSetGlobal.cpp
+++ b/MWSE/xSetGlobal.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 		float value = Stack::getInstance().popFloat();
 
 		TES3::GlobalVariable* global = TES3::DataHandler::get()->nonDynamicData->findGlobalVariable(variable.c_str());
-		if (global == NULL) {
+		if (global == nullptr) {
 			mwse::log::getLog() << "xSetGlobal: No global could be found with id '" << variable << "'." << std::endl;
 			mwse::Stack::getInstance().pushLong(false);
 			return 0.0f;

--- a/MWSE/xSetIngredientEffect.cpp
+++ b/MWSE/xSetIngredientEffect.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get the ingredient.
 		const auto ingredient = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Ingredient>(id);
-		if (ingredient == NULL) {
+		if (ingredient == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetIngredientEffect: No ingredient record found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xSetIngredientEffect.cpp
+++ b/MWSE/xSetIngredientEffect.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get the ingredient.
 		const auto ingredient = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Ingredient>(id);
-		if (ingredient == NULL) {
+		if (!ingredient) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetIngredientEffect: No ingredient record found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xSetIngredientEffect.cpp
+++ b/MWSE/xSetIngredientEffect.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get the ingredient.
 		const auto ingredient = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Ingredient>(id);
-		if (!ingredient) {
+		if (ingredient == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetIngredientEffect: No ingredient record found with id '" << id << "'." << std::endl;
 			}

--- a/MWSE/xSetLevel.cpp
+++ b/MWSE/xSetLevel.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetLevel: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xSetLevel.cpp
+++ b/MWSE/xSetLevel.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetLevel: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xSetLevel.cpp
+++ b/MWSE/xSetLevel.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetLevel: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xSetMaxCharge.cpp
+++ b/MWSE/xSetMaxCharge.cpp
@@ -44,7 +44,7 @@ namespace mwse {
 		}
 
 		// If we found an enchantment record, set the max charge.
-		TES3::Enchantment* enchantment = object->vTable.object->getEnchantment(object);
+		TES3::Enchantment* enchantment = object->getEnchantment();
 		if (enchantment) {
 			enchantment->maxCharge = static_cast<unsigned short>(maxCharge);
 

--- a/MWSE/xSetMaxCharge.cpp
+++ b/MWSE/xSetMaxCharge.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCharge: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (object == NULL) {
+		if (!object) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xSetMaxCharge.cpp
+++ b/MWSE/xSetMaxCharge.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCharge: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (!object) {
+		if (object == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xSetMaxCharge.cpp
+++ b/MWSE/xSetMaxCharge.cpp
@@ -25,7 +25,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCharge: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::Object* object = reference->baseObject;
-		if (object == NULL) {
+		if (object == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCharge: No record found for reference." << std::endl;
 			}

--- a/MWSE/xSetMaxCondition.cpp
+++ b/MWSE/xSetMaxCondition.cpp
@@ -29,7 +29,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCondition: No reference provided." << std::endl;
 			}
@@ -39,7 +39,7 @@ namespace mwse {
 
 		// Get the base object.
 		TES3::BaseObject* object = reference->baseObject;
-		if (object == NULL) {
+		if (object == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCondition: No object found for reference." << std::endl;
 			}

--- a/MWSE/xSetMaxCondition.cpp
+++ b/MWSE/xSetMaxCondition.cpp
@@ -29,7 +29,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCondition: No reference provided." << std::endl;
 			}
@@ -39,7 +39,7 @@ namespace mwse {
 
 		// Get the base object.
 		TES3::BaseObject* object = reference->baseObject;
-		if (object == NULL) {
+		if (!object) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCondition: No object found for reference." << std::endl;
 			}

--- a/MWSE/xSetMaxCondition.cpp
+++ b/MWSE/xSetMaxCondition.cpp
@@ -29,7 +29,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCondition: No reference provided." << std::endl;
 			}
@@ -39,7 +39,7 @@ namespace mwse {
 
 		// Get the base object.
 		TES3::BaseObject* object = reference->baseObject;
-		if (!object) {
+		if (object == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetMaxCondition: No object found for reference." << std::endl;
 			}

--- a/MWSE/xSetName.cpp
+++ b/MWSE/xSetName.cpp
@@ -39,7 +39,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetName: No reference provided." << std::endl;
 			}
@@ -49,7 +49,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::BaseObject* recordGeneric = reference->baseObject;
-		if (recordGeneric == NULL) {
+		if (!recordGeneric) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetName: No record found for reference." << std::endl;
 			}
@@ -58,8 +58,8 @@ namespace mwse {
 		}
 
 		// Get string pointer based on record type.
-		char* namePtr = NULL;
-		char** nameContainer = NULL;
+		char* namePtr = nullptr;
+		char** nameContainer = nullptr;
 		TES3::ObjectType::ObjectType recordType = recordGeneric->objectType;
 		switch (recordType) {
 		case TES3::ObjectType::NPC:
@@ -104,7 +104,7 @@ namespace mwse {
 		}
 
 		// Bail out if we haven't found the name.
-		if (namePtr == NULL) {
+		if (!namePtr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetName: Unsupported record format: " << recordType << "." << std::endl;
 			}
@@ -113,7 +113,7 @@ namespace mwse {
 		}
 
 		// Some strings might need to be recreated.
-		if (nameContainer != NULL && name.length() > strlen(namePtr)) {
+		if (nameContainer != nullptr && name.length() > strlen(namePtr)) {
 			namePtr = reinterpret_cast<char*>(se::memory::realloc(namePtr, name.length() + 1));
 			*nameContainer = namePtr;
 		}

--- a/MWSE/xSetName.cpp
+++ b/MWSE/xSetName.cpp
@@ -39,7 +39,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetName: No reference provided." << std::endl;
 			}
@@ -49,7 +49,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::BaseObject* recordGeneric = reference->baseObject;
-		if (recordGeneric == NULL) {
+		if (recordGeneric == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetName: No record found for reference." << std::endl;
 			}
@@ -58,8 +58,8 @@ namespace mwse {
 		}
 
 		// Get string pointer based on record type.
-		char* namePtr = NULL;
-		char** nameContainer = NULL;
+		char* namePtr = nullptr;
+		char** nameContainer = nullptr;
 		TES3::ObjectType::ObjectType recordType = recordGeneric->objectType;
 		switch (recordType) {
 		case TES3::ObjectType::NPC:
@@ -104,7 +104,7 @@ namespace mwse {
 		}
 
 		// Bail out if we haven't found the name.
-		if (namePtr == NULL) {
+		if (namePtr == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetName: Unsupported record format: " << recordType << "." << std::endl;
 			}
@@ -113,7 +113,7 @@ namespace mwse {
 		}
 
 		// Some strings might need to be recreated.
-		if (nameContainer != NULL && name.length() > strlen(namePtr)) {
+		if (nameContainer != nullptr && name.length() > strlen(namePtr)) {
 			namePtr = reinterpret_cast<char*>(se::memory::realloc(namePtr, name.length() + 1));
 			*nameContainer = namePtr;
 		}

--- a/MWSE/xSetName.cpp
+++ b/MWSE/xSetName.cpp
@@ -39,7 +39,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetName: No reference provided." << std::endl;
 			}
@@ -49,7 +49,7 @@ namespace mwse {
 
 		// Get the base record.
 		TES3::BaseObject* recordGeneric = reference->baseObject;
-		if (!recordGeneric) {
+		if (recordGeneric == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetName: No record found for reference." << std::endl;
 			}
@@ -58,8 +58,8 @@ namespace mwse {
 		}
 
 		// Get string pointer based on record type.
-		char* namePtr = nullptr;
-		char** nameContainer = nullptr;
+		char* namePtr = NULL;
+		char** nameContainer = NULL;
 		TES3::ObjectType::ObjectType recordType = recordGeneric->objectType;
 		switch (recordType) {
 		case TES3::ObjectType::NPC:
@@ -104,7 +104,7 @@ namespace mwse {
 		}
 
 		// Bail out if we haven't found the name.
-		if (!namePtr) {
+		if (namePtr == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetName: Unsupported record format: " << recordType << "." << std::endl;
 			}
@@ -113,7 +113,7 @@ namespace mwse {
 		}
 
 		// Some strings might need to be recreated.
-		if (nameContainer != nullptr && name.length() > strlen(namePtr)) {
+		if (nameContainer != NULL && name.length() > strlen(namePtr)) {
 			namePtr = reinterpret_cast<char*>(se::memory::realloc(namePtr, name.length() + 1));
 			*nameContainer = namePtr;
 		}

--- a/MWSE/xSetProgressLevel.cpp
+++ b/MWSE/xSetProgressLevel.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = TES3::WorldController::get()->getMobilePlayer();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetProgressLevel: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xSetProgressLevel.cpp
+++ b/MWSE/xSetProgressLevel.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = TES3::WorldController::get()->getMobilePlayer();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetProgressLevel: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xSetProgressLevel.cpp
+++ b/MWSE/xSetProgressLevel.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = TES3::WorldController::get()->getMobilePlayer();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetProgressLevel: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xSetProgressSkill.cpp
+++ b/MWSE/xSetProgressSkill.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = TES3::WorldController::get()->getMobilePlayer();
-		if (mobileObject == NULL) {
+		if (!mobileObject) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetProgressSkill: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xSetProgressSkill.cpp
+++ b/MWSE/xSetProgressSkill.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = TES3::WorldController::get()->getMobilePlayer();
-		if (!mobileObject) {
+		if (mobileObject == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetProgressSkill: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xSetProgressSkill.cpp
+++ b/MWSE/xSetProgressSkill.cpp
@@ -27,7 +27,7 @@ namespace mwse {
 
 		// Get the associated MACP record.
 		auto mobileObject = TES3::WorldController::get()->getMobilePlayer();
-		if (mobileObject == NULL) {
+		if (mobileObject == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetProgressSkill: Could not find MACP record for reference." << std::endl;
 			}

--- a/MWSE/xSetQuality.cpp
+++ b/MWSE/xSetQuality.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetQuality: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (record == NULL) {
+		if (record == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetQuality: No base record found." << std::endl;
 			}

--- a/MWSE/xSetQuality.cpp
+++ b/MWSE/xSetQuality.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetQuality: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (record == NULL) {
+		if (!record) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetQuality: No base record found." << std::endl;
 			}

--- a/MWSE/xSetQuality.cpp
+++ b/MWSE/xSetQuality.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetQuality: No reference provided." << std::endl;
 			}
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (!record) {
+		if (record == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetQuality: No base record found." << std::endl;
 			}

--- a/MWSE/xSetService.cpp
+++ b/MWSE/xSetService.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetService: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xSetService.cpp
+++ b/MWSE/xSetService.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetService: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xSetService.cpp
+++ b/MWSE/xSetService.cpp
@@ -1,6 +1,7 @@
 #include "VMExecuteInterface.h"
 #include "Stack.h"
 #include "InstructionInterface.h"
+#include "TES3Class.h"
 #include "TES3Util.h"
 #include "TES3NPC.h"
 #include "TES3Reference.h"
@@ -19,7 +20,7 @@ namespace mwse {
 
 	float xSetService::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get parameters.
-		long flags = mwse::Stack::getInstance().popLong() & 0x0003FFFF;
+		long flags = mwse::Stack::getInstance().popLong() & TES3::ServiceFlag::AllServicesMask;
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();

--- a/MWSE/xSetService.cpp
+++ b/MWSE/xSetService.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetService: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xSetService.cpp
+++ b/MWSE/xSetService.cpp
@@ -32,7 +32,7 @@ namespace mwse {
 		}
 
 		// Set service mask.
-		TES3::AIConfig* aiConfig = reference->baseObject->vTable.object->getAIConfig(reference->baseObject);
+		TES3::AIConfig* aiConfig = reference->baseObject->getAIConfig();
 		if (aiConfig) {
 			aiConfig->merchantFlags = flags;
 		}

--- a/MWSE/xSetSpellInfo.cpp
+++ b/MWSE/xSetSpellInfo.cpp
@@ -55,7 +55,7 @@ namespace mwse {
 
 		// Get spell data by id.
 		const auto spell = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Spell>(spellId);;
-		if (spell == NULL) {
+		if (spell == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetSpellInfo: Could not find spell of id '" << spellId << "'" << std::endl;
 			}

--- a/MWSE/xSetSpellInfo.cpp
+++ b/MWSE/xSetSpellInfo.cpp
@@ -55,7 +55,7 @@ namespace mwse {
 
 		// Get spell data by id.
 		const auto spell = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Spell>(spellId);;
-		if (!spell) {
+		if (spell == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetSpellInfo: Could not find spell of id '" << spellId << "'" << std::endl;
 			}

--- a/MWSE/xSetSpellInfo.cpp
+++ b/MWSE/xSetSpellInfo.cpp
@@ -55,7 +55,7 @@ namespace mwse {
 
 		// Get spell data by id.
 		const auto spell = TES3::DataHandler::get()->nonDynamicData->resolveObjectByType<TES3::Spell>(spellId);;
-		if (spell == NULL) {
+		if (!spell) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetSpellInfo: Could not find spell of id '" << spellId << "'" << std::endl;
 			}

--- a/MWSE/xSetTrap.cpp
+++ b/MWSE/xSetTrap.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		// Get reference to what we're finding the trap of.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetTrap: No reference provided." << std::endl;
 			}
@@ -51,7 +51,7 @@ namespace mwse {
 		}
 
 		// If we have a spellId, set it. Otherwise we'll clear it.
-		TES3::Spell* spell = nullptr;
+		TES3::Spell* spell = NULL;
 		if (spellId) {
 			// Get the spell based on the ID given.
 			mwseString& spellObjId = virtualMachine.getString(spellId);

--- a/MWSE/xSetTrap.cpp
+++ b/MWSE/xSetTrap.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		// Get reference to what we're finding the trap of.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetTrap: No reference provided." << std::endl;
 			}
@@ -51,7 +51,7 @@ namespace mwse {
 		}
 
 		// If we have a spellId, set it. Otherwise we'll clear it.
-		TES3::Spell* spell = NULL;
+		TES3::Spell* spell = nullptr;
 		if (spellId) {
 			// Get the spell based on the ID given.
 			mwseString& spellObjId = virtualMachine.getString(spellId);

--- a/MWSE/xSetTrap.cpp
+++ b/MWSE/xSetTrap.cpp
@@ -22,7 +22,7 @@ namespace mwse {
 
 		// Get reference to what we're finding the trap of.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetTrap: No reference provided." << std::endl;
 			}
@@ -51,7 +51,7 @@ namespace mwse {
 		}
 
 		// If we have a spellId, set it. Otherwise we'll clear it.
-		TES3::Spell* spell = NULL;
+		TES3::Spell* spell = nullptr;
 		if (spellId) {
 			// Get the spell based on the ID given.
 			mwseString& spellObjId = virtualMachine.getString(spellId);

--- a/MWSE/xSetValue.cpp
+++ b/MWSE/xSetValue.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetValue: No reference provided." << std::endl;
 			}
@@ -41,7 +41,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (!record) {
+		if (record == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetValue: No base record found." << std::endl;
 			}

--- a/MWSE/xSetValue.cpp
+++ b/MWSE/xSetValue.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetValue: No reference provided." << std::endl;
 			}
@@ -41,7 +41,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (record == NULL) {
+		if (!record) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetValue: No base record found." << std::endl;
 			}

--- a/MWSE/xSetValue.cpp
+++ b/MWSE/xSetValue.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetValue: No reference provided." << std::endl;
 			}
@@ -41,7 +41,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (record == NULL) {
+		if (record == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetValue: No base record found." << std::endl;
 			}

--- a/MWSE/xSetWeight.cpp
+++ b/MWSE/xSetWeight.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetWeight: No reference provided." << std::endl;
 			}
@@ -41,7 +41,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (!record) {
+		if (record == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetWeight: No base record found." << std::endl;
 			}

--- a/MWSE/xSetWeight.cpp
+++ b/MWSE/xSetWeight.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetWeight: No reference provided." << std::endl;
 			}
@@ -41,7 +41,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (record == NULL) {
+		if (record == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetWeight: No base record found." << std::endl;
 			}

--- a/MWSE/xSetWeight.cpp
+++ b/MWSE/xSetWeight.cpp
@@ -31,7 +31,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetWeight: No reference provided." << std::endl;
 			}
@@ -41,7 +41,7 @@ namespace mwse {
 
 		// Get record.
 		TES3::BaseObject* record = reference->baseObject;
-		if (record == NULL) {
+		if (!record) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSetWeight: No base record found." << std::endl;
 			}

--- a/MWSE/xSpellList.cpp
+++ b/MWSE/xSpellList.cpp
@@ -26,8 +26,8 @@ namespace mwse {
 
 		// Arguments we will be returning.
 		long spellCount = 0;
-		char* spellId = NULL;
-		char* spellName = NULL;
+		char* spellId = nullptr;
+		char* spellName = nullptr;
 		long spellType = 0;
 		long spellCost = 0;
 		long spellEffectCount = 0;
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the reference we're checking.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSpellList: Could not get reference." << std::endl;
 			}
@@ -60,11 +60,11 @@ namespace mwse {
 
 
 		// If we're not provided a node, get the first node of the NPC.
-		if (node == NULL) {
+		if (node == nullptr) {
 			node = npc->spellList.list.head;
 
-			// If the node is still NULL, the reference has no spells.
-			if (node == NULL) {
+			// If the node is still nullptr, the reference has no spells.
+			if (node == nullptr) {
 				pushErrorResponse();
 				return 0.0f;
 			}

--- a/MWSE/xSpellList.cpp
+++ b/MWSE/xSpellList.cpp
@@ -26,8 +26,8 @@ namespace mwse {
 
 		// Arguments we will be returning.
 		long spellCount = 0;
-		char* spellId = NULL;
-		char* spellName = NULL;
+		char* spellId = nullptr;
+		char* spellName = nullptr;
 		long spellType = 0;
 		long spellCost = 0;
 		long spellEffectCount = 0;
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the reference we're checking.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSpellList: Could not get reference." << std::endl;
 			}
@@ -60,11 +60,11 @@ namespace mwse {
 
 
 		// If we're not provided a node, get the first node of the NPC.
-		if (node == NULL) {
+		if (!node) {
 			node = npc->spellList.list.head;
 
-			// If the node is still NULL, the reference has no spells.
-			if (node == NULL) {
+			// If the node is still nullptr, the reference has no spells.
+			if (!node) {
 				pushErrorResponse();
 				return 0.0f;
 			}

--- a/MWSE/xSpellList.cpp
+++ b/MWSE/xSpellList.cpp
@@ -26,8 +26,8 @@ namespace mwse {
 
 		// Arguments we will be returning.
 		long spellCount = 0;
-		char* spellId = nullptr;
-		char* spellName = nullptr;
+		char* spellId = NULL;
+		char* spellName = NULL;
 		long spellType = 0;
 		long spellCost = 0;
 		long spellEffectCount = 0;
@@ -35,7 +35,7 @@ namespace mwse {
 
 		// Get the reference we're checking.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xSpellList: Could not get reference." << std::endl;
 			}
@@ -60,11 +60,11 @@ namespace mwse {
 
 
 		// If we're not provided a node, get the first node of the NPC.
-		if (!node) {
+		if (node == NULL) {
 			node = npc->spellList.list.head;
 
-			// If the node is still nullptr, the reference has no spells.
-			if (!node) {
+			// If the node is still NULL, the reference has no spells.
+			if (node == NULL) {
 				pushErrorResponse();
 				return 0.0f;
 			}

--- a/MWSE/xStartCombat.cpp
+++ b/MWSE/xStartCombat.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (!reference) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xStartCombat: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xStartCombat.cpp
+++ b/MWSE/xStartCombat.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (!reference) {
+		if (reference == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xStartCombat: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xStartCombat.cpp
+++ b/MWSE/xStartCombat.cpp
@@ -23,7 +23,7 @@ namespace mwse {
 
 		// Get reference.
 		TES3::Reference* reference = virtualMachine.getReference();
-		if (reference == NULL) {
+		if (reference == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xStartCombat: Called on invalid reference." << std::endl;
 			}

--- a/MWSE/xStartScript.cpp
+++ b/MWSE/xStartScript.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Try to get the target script.
 		TES3::Script* targetScript = TES3::DataHandler::get()->nonDynamicData->findScriptByName(scriptName.c_str());
-		if (!targetScript) {
+		if (targetScript == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xStartScript: No script could be found with name '" << scriptName << "'." << std::endl;
 			}

--- a/MWSE/xStartScript.cpp
+++ b/MWSE/xStartScript.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Try to get the target script.
 		TES3::Script* targetScript = TES3::DataHandler::get()->nonDynamicData->findScriptByName(scriptName.c_str());
-		if (targetScript == NULL) {
+		if (targetScript == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xStartScript: No script could be found with name '" << scriptName << "'." << std::endl;
 			}

--- a/MWSE/xStartScript.cpp
+++ b/MWSE/xStartScript.cpp
@@ -26,7 +26,7 @@ namespace mwse {
 
 		// Try to get the target script.
 		TES3::Script* targetScript = TES3::DataHandler::get()->nonDynamicData->findScriptByName(scriptName.c_str());
-		if (targetScript == NULL) {
+		if (!targetScript) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xStartScript: No script could be found with name '" << scriptName << "'." << std::endl;
 			}

--- a/MWSE/xStopScript.cpp
+++ b/MWSE/xStopScript.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 	float xStopScript::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get parameter: script name. We allow a value of 0 to target the current script.
 		long scriptNameId = mwse::Stack::getInstance().popLong();
-		const char* scriptName = NULL;
+		const char* scriptName = nullptr;
 		if (scriptNameId == 0) {
 			scriptName = virtualMachine.getScript()->header.name;
 		}
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Try to get the target script.
 		TES3::Script* targetScript = TES3::DataHandler::get()->nonDynamicData->findScriptByName(scriptName);
-		if (targetScript == NULL) {
+		if (!targetScript) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xStopScript: No script could be found with name '" << scriptName << "'." << std::endl;
 			}

--- a/MWSE/xStopScript.cpp
+++ b/MWSE/xStopScript.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 	float xStopScript::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get parameter: script name. We allow a value of 0 to target the current script.
 		long scriptNameId = mwse::Stack::getInstance().popLong();
-		const char* scriptName = NULL;
+		const char* scriptName = nullptr;
 		if (scriptNameId == 0) {
 			scriptName = virtualMachine.getScript()->header.name;
 		}
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Try to get the target script.
 		TES3::Script* targetScript = TES3::DataHandler::get()->nonDynamicData->findScriptByName(scriptName);
-		if (targetScript == NULL) {
+		if (targetScript == nullptr) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xStopScript: No script could be found with name '" << scriptName << "'." << std::endl;
 			}

--- a/MWSE/xStopScript.cpp
+++ b/MWSE/xStopScript.cpp
@@ -24,7 +24,7 @@ namespace mwse {
 	float xStopScript::execute(mwse::VMExecuteInterface& virtualMachine) {
 		// Get parameter: script name. We allow a value of 0 to target the current script.
 		long scriptNameId = mwse::Stack::getInstance().popLong();
-		const char* scriptName = nullptr;
+		const char* scriptName = NULL;
 		if (scriptNameId == 0) {
 			scriptName = virtualMachine.getScript()->header.name;
 		}
@@ -34,7 +34,7 @@ namespace mwse {
 
 		// Try to get the target script.
 		TES3::Script* targetScript = TES3::DataHandler::get()->nonDynamicData->findScriptByName(scriptName);
-		if (!targetScript) {
+		if (targetScript == NULL) {
 			if constexpr (DEBUG_MWSCRIPT_FUNCTIONS) {
 				mwse::log::getLog() << "xStopScript: No script could be found with name '" << scriptName << "'." << std::endl;
 			}

--- a/MWSE/xStringParse.cpp
+++ b/MWSE/xStringParse.cpp
@@ -34,14 +34,12 @@ namespace mwse {
 		se::string::enumerate(format.c_str(), resultCount, eolMode);
 		resultCount++;
 
-		long* results = new long[resultCount];
-		se::string::secernate(format.c_str(), string.c_str(), results, resultCount);
+		std::vector<long> results(resultCount);
+		se::string::secernate(format.c_str(), string.c_str(), results.data(), resultCount);
 
 		while (resultCount--) {
 			mwse::Stack::getInstance().pushLong(results[resultCount]);
 		}
-
-		delete[] results;
 
 		return 0.0f;
 	}

--- a/MWSE/xTextInput.cpp
+++ b/MWSE/xTextInput.cpp
@@ -2,6 +2,7 @@
 #include "Stack.h"
 #include "InstructionInterface.h"
 #include "TES3Util.h"
+#include "BitUtil.h"
 #include "StringUtil.h"
 
 
@@ -22,7 +23,7 @@ namespace mwse {
 	static std::map<int, char> keyCharMap;
 
 	bool xTextInput::GetKeyIsPressed(int VK_key) {
-		return (GetAsyncKeyState(VK_key) & 0x8001) == 0x8001;
+		return BITMASK_TEST(GetAsyncKeyState(VK_key), 0x8001);
 	}
 
 	float xTextInput::execute(mwse::VMExecuteInterface& virtualMachine) {

--- a/MWSE/xTextInputAlt.cpp
+++ b/MWSE/xTextInputAlt.cpp
@@ -2,6 +2,7 @@
 #include "Stack.h"
 #include "InstructionInterface.h"
 #include "TES3Util.h"
+#include "BitUtil.h"
 #include "StringUtil.h"
 
 
@@ -22,7 +23,7 @@ namespace mwse {
 	static std::map<int, char> keyCharMap;
 
 	bool xTextInputAlt::GetKeyIsPressed(int VK_key) {
-		return (GetAsyncKeyState(VK_key) & 0x8001) == 0x8001;
+		return BITMASK_TEST(GetAsyncKeyState(VK_key), 0x8001);
 	}
 
 	float xTextInputAlt::execute(mwse::VMExecuteInterface& virtualMachine) {


### PR DESCRIPTION
Started with the intention of replacing NULL usage with nullptr. In the process, I also came across other things I could update:

- Use our vTable wrappers instead of directly calling vTable methods on `TES3::Object`.
- Added some masks when dealing with bitfield flags instead of masking with magic numbers
- Use existing iterators/helper methods on collections
- Found one instance of manual distance calculation for 2 `Point3`s. Use available method instead
- Use available BitUtil defines  