### PR TITLE
Fix/timer teardown lua lock

### DIFF
--- a/MWSE/LuaManager.cpp
+++ b/MWSE/LuaManager.cpp
@@ -6922,6 +6922,8 @@ namespace mwse::lua {
 	}
 
 	void LuaManager::savePersistentTimers() {
+		const auto stateHandle = getThreadSafeStateHandle();
+
 		auto macp = TES3::WorldController::get()->getMobilePlayer();
 		if (macp == nullptr) {
 			return;
@@ -6960,6 +6962,8 @@ namespace mwse::lua {
 	}
 
 	void LuaManager::restorePersistentTimers() {
+		const auto stateHandle = getThreadSafeStateHandle();
+
 		auto macp = TES3::WorldController::get()->getMobilePlayer();
 		if (macp == nullptr) {
 			return;
@@ -6982,6 +6986,8 @@ namespace mwse::lua {
 	}
 
 	void LuaManager::clearPersistentTimers() {
+		const auto stateHandle = getThreadSafeStateHandle();
+
 		auto macp = TES3::WorldController::get()->getMobilePlayer();
 		if (macp == nullptr) {
 			return;
@@ -6992,6 +6998,8 @@ namespace mwse::lua {
 	}
 
 	void LuaManager::clearTimers() {
+		const auto stateHandle = getThreadSafeStateHandle();
+
 		realTimers->clearTimers();
 		simulateTimers->clearTimers();
 		gameTimers->clearTimers();

--- a/MWSE/LuaTimer.cpp
+++ b/MWSE/LuaTimer.cpp
@@ -167,6 +167,9 @@ namespace mwse::lua {
 	}
 
 	void TimerController::clearTimers() {
+		// Destroying timers releases their Lua references.
+		const auto stateHandle = LuaManager::getInstance().getThreadSafeStateHandle();
+
 		// Mark all timers as expired.
 		for (auto itt = m_ActiveTimers.begin(); itt != m_ActiveTimers.end(); ++itt) {
 			(*itt)->state = TimerState::Expired;

--- a/MWSE/LuaTimer.cpp
+++ b/MWSE/LuaTimer.cpp
@@ -167,9 +167,6 @@ namespace mwse::lua {
 	}
 
 	void TimerController::clearTimers() {
-		// Destroying timers releases their Lua references.
-		const auto stateHandle = LuaManager::getInstance().getThreadSafeStateHandle();
-
 		// Mark all timers as expired.
 		for (auto itt = m_ActiveTimers.begin(); itt != m_ActiveTimers.end(); ++itt) {
 			(*itt)->state = TimerState::Expired;


### PR DESCRIPTION
Fixes a rare crash on New Game / Load Game: `UKNOWN_EXCEPTION (E24C4A02)` on `GameBackgroundThread` with `sol: cannot set (new_index) into this object` on the stack.

`E24C4A02` is LuaJIT's own SEH code for a Lua error (`LJ_EXCODE | LUA_ERRRUN`) raised on a thread with no `pcall` frame.

## Cause

`LuaManager::clearTimers()` (called from `startNewGame` and both `loadGame*` hooks) destroys every `Timer`, and each `Timer` owns a `sol::object callback` and `sol::table data`. Their destructors call `luaL_unref`. This ran on the main thread **without the Lua state mutex**; only the `setClock()` call that follows takes it. `restorePersistentTimers()` / `savePersistentTimers()` / `clearPersistentTimers()` had the same gap.

`TES3_newGame()` and the load-game functions return while the loader thread is still creating cell references and firing `referenceSceneNodeCreated` under the mutex. `luaL_ref` / `luaL_unref` are unsynchronised freelist updates on the registry table, so an interleaving hands a live slot out twice. In the captured dump the `sol::table` from `create_table()` in `ReferenceSceneNodeCreatedEvent::createEventTable` resolved to a `TES3::Reference` userdata by the time `eventData["reference"]` was written, so `lua_setfield` hit the usertype `__newindex`, which raised outside any protected call.

Symbolised stacks from the minidump (nightly 5355):

```
GameBackgroundThread
  game_threadLoadCells
  TES3::Reference::getSceneGraphNode
  ThreadedStateHandle::triggerEvent (ReferenceSceneNodeCreatedEvent)
  createEventTable: eventData["reference"] = m_Reference
  lua_setfield -> __newindex on TES3::Reference userdata
  sol usertype_storage<TES3::Reference>::index_call_with_bases<is_new_index=1>
  luaL_error -> lj_err_throw -> RaiseException          (unprotected)

GameMainThread
  MenuInputController::dispatchMouseReleaseEvent
  OnNewGame -> mwse::tes3::startNewGame
  LuaManager::clearTimers -> TimerController::update
  getThreadSafeStateHandle                                (blocked; timers already destroyed unlocked)
```

## Fix

Take `getThreadSafeStateHandle()` in `LuaManager::clearTimers()`, `restorePersistentTimers()`, `savePersistentTimers()` and `clearPersistentTimers()`. The mutex is recursive, so the existing nested locks in `update()` / `insertActiveTimer()` are unaffected.

All four run once per save, load, or new game; no per-frame path is touched.

🤖 Generated with [Claude Code]