### PR TITLE
Fix `:delete()` on disabled references leaving stale caster pointers.

### DIFF
--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -546,9 +546,11 @@ namespace TES3 {
 	void Reference::setDeletedWithSafety() {
 		disable();
 
-		const auto worldController = TES3::WorldController::get();
-		if (worldController && worldController->magicInstanceController) {
-			worldController->magicInstanceController->cleanupReference(this);
+		if (baseObject && baseObject->isMobileCapableActor()) {
+			const auto worldController = TES3::WorldController::get();
+			if (worldController && worldController->magicInstanceController) {
+				worldController->magicInstanceController->retireMagicCastedByActor(this);
+			}
 		}
 
 		if (baseObject) {

--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -546,6 +546,11 @@ namespace TES3 {
 	void Reference::setDeletedWithSafety() {
 		disable();
 
+		const auto worldController = TES3::WorldController::get();
+		if (worldController && worldController->magicInstanceController) {
+			worldController->magicInstanceController->cleanupReference(this);
+		}
+
 		if (baseObject) {
 			// This always seems to return 0 and do nothing.
 			// But we'll keep it for consistency.


### PR DESCRIPTION
Reported on discord. I was able to replicate it myself. When `:delete()` is called on a disabled reference, the `disable()` function early returns (already disabled) and thus doesn't do the magic instance cleanup. 

Already-disabled actors can still have magic active if they were mwscript-disabled (doesn't call retire) or if a script had called `cast` after disabling.

Specifically: `MagicSourceInstance::caster` still holds a pointer to the deleted reference. Then next frame's call sequence of `ActiveMagicManager::processAllMagics -> MagicSourceInstance::process -> Reference::getAttachment8Mobile` happens and we get an access violation.

The fix is just to call `retireMagicCastedByActor` unconditionally since even in the cases where things were already cleaned up it's only a cheap/harmless StdMap lookup inside a rarely called function.

For me it triggering the bug caused around 70,000 lines in `mwse.log` of 
```
[MWSE] WARNING: An unknown object type was identified with a virtual table address of 0x74a2d8. Report this to MWSE developers.
```
Then a crash
```
Thread: GameMainThread
Exception: EXCEPTION_ACCESS_VIOLATION (C0000005)
Last Error: The handle is invalid. (00000006)
Install Path: C:\Users\Admin\Games\Morrowind
OS:  Windows 11 Enterprise - 26200 (25H2)
CPU: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz
GPU: NVIDIA GeForce GTX 1080 Ti
RAM: 32.00 GB
=== CALL STACK: ========================================================================================================
   EBP     |       Function Address | Function Name                             | Source
0x001AFD38 | Morrowind (0x004E5757) | Reference::getAttachment8Mobile+0x7       | 
0x001AFDC8 | Morrowind (0x004552BA) | ActiveMagicManager::processAllMagics+0x2A | 
0x001AFE68 | Morrowind (0x0041ABB5) | TES3Game::mainLoop+0xC5                   | 
0x001AFED8 | Morrowind (0x00417232) | WinMain+0x422                             | 
0x001AFF74 | Morrowind (0x007279B2) | start+0x134                               | 
0x001AFF84 |  KERNEL32 (0x10015D49) | BaseThreadInitThunk+0x19                  | 
0x001AFFDC |     ntdll (0x1006E12B) | RtlInitializeExceptionChain+0x6B          | 
0x001AFFEC |     ntdll (0x1006E0B1) | RtlGetAppContainerNamedObjectPath+0x231   | 
=== LUA STACK: =========================================================================================================
=== REGISTRY: ==========================================================================================================
REG |   Value    | DEREFERENCE INFO
eax | 0x000000FA | 
ebp | 0x001AFD38 | 
ebx | 0x00000000 | 
ecx | 0x29210CE0 | 
edi | 0x02A36FF0 | 0x02AB5DC8 ==> 0x0074F9C8 ==> Class: NiNode: Name: WorldSpellRoot
edx | 0x270F0F48 | 
eip | 0x004E5757 | 
esi | 0x28C462F0 | 0x0074AA14 ==> RTTI: MagicSourceInstance
esp | 0x001AFC60 | 0x005143D2 ==> RTTI: MagicSourceInstance::process+0x52
=== MWSCRIPT STATE: ====================================================================================================
No mwscript instance running.
=== STACK: =============================================================================================================
  # |   Value    | DEREFERENCE INFO
  0 | 0x005143D2 | 
  1 | 0x02A36FF0 | 0x02AB5DC8 ==> 0x0074F9C8 ==> Class: NiNode: Name: WorldSpellRoot
  2 | 0x3C1374BD | 
  3 | 0x001AFDD0 | 
  4 | 0x27B14180 | 0x0074A140 ==> Class: Reference: ID: No Source Mod: Reference 
  5 | 0x00000000 | 
  6 | 0x00000032 | 
  7 | 0x45D4FB5C | 
  8 | 0x00000000 | Identical to  5
 23 | 0x28C462F0 | 0x0074AA14 ==> RTTI: MagicSourceInstance
 25 | 0x02A04260 | 0x0074665C ==> RTTI: Game
 26 | 0x3438B0C0 | 0x00750D68 ==> Class: BSAnimationNode: Unable to dereference
 2A | 0x1706D0E8 | 0x0074FAA8 ==> Class: NiCamera: 
 2B | 0x2891FBA0 | 0x288F7480 ==> 0x79616C50 ==> String: "PlayerSaveGame"
 34 | 0x0072DB03 | 0x7582F8B8 ==> RTTI: WdtpInterfacePointer_UserUnmarshal+0x55711
 3F | 0x1706CE30 | 0x0074FAA8 ==> Class: NiCamera: 
 47 | 0x007CB478 | 0x00363731 ==> String: "176"
 53 | 0x001AFDC0 | 0x70A5D5CC ==> RTTI: _tan_pentium4+0x6DD4
 7F | 0x001AFE98 | 0x001B0AA2 ==> 0x0069006D ==> RTTI: sub_690040+0x2D
 84 | 0x0072787E | 0x6AEC8B55 ==> RTTI: destroyFinalizer+0xCA1B85
 8E | 0x001B0AA2 | 0x0069006D ==> RTTI: sub_690040+0x2D
 9E | 0x00776E90 | 0x72726F4D ==> RTTI: CreateInputSystemClientConnection+0xE319D
 A9 | 0x029D18F8 | 0x029D1900 ==> 0x555C3A43 ==> String: "C:\Users\*****\Games\Morrowind\Morrowind.exe"
 AC | 0x029D2158 | 0x029D224C ==> 0x554C4C41 ==> String: "ALLUSERSPROFILE=C:\ProgramData"
 B0 | 0x00B16E78 | 0x536E6957 ==> String: "WinSta0\Default"
 B1 | 0x00B20678 | 0x555C3A43 ==> String: "C:\Users\*****\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Morrowind.lnk"
 BF | 0x001AFEF0 | 0x0072787E ==> RTTI: start
 ```
 
 Which matched the discord report exactly.