### PR TITLE
Implement some TODOs

### DIFF
--- a/MWSE/TES3Inventory.cpp
+++ b/MWSE/TES3Inventory.cpp
@@ -207,7 +207,7 @@ namespace TES3 {
 
 		if (mobile && mobile->lightMagicEffectData && mobile->lightMagicEffectData->light) {
 			mobile->lightMagicEffectData->light->update(0.0f, true, true);
-			mobile->actorFlags &= ~0x80; // TODO: Name and create helper functions for this flag.
+			mobile->setLightingValidFlag(false);
 		}
 	}
 

--- a/MWSE/TES3ScriptCompiler.cpp
+++ b/MWSE/TES3ScriptCompiler.cpp
@@ -1,5 +1,7 @@
 #include "TES3ScriptCompiler.h"
 
+#include "Log.h"
+
 namespace TES3 {
 	ScriptCompiler::ScriptCompiler() {
 		const auto TES3_ScriptCompiler_ctor = reinterpret_cast<void(__thiscall*)(ScriptCompiler*)>(0x4F7260);
@@ -65,7 +67,8 @@ namespace TES3 {
 
 				function = parseFunctionName();
 				if (function == CompilerFunction::INVALID) {
-					// TODO: Error. Need to end with `end`
+					mwse::log::getLog() << "tes3script:recompile: Could not recompile provided script " << scriptHeader.name 
+						<< ". Script needs to end with `end` keyword." << std::endl;
 					delete shortVarList;
 					shortVarList = nullptr;
 					delete longVarList;
@@ -86,7 +89,8 @@ namespace TES3 {
 			return false;
 		}
 		else {
-			// TODO: Error. Need to start with `begin`
+			mwse::log::getLog() << "tes3script:recompile: Could not recompile provided script " << scriptHeader.name
+				<< ". Script needs to start with `begin` keyword." << std::endl;
 			return false;
 		}
 	}


### PR DESCRIPTION
- We now have a helper to write 0x80 in MobileActor::actorFlags
- Just log in to MWSE.log when an error occurs in TES3::ScriptCompiler::compile. This is only called from TES3::Script::recompile, which is available to the Lua API. That's why it seemed appropriate to log the error to MWSE.log.