### PR TITLE
Correct `memmove_s calls` in `UIElement::reorderChildren`

### DIFF
--- a/MWSE/TES3UIElement.cpp
+++ b/MWSE/TES3UIElement.cpp
@@ -289,12 +289,12 @@ namespace TES3::UI {
 		if (moveFrom < insertBefore) {
 			int shift = insertBefore - moveFrom;
 			memmove_s(from, sizeof(Element*) * shift, from + count, sizeof(Element*) * shift);
-			memmove_s(to - count, sizeof(Element*) * count, &*temp.begin(), sizeof(Element*) * count);
+			memmove_s(to - count, sizeof(Element*) * count, std::to_address(temp.begin()), sizeof(Element*) * count);
 		}
 		else {
 			int shift = moveFrom - insertBefore;
 			memmove_s(to + count, sizeof(Element*) * shift, to, sizeof(Element*) * shift);
-			memmove_s(to, sizeof(Element*) * count, &*temp.begin(), sizeof(Element*) * count);
+			memmove_s(to, sizeof(Element*) * count, std::to_address(temp.begin()), sizeof(Element*) * count);
 		}
 
 		return true;

--- a/MWSE/TES3UIElement.cpp
+++ b/MWSE/TES3UIElement.cpp
@@ -288,13 +288,13 @@ namespace TES3::UI {
 		// Slide <shift> children in-place, then write buffer into correct location
 		if (moveFrom < insertBefore) {
 			int shift = insertBefore - moveFrom;
-			memmove_s(from, sizeof(Element*) * shift, from + count, sizeof(Element*) * shift);
-			memmove_s(to - count, sizeof(Element*) * count, std::to_address(temp.begin()), sizeof(Element*) * count);
+			memmove_s(from, sizeof(Element**) * shift, from + count, sizeof(Element**) * shift);
+			memmove_s(to - count, sizeof(Element**) * count, temp.data(), sizeof(Element**) * count);
 		}
 		else {
 			int shift = moveFrom - insertBefore;
-			memmove_s(to + count, sizeof(Element*) * shift, to, sizeof(Element*) * shift);
-			memmove_s(to, sizeof(Element*) * count, std::to_address(temp.begin()), sizeof(Element*) * count);
+			memmove_s(to + count, sizeof(Element**) * shift, to, sizeof(Element**) * shift);
+			memmove_s(to, sizeof(Element**) * count, temp.data(), sizeof(Element**) * count);
 		}
 
 		return true;

--- a/MWSE/stdafx.h
+++ b/MWSE/stdafx.h
@@ -14,7 +14,6 @@
 #include <istream>
 #include <list>
 #include <map>
-#include <memory>
 #include <mutex>
 #include <numbers>
 #include <numeric>

--- a/MWSE/stdafx.h
+++ b/MWSE/stdafx.h
@@ -14,6 +14,7 @@
 #include <istream>
 #include <list>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <numbers>
 #include <numeric>


### PR DESCRIPTION
This can be used instead of a bit confusing `&*` concept. I'm not sure if we want this change.