### PR TITLE
Correctly determine weight class for custom armor slots

### DIFF
--- a/MWSE/TES3Armor.cpp
+++ b/MWSE/TES3Armor.cpp
@@ -133,10 +133,10 @@ namespace TES3 {
 
 			float armorEpsilon = *reinterpret_cast<float*>(0x7483A0);
 			auto dataHandler = TES3::DataHandler::get();
-			if (slotData->weight * dataHandler->nonDynamicData->GMSTs[TES3::GMST::fLightMaxMod]->value.asFloat + armorEpsilon < weight) {
+			if (weight <= slotData->weight * dataHandler->nonDynamicData->GMSTs[TES3::GMST::fLightMaxMod]->value.asFloat + armorEpsilon) {
 				return ArmorWeightClass::Light;
 			}
-			else if (slotData->weight * dataHandler->nonDynamicData->GMSTs[TES3::GMST::fMedMaxMod]->value.asFloat + armorEpsilon < weight) {
+			else if (weight <= slotData->weight * dataHandler->nonDynamicData->GMSTs[TES3::GMST::fMedMaxMod]->value.asFloat + armorEpsilon) {
 				return ArmorWeightClass::Medium;
 			}
 			else {


### PR DESCRIPTION
The armor weight class wasn't determined correctly because the conditions tested the opposite of what Morrowind does. Based on research from:

https://wiki.openmw.org/index.php?title=Research:Combat#Determining_armor_class

Fixes: #727 