### PR TITLE
Fix dangling casters on reference destruction without the serial scan

### DIFF
--- a/MWSE/TES3MagicInstanceController.cpp
+++ b/MWSE/TES3MagicInstanceController.cpp
@@ -37,9 +37,27 @@ namespace TES3 {
 		TES3_MagicInstanceController_retireMagicBySerial(this, serial);
 	}
 
+	// One link per active retirement, chained on the stack so nesting can be checked without allocating.
+	struct RetiringReference {
+		Reference* reference;
+		RetiringReference* previous;
+	};
+
 	const auto TES3_MagicInstanceController_retireMagicCastedByActor = reinterpret_cast<void(__thiscall*)(MagicInstanceController*, Reference*)>(0x454EC0);
 	void MagicInstanceController::retireMagicCastedByReference(Reference* reference) {
+		// process() runs lua callbacks before retireSpellBySerial() erases the caster entry, so a callback that
+		// deletes anything already retiring would free the instance an outer call is still holding.
+		static RetiringReference* retiring = nullptr;
+		for (auto entry = retiring; entry; entry = entry->previous) {
+			if (entry->reference == reference) {
+				return;
+			}
+		}
+
+		RetiringReference entry{ reference, retiring };
+		retiring = &entry;
 		TES3_MagicInstanceController_retireMagicCastedByActor(this, reference);
+		retiring = entry.previous;
 	}
 
 	const auto TES3_MagicInstanceController_interruptCasting = reinterpret_cast<void(__thiscall*)(MagicInstanceController*, Reference*)>(0x455610);
@@ -47,6 +65,7 @@ namespace TES3 {
 		TES3_MagicInstanceController_interruptCasting(this, reference);
 	}
 
+	// Unused: probing every serial was too slow to run per destroyed reference. See Reference::cleanupAssociatedData().
 	void MagicInstanceController::cleanupReference(Reference* reference) {
 		if (reference == nullptr) {
 			return;

--- a/MWSE/TES3Reference.cpp
+++ b/MWSE/TES3Reference.cpp
@@ -548,7 +548,7 @@ namespace TES3 {
 			return;
 		}
 
-		disable();
+		const auto didDisable = disable();
 
 		if (baseObject) {
 			// This always seems to return 0 and do nothing.
@@ -556,7 +556,8 @@ namespace TES3 {
 			baseObject->vTable.object->unknown_0x12C(baseObject);
 		}
 
-		handleUpdate(UpdateType::Deleted, true);
+		// disable() updates collision groups when it runs, so only rebuild here if it didn't.
+		handleUpdate(UpdateType::Deleted, !didDisable);
 		removeAllAttachments();
 		setScale(1.0f);
 		setDeleted(true);
@@ -601,9 +602,9 @@ namespace TES3 {
 			worldController->mobManager->processManager->cleanupAIPackages(this, mobile);
 		}
 
-		// Clean up any related magic effects.
+		// Vanilla only retires casters that have a mobile (0x4E476E). mapReferenceToSerial indexes every caster (0x454BE5), so this is one lookup.
 		if (worldController && worldController->magicInstanceController) {
-			worldController->magicInstanceController->cleanupReference(this);
+			worldController->magicInstanceController->retireMagicCastedByReference(this);
 		}
 
 		// Clean up global scripts for the reference.


### PR DESCRIPTION
Tested on my install. Fixed the extra cell stutters as far as I could tell. Storm's test script passes.

TL;DR - Use `retireMagicCastedByReference` since its the fast hashmap path, and guard `handleUpdate` duplicating the collision update work.

Reviewed by an army of AIs, who discovered a new bug during the process that we missed last time: lua callbacks can also trigger synchronously during the retire lifecycle and delete things themselves making more problems.

<details>

<summary>Warning, Clanker Explanation, expand at your own risk</summary>

## Detailed Explanation

The cell load hitches are MagicInstanceController::cleanupReference(). #750 dropped its guard, which is what made it live. The guard was reference->isMobileCapableActor() called on the Reference, and a Reference's own objectType is Reference, so it always returned false. The body had never run once since #685.

With the guard gone it probes serial 0 through getSerialCount() for every reference that gets destroyed. getSerialCount() is a high-water mark for the session, not a live spell count, and cell unloading frees a whole temporary reference list in one go. Cost is refs freed times serials ever allocated. On an old save that's the stall.

The scan isn't needed. retireMagicCastedByReference() (0x454EC0) goes through findFirstInstanceByReference, which is one lookup in mapReferenceToSerial. activateMagic inserts into that map for any caster reference, no type check and no mobile required (0x454BE5), and retireSpellBySerial erases the entry when the spell retires. So the map only ever holds live casts, and a reference that never cast anything costs one lookup that misses. Cheap enough to run on every destruction.

It also covers the crash better than the scan did. Vanilla Reference::dtor calls both retireReferenceMagics and retireActorCastMagic, but behind a if (!mact) skip gate at 0x4E476E. A plugin static that cast a spell and then got evicted with its cell fails that gate, so MagicSourceInstance::caster was left dangling. That's Storm's repro.

That change needed a reentrancy guard, which I missed on the first pass and Codex caught. MWSE fires magicEffectRemoved from inside MagicSourceInstance::process (0x515CE5), and process runs at 0x454F1A, before retireSpellBySerial erases the caster entry at 0x4550E2. Vanilla's own call is safe because Reference::dtor sets the deleted flag first and setDeletedWithSafety early-outs on it. MWSE cleans up ahead of that flag, so a mod handler calling :delete() during the retire re-enters, and if the inner call finishes retireSpellBySerial the instance is freed at 0x455224 while the outer frame still reads it at 0x454F28. Use after free, not just recursion. The guard chains active retirements on the stack and refuses any reference already in the chain, which also blocks the A to B to A cycle that a single-slot guard would let through.

Second fix in the same commit. setDeletedWithSafety() was rebuilding collision groups twice, because disable() already calls handleUpdate() and getUpdatesCollisionGroups() keys off base object type rather than disabled state. Every enabled static, activator, door, container and non-carriable light paid for two updateCollisionGroupsForActiveCells() passes per :delete(). The post-delete rebuild was never load bearing: addToCollisionGrid filters app-culled nodes at 0x488AEE, and disable() app-culls before rebuilding.

An independent reviewer checked the disassembly and confirmed the map lifetime has no stale-entry path, the later vanilla call at 0x4E47A3 misses as expected, and the multi-cast loop terminates.

cleanupReference() is now unused, so either it goes, or it stays as the starting point for target side coverage by walking mapSerialToMagicSourceInstance, which is O(live instances) and would be affordable. isValidSpellTarget() and StlMap::Node came in with #750 and are referenced nowhere.

Still open. Pre-existing before #750 was out: Non-actor targets are uncovered, since nothing indexes them. One sharp edge there: a non-actor target freed earlier in the same unload can still be processed as a freed pointer, since the 564b063d80 patch covers a live target with no mobile, not freed memory. 

What makes that case unlikely is the first condition. Vanilla's non-actor targets are Lock and Open, which are instant and which the engine already special-cases before the call Storm patched. Getting a lasting effect onto a door or container basically means a mod calling tes3.applyMagicSource with a non-actor target. Then that reference has to be freed, so an unmodified temp ref evicted with its cell, or a :delete().

</details>

