### PR TITLE
Fix MagicInstanceController::cleanupReference never executing

### DIFF
--- a/MWSE/TES3MagicInstanceController.cpp
+++ b/MWSE/TES3MagicInstanceController.cpp
@@ -47,19 +47,42 @@ namespace TES3 {
 		TES3_MagicInstanceController_interruptCasting(this, reference);
 	}
 
+	// The engine function is compiled against this map's sentinel, so it is not valid for the other maps.
+	const auto TES3_MagicInstanceController_nextSerialInstanceNode = reinterpret_cast<void(__thiscall*)(MagicInstanceController::StlMap::Node**)>(0x457750);
+	MagicInstanceController::StlMap::Node* MagicInstanceController::getNextSerialInstanceNode(StlMap::Node* node) const {
+		TES3_MagicInstanceController_nextSerialInstanceNode(&node);
+		return node;
+	}
+
 	void MagicInstanceController::cleanupReference(Reference* reference) {
 		if (reference == nullptr) {
 			return;
 		}
 
-		// Only NPCs/creatures can have effects.
-		if (!reference->isMobileCapableActor()) {
+		// Retire any magic this reference cast. This also covers non-actor casters such as trapped doors and containers, and unlike the retire in Reference::dtor it does not require a live mobile.
+		retireMagicCastedByActor(reference);
+
+		// Only actors and lockable objects can be targets of magic effects.
+		const auto baseObject = reference->baseObject;
+		if (baseObject == nullptr) {
+			return;
+		}
+		const auto canBeEffectTarget = baseObject->isMobileCapableActor()
+			|| baseObject->objectType == ObjectType::Door
+			|| baseObject->objectType == ObjectType::Container;
+		if (!canBeEffectTarget) {
 			return;
 		}
 
-		// TODO: It'd be nice if we could iterate over this hash map more cleanly. This method of indexing is slower.
-		const auto maxSerial = getSerialCount();
-		for (auto serial = 0u; serial <= maxSerial; ++serial) {
+		// Snapshot the live serials first, as retiring modifies the map.
+		std::vector<unsigned int> serials;
+		serials.reserve(mapSerialToMagicSourceInstance.itemCount);
+		const auto sentinel = mapSerialToMagicSourceInstance.root;
+		for (auto node = sentinel->left; node != sentinel; node = getNextSerialInstanceNode(node)) {
+			serials.push_back(node->key);
+		}
+
+		for (const auto serial : serials) {
 			auto instance = getInstanceFromSerial(serial);
 			if (instance == nullptr) {
 				continue;

--- a/MWSE/TES3MagicInstanceController.h
+++ b/MWSE/TES3MagicInstanceController.h
@@ -7,8 +7,18 @@
 namespace TES3 {
 	struct MagicInstanceController {
 		struct StlMap {
+			// Node of the engine's std::map. The root member points at the sentinel head node, whose left child is the first element in key order.
+			struct Node {
+				Node* left; // 0x0
+				Node* parent; // 0x4
+				Node* right; // 0x8
+				unsigned int key; // 0xC
+				void* value; // 0x10
+				char redBlack; // 0x14
+			};
+
 			char tag;
-			void * root;
+			Node * root;
 			char unknown_8;
 			size_t itemCount;
 
@@ -41,6 +51,7 @@ namespace TES3 {
 		// Custom functions.
 		//
 
+		StlMap::Node* getNextSerialInstanceNode(StlMap::Node* node) const;
 		void cleanupReference(Reference* reference);
 
 		//


### PR DESCRIPTION
The guard `reference->isMobileCapableActor()` resolves to the inherited BaseObject method, which switches on the object's own objectType - and a Reference's tag is 'RFER', never an actor type. It returned false for every reference, so the entire cleanup has been dead code since it shipped in #685.

That left MagicSourceInstance::caster dangling whenever a caster reference was freed while its instance was still live. The engine's own retire calls in Reference::dtor are gated on the reference having a live mobile (0x4E476C), and mobile deactivation retires nothing, so this cleanup was the only backstop - and it never ran. The next ActiveMagicManager tick then read the freed pointer in MagicSourceInstance::process, which dereferences the caster first thing. Matches a user-reported minidump on build 5347: AV at Reference::getAttachment8Mobile+0x7 with a freed caster pointer.

The realistic trigger is not an actor. A reference of any type can be a caster (mwscript Cast/ExplodeSpell and Lua casts pass whatever reference is executing; trapped doors/containers cast via the engine's triggerTrap), and casting does not mark the reference modified. When such an unmodified, non-actor temporary reference is freed by cell-buffer eviction (Cell::unloadTempRefs -> EntityList::clear frees the unmodified temporary refs; modified ones are moved to the persistent list, actors live in a separate list), its instance is left with a dangling caster. An actor-only guard on this path would miss it entirely.

Rework while fixing the guard:

- Caster side: delegate to the engine's retireMagicCastedByActor. It is the exact sequence the dtor runs when its gate passes, it is indexed via mapReferenceToSerial (verified complete for both fresh casts and save-loaded instances), it is safe against map mutation, it erases all three controller maps via retireSpellBySerial, and it also covers non-actor casters. For a reference that never cast anything this is one failed map lookup, so it needs no type filter.

- Target side: keep the surgical effect scan, but iterate a snapshot of live serials collected by walking mapSerialToMagicSourceInstance with the engine's own in-order iterator instead of probing every serial from 0 to the global counter. The old probe was correct (the counter dominates all live serials, including across save load) but cost O(all serials ever issued) per destroyed reference. The snapshot costs O(live instances) and stays safe against retire-driven map mutation by re-resolving each serial through getInstanceFromSerial.

- Scope the target scan to references that can carry effects: actors, plus doors and containers (Lock/Open targets - the class #743 worked around downstream).

The caster==reference branch inside the loop is kept as a fallback for any instance that escaped the reference index.

Verified with an in-game A/B test: on an unmodified activator that casts a long-duration spell, then cell-buffer eviction of its cell, the unpatched build leaves the instance live with a freed caster (use after free), while this build retires the instance in the reference dtor.

Complements the delete-crash-fix branch (setDeletedWithSafety retire), which covers the Lua :delete() route; this revives the dtor-level backstop that also covers mwscript Disable/SetDelete despawns and every other destruction path.