### PR TITLE
Fix the documentation definition

### DIFF
--- a/autocomplete/definitions/namedTypes/niSkinDataBoneData/weights.lua
+++ b/autocomplete/definitions/namedTypes/niSkinDataBoneData/weights.lua
@@ -1,6 +1,6 @@
 return {
 	type = "value",
-	description = [[Contains all the per-vertex weight coefficients used when deforming the verticies influenced by this bone.]],
+	description = [[Contains all the per-vertex weight coefficients used when deforming the vertices influenced by this bone.]],
 	readOnly = true,
 	valuetype = "niSkinDataBoneDataVertexWeight[]",
 }

--- a/autocomplete/definitions/namedTypes/niTriangle/vertices.lua
+++ b/autocomplete/definitions/namedTypes/niTriangle/vertices.lua
@@ -1,0 +1,5 @@
+return {
+	type = "value",
+	description = [[The access to the three indices of the vertices that make up this triangle (0-indexed).]],
+	valuetype = "number[]",
+}

--- a/autocomplete/definitions/namedTypes/niTriangle/verticies.lua
+++ b/autocomplete/definitions/namedTypes/niTriangle/verticies.lua
@@ -1,5 +1,0 @@
-return {
-	type = "value",
-	description = [[The access to the three indices of the verticies that make up this triangle (0-indexed).]],
-	valuetype = "number[]",
-}

--- a/autocomplete/definitions/namedTypes/tes3magicEffect.lua
+++ b/autocomplete/definitions/namedTypes/tes3magicEffect.lua
@@ -1,4 +1,5 @@
 return {
 	type = "class",
 	description = [[A core magic effect definition.]],
+	inherits = "tes3baseObject",
 }


### PR DESCRIPTION
- Fix the typo `verticies` in the documentation.
- Fix `tes3magicEffect` did not inherit from `tes3baseObject` in the documentation.

I haven't been able to test if the documentation is generated automatically correctly.