### PR TITLE
Use constrained algorithms in more places

### DIFF
--- a/CSSE/CSCell.cpp
+++ b/CSSE/CSCell.cpp
@@ -65,7 +65,7 @@ namespace se::cs {
 		}
 
 		auto& incorrectList = reference->baseObject->isMobileCapableActor() ? cellObjRefs : cellNpcRefs;
-		const auto it = std::find(incorrectList.begin(), incorrectList.end(), reference);
+		const auto it = std::ranges::find(incorrectList, reference);
 		if (it != incorrectList.end()) {
 			incorrectList.erase(it);
 			addReference(reference);

--- a/CSSE/CSNPC.cpp
+++ b/CSSE/CSNPC.cpp
@@ -35,9 +35,9 @@ namespace se::cs {
 		}
 
 		// Sort the array in descending order based on the second index (skill level)
-		std::sort(trainingSkills.begin(), trainingSkills.end(), 
-			[](const std::vector<int>& above, const std::vector<int>& below) {
-				return (above[1] > below[1]);
+		std::ranges::sort(trainingSkills, std::ranges::greater{}, 
+			[](const std::vector<int>& skill) {
+				return skill[1];
 			});
 
 		// Construct the skill string, ex: "Alchemy(100), Blunt Weapon(90), Long Blade(60)"

--- a/CSSE/DarkMode.cpp
+++ b/CSSE/DarkMode.cpp
@@ -999,7 +999,7 @@ namespace se::cs::darkmode {
 		const auto hdc = GetDC(nullptr);
 		const auto scanLines = GetDIBits(hdc, imageInfo.hbmImage, 0, bitmap.bmHeight, pixels.data(), &bitmapInfo, DIB_RGB_COLORS);
 		if (scanLines == bitmap.bmHeight) {
-			const auto hasAlpha = std::any_of(pixels.begin(), pixels.end(), [](DWORD pixel) {
+			const auto hasAlpha = std::ranges::any_of(pixels, [](DWORD pixel) {
 				return (pixel & 0xFF000000) != 0;
 			});
 			if (!hasAlpha) {

--- a/CSSE/DialogLayersWindow.cpp
+++ b/CSSE/DialogLayersWindow.cpp
@@ -489,9 +489,7 @@ namespace se::cs::dialog::layer_window {
 		}
 
 		// Sort g_Layers by their IDs (ascending) for consistent ordering in the UI
-		std::ranges::sort(g_Layers, [](LayerData* a, LayerData* b) {
-			return a->id < b->id;
-		});
+		std::ranges::sort(g_Layers, {}, &LayerData::id);
 
 		auto recordHandler = DataHandler::get()->recordHandler;
 		auto cellList = recordHandler->cells;

--- a/CSSE/DialogLayersWindow.cpp
+++ b/CSSE/DialogLayersWindow.cpp
@@ -489,9 +489,9 @@ namespace se::cs::dialog::layer_window {
 		}
 
 		// Sort g_Layers by their IDs (ascending) for consistent ordering in the UI
-		std::sort(g_Layers.begin(), g_Layers.end(), [](LayerData* a, LayerData* b) {
+		std::ranges::sort(g_Layers, [](LayerData* a, LayerData* b) {
 			return a->id < b->id;
-			});
+		});
 
 		auto recordHandler = DataHandler::get()->recordHandler;
 		auto cellList = recordHandler->cells;

--- a/CSSE/DialogRenderWindow.cpp
+++ b/CSSE/DialogRenderWindow.cpp
@@ -3329,7 +3329,7 @@ namespace se::cs::dialog::render_window {
 			if (!outIds.empty()) {
 				std::vector<std::string> uniqueIds;
 				for (const auto& id : outIds) {
-					if (std::find(uniqueIds.begin(), uniqueIds.end(), id) == uniqueIds.end()) {
+					if (std::ranges::find(uniqueIds, id) == uniqueIds.end()) {
 						uniqueIds.push_back(id);
 					}
 				}

--- a/MWSE/CrashLoggerMWSE.cpp
+++ b/MWSE/CrashLoggerMWSE.cpp
@@ -127,11 +127,11 @@ namespace CrashLogger::Mods {
 			const auto activeMods = dataHandler->nonDynamicData->getActiveMods();
 			if (activeMods.empty()) return;
 
-			const auto filenameLength = std::strlen((*std::ranges::max_element(activeMods, [](const auto& a, const auto& b) {
-				return std::strlen(a->getFilename()) < std::strlen(b->getFilename());
+			const auto filenameLength = std::strlen((*std::ranges::max_element(activeMods, {}, [](const auto& mod) {
+				return std::strlen(mod->getFilename());
 			}))->getFilename());
-			const auto authorLength = std::strlen((*std::ranges::max_element(activeMods, [](const auto& a, const auto& b) {
-				return std::strlen(a->getAuthor()) < std::strlen(b->getAuthor());
+			const auto authorLength = std::strlen((*std::ranges::max_element(activeMods, {}, [](const auto& mod) {
+				return std::strlen(mod->getAuthor());
 			}))->getAuthor());
 
 			output << fmt::format("{:<{}} | {:<{}} | {:<s}", "File", filenameLength, "Author", authorLength, "Size") << '\n';
@@ -192,11 +192,11 @@ namespace CrashLogger::LuaMods {
 
 			if (results.empty()) return;
 
-			const auto keyLength = std::ranges::max_element(results, [](const auto& a, const auto& b) {
-				return a.key.length() < b.key.length();
+			const auto keyLength = std::ranges::max_element(results, {}, [](const auto& luaMod) {
+				return luaMod.key.length();
 			})->key.length();
-			const auto authorLength = std::ranges::max_element(results, [](const auto& a, const auto& b) {
-				return a.firstAuthor.length() < b.firstAuthor.length();
+			const auto authorLength = std::ranges::max_element(results, {}, [](const auto& luaMod) {
+				return luaMod.firstAuthor.length();
 			})->firstAuthor.length();
 
 			output << fmt::format("{:<{}} | {:<{}} | {:<s}", "Mod", keyLength, "Author", authorLength, "Version") << '\n';

--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -2736,7 +2736,7 @@ namespace mwse::lua {
 	const std::array<std::string, 2> disabledMarkers = { ".disabled", ".mohidden" };
 
 	bool isPathDisabled(std::string_view path) {
-		const auto disabledPathItt = std::find_if(disabledMarkers.begin(), disabledMarkers.end(),
+		const auto disabledPathItt = std::ranges::find_if(disabledMarkers,
 			[&](std::string_view s) {
 				return path.find(s) != std::string::npos;
 			});
@@ -2777,7 +2777,7 @@ namespace mwse::lua {
 
 					// Get a version of its path as a key.
 					auto luaModKey = pathString.substr(path.length() + 1, pathString.length() - path.length() - scriptFilename.length() - 2);
-					std::replace(luaModKey.begin(), luaModKey.end(), '\\', '.');
+					std::ranges::replace(luaModKey, '\\', '.');
 					se::string::to_lower(luaModKey);
 
 					// Check for key conflicts.

--- a/MWSE/LuaTimer.cpp
+++ b/MWSE/LuaTimer.cpp
@@ -227,7 +227,7 @@ namespace mwse::lua {
 	}
 
 	std::vector<std::shared_ptr<Timer>>::iterator TimerController::insertActiveTimer(std::shared_ptr<Timer> timer) {
-		auto position = std::upper_bound(m_ActiveTimers.begin(), m_ActiveTimers.end(), timer, comparer);
+		auto position = std::ranges::upper_bound(m_ActiveTimers, timer, comparer);
 		return m_ActiveTimers.insert(position, timer);
 	}
 

--- a/MWSE/LuaTimer.cpp
+++ b/MWSE/LuaTimer.cpp
@@ -90,11 +90,9 @@ namespace mwse::lua {
 		}
 
 		// Remove from the active timer list.
-		auto result = std::find(m_ActiveTimers.begin(), m_ActiveTimers.end(), timer);
-		if (result == m_ActiveTimers.end()) {
+		if (std::erase(m_ActiveTimers, timer) == 0) {
 			return false;
 		}
-		m_ActiveTimers.erase(result);
 
 		// And add it to the paused list.
 		m_PausedTimers.insert(timer);
@@ -150,12 +148,7 @@ namespace mwse::lua {
 
 		// Remove from the active list.
 		if (previousState == TimerState::Active) {
-			auto position = std::find(m_ActiveTimers.begin(), m_ActiveTimers.end(), timer);
-			if (position == m_ActiveTimers.end()) {
-				return false;
-			}
-			m_ActiveTimers.erase(position);
-			return true;
+			return std::erase(m_ActiveTimers, timer) == 1;
 		}
 
 		// Remove from the paused timer list.
@@ -242,12 +235,10 @@ namespace mwse::lua {
 		const auto stateHandle = LuaManager::getInstance().getThreadSafeStateHandle();
 
 		// Remove from current position.
-		auto position = std::find(m_ActiveTimers.begin(), m_ActiveTimers.end(), timer);
-		if (position == m_ActiveTimers.end()) {
+		if (std::erase(m_ActiveTimers, timer) == 0) {
 			return;
 		}
-		m_ActiveTimers.erase(position);
-
+		
 		// Then insert it back in.
 		insertActiveTimer(timer);
 	}

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -1745,11 +1745,6 @@ namespace mwse::patch {
 				length = strlen(d->name ? d->name : "");
 			}
 		};
-		struct {
-			bool operator()(const DialogueLengthCache& a, const DialogueLengthCache& b) {
-				return a.length > b.length;
-			}
-		} dialogueLengthSorter;
 
 		// Clone the dialogues in an array, then sort the array.
 		// TODO: We should improve our TList implementation to support sorting.
@@ -1758,7 +1753,7 @@ namespace mwse::patch {
 		for (const auto& dialogue : *dialogues) {
 			sortedDialogues.push_back(dialogue);
 		}
-		std::ranges::sort(sortedDialogues, dialogueLengthSorter);
+		std::ranges::sort(sortedDialogues, std::ranges::greater{}, &DialogueLengthCache::length);
 
 		// Clone the sorted data back into the TList, without any allocations.
 		auto itt = dialogues->head;

--- a/MWSE/PatchUtil.cpp
+++ b/MWSE/PatchUtil.cpp
@@ -1141,10 +1141,7 @@ namespace mwse::patch {
 
 	BOOL __stdcall PatchFindClose(HANDLE hFindFile) {
 		findFileMutex.lock();
-		const auto itt = findFilePaths.find(hFindFile);
-		if (itt != findFilePaths.end()) {
-			findFilePaths.erase(itt);
-		}
+		findFilePaths.erase(hFindFile);
 		findFileMutex.unlock();
 
 		return FindClose(hFindFile);

--- a/MWSE/ReferenceTracker.cpp
+++ b/MWSE/ReferenceTracker.cpp
@@ -94,7 +94,7 @@ namespace mwse {
 		}
 
 		auto& references = referencesIt->second.references;
-		references.erase(std::remove(references.begin(), references.end(), reference), references.end());
+		std::erase(references, reference);
 		referencesIt->second.dirtyLookup = true;
 	}
 
@@ -457,12 +457,7 @@ namespace mwse {
 	}
 
 	static void invalidateCell(const TES3::Cell* cell) {
-		const auto itt = referenceLookupCellOrder.find(cell);
-		if (itt == referenceLookupCellOrder.end()) {
-			return;
-		}
-
-		referenceLookupCellOrder.erase(itt);
+		referenceLookupCellOrder.erase(cell);
 	}
 
 	static void invalidatePhysicalObject(const TES3::PhysicalObject* object) {
@@ -470,12 +465,7 @@ namespace mwse {
 			return;
 		}
 
-		const auto itt = referenceDataByObject.find(object);
-		if (itt == referenceDataByObject.end()) {
-			return;
-		}
-
-		referenceDataByObject.erase(itt);
+		referenceDataByObject.erase(object);
 	}
 
 	void ReferenceTracker::invalidateObject(TES3::BaseObject* object) {

--- a/MWSE/TES3UIElement.cpp
+++ b/MWSE/TES3UIElement.cpp
@@ -755,7 +755,7 @@ namespace TES3::UI {
 			std::string& path = value.value();
 
 			// Sanitize path.
-			std::replace(path.begin(), path.end(), '/', '\\');
+			std::ranges::replace(path, '/', '\\');
 
 			setIcon(path.c_str());
 		}
@@ -1448,7 +1448,7 @@ namespace TES3::UI {
 
 		if (!path.empty()) {
 			// Sanitize path.
-			std::replace(path.begin(), path.end(), '/', '\\');
+			std::ranges::replace(path, '/', '\\');
 
 			// Make sure the file exists.
 			if (mwse::tes3::resolveAssetPath(path.c_str()) == 0) {
@@ -1471,7 +1471,7 @@ namespace TES3::UI {
 		std::string path = mwse::lua::getOptionalParam<const char*>(params, "path", "");
 
 		// Sanitize path.
-		std::replace(path.begin(), path.end(), '/', '\\');
+		std::ranges::replace(path, '/', '\\');
 
 		return createNif(id, path.c_str());
 	}

--- a/MWSE/TES3UIManagerLua.cpp
+++ b/MWSE/TES3UIManagerLua.cpp
@@ -232,12 +232,12 @@ namespace mwse::lua {
 		auto& properties = eventCallbacksBefore[target];
 		auto& callbacks = properties[eventID];
 
-		auto existing = std::find_if(callbacks.begin(), callbacks.end(), [&](auto& s) { return s.callback == callback && s.priority == priority; });
+		auto existing = std::ranges::find_if(callbacks, [&](auto& s) { return s.callback == callback && s.priority == priority; });
 		if (existing != callbacks.end()) {
 			return;
 		}
 
-		auto pos = std::find_if(callbacks.begin(), callbacks.end(), [priority](auto& s) { return s.priority < priority; });
+		auto pos = std::ranges::find_if(callbacks, [priority](auto& s) { return s.priority < priority; });
 		callbacks.insert(pos, { callback, priority });
 
 		// Forward the event to our dispatcher.
@@ -262,12 +262,12 @@ namespace mwse::lua {
 		auto& properties = eventCallbacksAfter[target];
 		auto& callbacks = properties[eventID];
 
-		auto existing = std::find_if(callbacks.begin(), callbacks.end(), [&](auto& s) { return s.callback == callback && s.priority == priority; });
+		auto existing = std::ranges::find_if(callbacks, [&](auto& s) { return s.callback == callback && s.priority == priority; });
 		if (existing != callbacks.end()) {
 			return;
 		}
 
-		auto pos = std::find_if(callbacks.begin(), callbacks.end(), [priority](auto& s) { return s.priority < priority; });
+		auto pos = std::ranges::find_if(callbacks, [priority](auto& s) { return s.priority < priority; });
 		callbacks.insert(pos, { callback, priority });
 
 		// Forward the event to our dispatcher.

--- a/MWSE/TES3UtilLua.cpp
+++ b/MWSE/TES3UtilLua.cpp
@@ -1838,14 +1838,14 @@ namespace mwse::lua {
 
 	bool getFileExists(std::string path) {
 		// Sanitize path.
-		std::replace(path.begin(), path.end(), '/', '\\');
+		std::ranges::replace(path, '/', '\\');
 
 		return tes3::resolveAssetPath(path.c_str()) != TES3::FileLoadSource::Missing;
 	}
 
 	sol::optional<std::tuple<std::string, std::string>> getFileSource(std::string path) {
 		// Sanitize path.
-		std::replace(path.begin(), path.end(), '/', '\\');
+		std::ranges::replace(path, '/', '\\');
 
 		char buffer[512];
 		int result = tes3::resolveAssetPath(path.c_str(), buffer);

--- a/SharedSE/CrashLogDevice.cpp
+++ b/SharedSE/CrashLogDevice.cpp
@@ -1,5 +1,7 @@
 #include "CrashLogger.h"
 
+#include "StringUtil.h"
+
 namespace CrashLogger::Device {
 	static std::stringstream output;
 
@@ -18,6 +20,7 @@ namespace CrashLogger::Device {
 			HKEY cpuKey = nullptr;
 			if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", 0, KEY_READ, &cpuKey) == ERROR_SUCCESS) {
 				cpu = GetRegistryString(cpuKey, "ProcessorNameString");
+				se::string::rtrim(cpu);
 				RegCloseKey(cpuKey);
 			}
 
@@ -39,10 +42,7 @@ namespace CrashLogger::Device {
 
 			ULONGLONG memoryAmount = 0;
 			GetPhysicallyInstalledSystemMemory(&memoryAmount);
-			cpu.erase(std::find_if(cpu.rbegin(), cpu.rend(), [](int character) {
-				return !std::isspace(character);
-			}).base(), cpu.end());
-
+			
 			output << fmt::format("OS:  {} - {} ({})", version, buildNumber, release) << '\n';
 			output << fmt::format("CPU: {}", cpu) << '\n';
 			output << fmt::format("GPU: {}", Client::GetGPU()) << '\n';

--- a/SharedSE/CrashLogSections.cpp
+++ b/SharedSE/CrashLogSections.cpp
@@ -186,11 +186,11 @@ namespace CrashLogger::Calltrace {
 				return;
 			}
 
-			const auto addressLength = std::max_element(entries.begin(), entries.end(), [](const auto& a, const auto& b) {
-				return a.address.length() < b.address.length();
+			const auto addressLength = std::ranges::max_element(entries, {}, [](const StackEntry& entry) {
+				return entry.address.length();
 			})->address.length();
-			const auto nameLength = std::max_element(entries.begin(), entries.end(), [](const auto& a, const auto& b) {
-				return a.name.length() < b.name.length();
+			const auto nameLength = std::ranges::max_element(entries, {}, [](const StackEntry& entry) { 
+				return entry.name.length();
 			})->name.length();
 
 			output << fmt::format("{:^10} | {:>{}} | {:<{}} | {}", "EBP", "Function Address", addressLength, "Function Name", nameLength, "Source") << '\n';

--- a/SharedSE/CrashLogUtilities.h
+++ b/SharedSE/CrashLogUtilities.h
@@ -18,7 +18,7 @@ inline std::string& SanitizeStringFromBadData(std::string& str) {
 	str.erase(first_nonprintable, str.end());
 
 	// Replace any newlines/tabs with spaces.
-	std::replace_if(str.begin(), str.end(), [](char c) { return std::isspace(c); }, ' ');
+	std::ranges::replace_if(str, [](char c) { return std::isspace(c); }, ' ');
 
 	return str;
 }

--- a/SharedSE/LinkedObjectsList.h
+++ b/SharedSE/LinkedObjectsList.h
@@ -16,8 +16,10 @@ namespace se {
 
 		private:
 			T* m_Object;
+			const LinkedObjectList* m_Parent;
 
-			iterator(T* object) : m_Object(object) {}
+			iterator(T* object, const LinkedObjectList* list)
+				: m_Object(object), m_Parent(list) {}
 
 		public:
 			using iterator_category = std::bidirectional_iterator_tag;
@@ -26,12 +28,12 @@ namespace se {
 			using value_type = T*;
 			using difference_type = int;
 			using pointer = T**;
-			using reference = T*&;
+			using reference = T* const&;
 
-			iterator() : m_Object(nullptr) {}
+			iterator() : m_Parent(nullptr), m_Object(nullptr) {}
 
 			iterator operator-(difference_type diff) const {
-				iterator r = m_Object;
+				iterator r = *this;
 				r -= diff;
 				return r;
 			}
@@ -39,6 +41,9 @@ namespace se {
 			iterator& operator--() {
 				if (m_Object) {
 					m_Object = static_cast<value_type>(m_Object->previousInCollection);
+				}
+				else if (m_Parent) {
+					m_Object = m_Parent->tail;
 				}
 				return *this;
 			}
@@ -57,7 +62,7 @@ namespace se {
 			}
 
 			iterator operator+(difference_type diff) const {
-				iterator r = m_Object;
+				iterator r = *this;
 				r += diff;
 				return r;
 			}
@@ -90,11 +95,11 @@ namespace se {
 				return itt.m_Object != m_Object;
 			}
 
-			T* operator->() const {
+			reference operator->() const {
 				return m_Object;
 			}
 
-			T* const& operator*() const {
+			reference operator*() const {
 				return m_Object;
 			}
 		};
@@ -110,14 +115,14 @@ namespace se {
 		using reverse_iterator = std::reverse_iterator<iterator>;
 		using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-		iterator begin() const { return head; }
-		iterator end() const { return nullptr; }
-		reverse_iterator rbegin() const { return tail; }
-		reverse_iterator rend() const { return nullptr; }
-		const_iterator cbegin() const { return head; }
-		const_iterator cend() const { return nullptr; }
-		const_reverse_iterator crbegin() const { return tail; }
-		const_reverse_iterator crend() const { return nullptr; }
+		iterator begin() const { return iterator(head, this); }
+		iterator end() const { return iterator(nullptr, this); }
+		reverse_iterator rbegin() const { return reverse_iterator(end()); }
+		reverse_iterator rend() const { return reverse_iterator(begin()); }
+		const_iterator cbegin() const { return const_iterator(head, this); }
+		const_iterator cend() const { return const_iterator(nullptr, this); }
+		const_reverse_iterator crbegin() const { return const_reverse_iterator(cend()); }
+		const_reverse_iterator crend() const { return const_reverse_iterator(cbegin()); }
 		size_type size() const noexcept { return count; }
 		bool empty() const noexcept { return count == 0; }
 
@@ -175,7 +180,7 @@ namespace se {
 				}
 			}
 
-			return value;
+			return iterator(value, this);
 		}
 
 		iterator insert(size_type position, reference value) {
@@ -200,7 +205,7 @@ namespace se {
 		}
 
 		iterator erase(iterator position) {
-			iterator nextInCollection = nullptr;
+			iterator nextInCollection(nullptr, this);
 
 			auto node = position.m_Object;
 			if (node) {
@@ -215,7 +220,7 @@ namespace se {
 					node->previousInCollection->nextInCollection = static_cast<value_type>(node->nextInCollection);
 				}
 				if (node->nextInCollection) {
-					nextInCollection = static_cast<value_type>(node->nextInCollection);
+					nextInCollection = iterator(static_cast<value_type>(node->nextInCollection), this);
 					node->nextInCollection->previousInCollection = static_cast<value_type>(node->previousInCollection);
 				}
 				node->previousInCollection = nullptr;

--- a/SharedSE/LinkedObjectsList.h
+++ b/SharedSE/LinkedObjectsList.h
@@ -15,12 +15,13 @@ namespace se {
 			friend class LinkedObjectList;
 
 		private:
-			T* m_Object;
+			mutable T* m_Object;
 
 			iterator(T* object) : m_Object(object) {}
 
 		public:
-			using iterator_category = std::random_access_iterator_tag;
+			using iterator_category = std::bidirectional_iterator_tag;
+			using iterator_concept = std::bidirectional_iterator_tag;
 
 			using value_type = T*;
 			using difference_type = int;
@@ -37,9 +38,15 @@ namespace se {
 
 			iterator& operator--() {
 				if (m_Object) {
-					m_Object = m_Object->previousInCollection;
+					m_Object = static_cast<value_type>(m_Object->previousInCollection);
 				}
 				return *this;
+			}
+
+			iterator operator--(int) {
+				auto result = *this;
+				--*this;
+				return result;
 			}
 
 			iterator& operator-=(difference_type diff) {
@@ -62,6 +69,12 @@ namespace se {
 				return *this;
 			}
 
+			iterator operator++(int) {
+				auto result = *this;
+				++*this;
+				return result;
+			}
+
 			iterator& operator+=(difference_type diff) {
 				while (m_Object && diff-- > 0) {
 					m_Object = static_cast<value_type>(m_Object->nextInCollection);
@@ -77,11 +90,11 @@ namespace se {
 				return itt.m_Object != m_Object;
 			}
 
-			reference operator->() {
+			reference operator->() const {
 				return m_Object;
 			}
 
-			reference operator*() {
+			reference operator*() const {
 				return m_Object;
 			}
 		};
@@ -92,7 +105,7 @@ namespace se {
 		using pointer = T**;
 		using const_pointer = const T**;
 		using reference = T*&;
-		using const_reference = const T*&;
+		using const_reference = T* const&;
 		using const_iterator = const iterator;
 		using reverse_iterator = std::reverse_iterator<iterator>;
 		using const_reverse_iterator = std::reverse_iterator<const_iterator>;
@@ -232,5 +245,6 @@ namespace se {
 		}
 
 	};
+
 	static_assert(sizeof(LinkedObjectList<void*>) == 0x0C, "TES3::LinkedObjectList failed size validation");
 }

--- a/SharedSE/LinkedObjectsList.h
+++ b/SharedSE/LinkedObjectsList.h
@@ -15,7 +15,7 @@ namespace se {
 			friend class LinkedObjectList;
 
 		private:
-			mutable T* m_Object;
+			T* m_Object;
 
 			iterator(T* object) : m_Object(object) {}
 
@@ -90,11 +90,11 @@ namespace se {
 				return itt.m_Object != m_Object;
 			}
 
-			reference operator->() const {
+			T* operator->() const {
 				return m_Object;
 			}
 
-			reference operator*() const {
+			T* const& operator*() const {
 				return m_Object;
 			}
 		};

--- a/SharedSE/NINode.cpp
+++ b/SharedSE/NINode.cpp
@@ -199,49 +199,47 @@ namespace NI {
 
 		// Land records get sorted to favor more influential lights.
 		if (isLand) {
-			std::sort(dynamicEffectsBuffer.begin(), dynamicEffectsBuffer.end(),
-				[&](const DynamicEffect* a, const DynamicEffect* b) -> bool {
-					// Lights can be sorted by their type index.
-					const auto aType = a->getType();
-					const auto bType = b->getType();
-					if (aType != bType) {
-						return aType < bType;
-					}
+			std::ranges::sort(dynamicEffectsBuffer, [&](const DynamicEffect* a, const DynamicEffect* b) -> bool {
+				// Lights can be sorted by their type index.
+				const auto aType = a->getType();
+				const auto bType = b->getType();
+				if (aType != bType) {
+					return aType < bType;
+				}
 
-					// From here on we only care about point lights.
-					if (aType != DynamicEffect::TYPE_POINT_LIGHT) {
-						return false;
-					}
+				// From here on we only care about point lights.
+				if (aType != DynamicEffect::TYPE_POINT_LIGHT) {
+					return false;
+				}
 
-					const auto aLight = static_cast<const PointLight*>(a);
-					const auto bLight = static_cast<const PointLight*>(b);
-					return aLight->getSortWeight() > bLight->getSortWeight();
-				});
+				const auto aLight = static_cast<const PointLight*>(a);
+				const auto bLight = static_cast<const PointLight*>(b);
+				return aLight->getSortWeight() > bLight->getSortWeight();
+			});
 		}
 		// Everything else gets sorted by distance.
 		else {
-			std::sort(dynamicEffectsBuffer.begin(), dynamicEffectsBuffer.end(),
-				[&](const DynamicEffect* a, const DynamicEffect* b) -> bool {
-					// Lights can be sorted by their type index.
-					const auto aType = a->getType();
-					const auto bType = b->getType();
-					if (aType != bType) {
-						return aType < bType;
-					}
+			std::ranges::sort(dynamicEffectsBuffer, [&](const DynamicEffect* a, const DynamicEffect* b) -> bool {
+				// Lights can be sorted by their type index.
+				const auto aType = a->getType();
+				const auto bType = b->getType();
+				if (aType != bType) {
+					return aType < bType;
+				}
 
-					// From here on we only care about point lights.
-					if (aType != DynamicEffect::TYPE_POINT_LIGHT) {
-						return false;
-					}
+				// From here on we only care about point lights.
+				if (aType != DynamicEffect::TYPE_POINT_LIGHT) {
+					return false;
+				}
 
-					const auto aLight = static_cast<const PointLight*>(a);
-					const auto bLight = static_cast<const PointLight*>(b);
-					const auto aDistance = aLight->worldTransform.translation.distance(&getWorldBound()->center);
-					const auto aRadius = aLight->getRadius();
-					const auto bDistance = bLight->worldTransform.translation.distance(&getWorldBound()->center);
-					const auto bRadius = bLight->getRadius();
-					return aRadius * aDistance > bRadius * bDistance;
-				});
+				const auto aLight = static_cast<const PointLight*>(a);
+				const auto bLight = static_cast<const PointLight*>(b);
+				const auto aDistance = aLight->worldTransform.translation.distance(&getWorldBound()->center);
+				const auto aRadius = aLight->getRadius();
+				const auto bDistance = bLight->worldTransform.translation.distance(&getWorldBound()->center);
+				const auto bRadius = bLight->getRadius();
+				return aRadius * aDistance > bRadius * bDistance;
+			});
 		}
 
 		// Rebuild the linked list.

--- a/SharedSE/StringUtil.h
+++ b/SharedSE/StringUtil.h
@@ -58,7 +58,7 @@ namespace se::string {
 	}
 
 	static inline void ltrim(std::string& s) {
-		s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
+		s.erase(s.begin(), std::ranges::find_if(s, [](int ch) { return !std::isspace(ch); }));
 	}
 
 	static inline void rtrim(std::string& s) {


### PR DESCRIPTION
Summary:

- Use std::erase(std::vector<T>& c, const U& value) available in C++ 20. Allows me to replace the find->erase construction.
- std::unordered_map has an erase overload that can delete by key, so a previous call to find isn't needed 
- SharedSE/CrashLogDevice basically reimplemented string right trim. Used existing function instead.
- Constrained algorithms can be used with a default comparer std::less. These, together with the projection function, can be used to eliminate custom comparison functions.
- The last commit needs thorough review. In order to use LinkedObjectsList with std::ranges::find, it needed some changes. I used help from ChatGPT to get that to compile.